### PR TITLE
🐛 fix: disable env_curve: 2 injection — causes silence in WASM scsynth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,18 @@ This has never been done before. You are building the first one.
 5. `artifacts/ref/RESEARCH_SUPERSONIC.md` — SuperSonic (scsynth WASM) API reference
 6. `artifacts/ref/RESEARCH_MATH_FOUNDATIONS.md` — Formal math (temporal monad, free monad, stratified isomorphism)
 
+### Ground Truth Documents (code-level pipeline traces with file:line citations)
+7. `artifacts/ref/GROUND_TRUTH_SONIC_PI_WEB.md` — **Our engine** end-to-end: Ruby code → transpile → sandbox → ProgramBuilder → AudioInterpreter → SoundLayer → OSC → audio
+8. `artifacts/ref/GROUND_TRUTH_SUPERSONIC.md` — SuperSonic end-to-end: send() → transport → AudioWorklet → WASM → audio
+9. `artifacts/ref/GROUND_TRUTH_DESKTOP_SP.md` — Desktop Sonic Pi end-to-end: eval → normalize → sleep → OSC → scsynth
+10. `artifacts/ref/GROUND_TRUTH_SONIC_TAU.md` — Sonic Tau end-to-end: editor → compiler → SPSC → AudioWorklet VM → OSC → audio
+11. `artifacts/ref/GROUND_TRUTH_META_PROMPT.md` — The meta-prompt that generated Ground Truth docs
+
+### Reference Source Code (downloaded locally)
+- `artifacts/ref/sources/supersonic/` — SuperSonic JS source from GitHub (22 files, ~11K lines)
+- `artifacts/ref/sources/desktop-sp/` — Desktop Sonic Pi Ruby source (7 files, ~17K lines)
+- `artifacts/ref/sources/sonic-tau/` — Sonic Tau demo JS source (7 files, ~25K lines)
+
 ### The Core Innovation
 `sleep()` returns a Promise that ONLY the VirtualTimeScheduler can resolve.
 This gives JavaScript cooperative concurrency with virtual time.
@@ -121,13 +133,60 @@ The capture tool records audio via Rec button in Chromium and analyzes the WAV:
 
 ---
 
+## Grounded Debugging Methodology
+
+### Two-Track Grounding
+
+**Internal (our code):** Catalogue entries describe our own patterns, invariants, lifecycles.
+```
+Catalogue entry (compact)     ← hetvabhasa, vyapti, krama, dharana
+    ↓ REF: our-file.ts:line
+Our source code (ground truth) ← src/engine/
+    ↓ traced in
+GROUND_TRUTH_SONIC_PI_WEB.md  ← full pipeline trace with file:line citations
+```
+
+**External (reference systems):** Ground Truth docs for systems we depend on or model after.
+```
+GROUND_TRUTH_SUPERSONIC.md    ← SuperSonic pipeline (external, opaque past WASM)
+GROUND_TRUTH_DESKTOP_SP.md    ← Desktop Sonic Pi pipeline (the reference we match)
+GROUND_TRUTH_SONIC_TAU.md     ← Sonic Tau pipeline (comparison architecture)
+    ↓ cite
+External source code          ← artifacts/ref/sources/{supersonic,desktop-sp,sonic-tau}/
+```
+
+Catalogue REFs point to our own source. External GT docs are consulted on demand when verifying parity claims or debugging at system boundaries. If a catalogue entry lacks a REF, it is ungrounded — add one.
+
+### The Rule: Source Code First, Hypothesis Second
+Before forming ANY hypothesis about a bug:
+1. Read the relevant Ground Truth document (internal: `GROUND_TRUTH_SONIC_PI_WEB.md`, external: the relevant system's GT doc)
+2. Cite the specific code block supporting your hypothesis
+3. If no Ground Truth doc covers the area, create one using `artifacts/ref/GROUND_TRUTH_META_PROMPT.md`
+
+### Provenance Chain (every fix must trace back)
+```
+Fix → Experiment that proved it → Hypothesis → Source code line (cited in GT doc)
+```
+If any link is missing, the fix is ungrounded.
+
+### When to Save Insights to Catalogues
+Save ONLY when a finding:
+1. Contradicts a current catalogue entry (update immediately)
+2. Reveals a new error pattern with REF to Ground Truth (add to hetvabhasa)
+3. Confirms or refutes an invariant with REF to Ground Truth (update vyapti)
+Do NOT save routine experiment results. Save ONLY high-entropy findings that change the worldview.
+
+---
+
 ## Project Catalogues
 
 Location: `artifacts/.anvi/`
-- `hetvabhasa.md` — 14 error patterns
-- `vyapti.md` — 13 invariants (SV12 and SV13 are NOT YET IMPLEMENTED)
-- `krama.md` — 9 lifecycle patterns
-- `dharana.md` — 4 boundaries, invariant spans, org health, composition pairs
+- `hetvabhasa.md` — 22 error patterns (SP1-SP22), each with REF to our source code
+- `vyapti.md` — 15 invariants (SV15 NOT YET IMPLEMENTED — cold-start warmup)
+- `krama.md` — 10 lifecycle patterns (SK10 = cross-platform cold-start comparison)
+- `dharana.md` — 5 boundaries (B5 = init↔AudioWorklet stability), invariant spans, org health
+
+Catalogue REFs point to our own `src/engine/*.ts` files. For the full pipeline trace, read `GROUND_TRUTH_SONIC_PI_WEB.md`. For external system behavior, consult the external GT docs.
 
 ### Dhyana — Active During SoundLayer Work
 
@@ -162,10 +221,12 @@ Location: `artifacts/.anvi/`
 
 5. **scsynth group execution order matters.** Synths → FX → mixer must execute in that order. Groups at "head" execute first. `ReplaceOut` overwrites, `Out` adds. Getting the order wrong means the mixer processes an empty bus.
 
-6. **Code comments about desktop behavior are claims, not evidence.** The comment "Sonic Pi passes arg_bpm_scaling: false for FX" was wrong — desktop DOES BPM-scale FX time params (phase, decay, max_phase). This wrong assumption propagated into unit tests and catalogues, passing CI while producing incorrect audio. **Before writing "matches desktop Sonic Pi"**, verify against the actual source: `synthinfo.rb` for `:bpm_scale` tags, `sound.rb` for the normalization chain. When A/B spectrogram comparison shows temporal (not just level) differences, the param transformation pipeline is the first suspect.
+6. **Code comments about desktop behavior are claims, not evidence.** The comment "Sonic Pi passes arg_bpm_scaling: false for FX" was wrong — desktop DOES BPM-scale FX time params (phase, decay, max_phase). This wrong assumption propagated into unit tests and catalogues, passing CI while producing incorrect audio. **Before writing "matches desktop Sonic Pi"**, verify against the actual source: `synthinfo.rb` for `:bpm_scale` tags, `sound.rb` for the normalization chain. When A/B spectrogram comparison shows temporal (not just level) differences, the param transformation pipeline is the first suspect. Similarly, `env_curve: 2` injection to match Desktop SP causes silence in WASM scsynth for overlapping nodes — the WASM build handles this parameter differently from native scsynth.
 
 7. **Temporal structure reveals param bugs that level analysis misses.** RMS and peak comparisons showed the clap+FX was "1.8x louder" but didn't reveal WHY. Spectrogram analysis showed the echo timing pattern was completely different — echoes at 250ms instead of 115ms. This pointed directly at FX BPM scaling. When spectrograms match in frequency content but differ in temporal pattern, check time-based param handling.
 
 8. **Check ALL code paths when adding optimizations — especially overflow/error paths.** Adding rAF batching to Console.log() fixed the normal path but missed Console.rebuild() which ran on buffer overflow — recreating 500 DOM elements synchronously. 12 experiments investigated exotic causes before finding the bypass. **Rule: grep for ALL callers of the unoptimized function.** Full case study: `artifacts/ref/CASE_STUDY_PERFORMANCE_INVESTIGATION.md`
 
 9. **Measure the actual hot function before theorizing.** A single `performance.now()` wrapper would have found the bottleneck in minutes. Profile first, theorize second.
+
+10. **Diff message content before investigating execution context.** The silent prophet bug was attributed to WASM AudioWorklet cold-start timing (SP22 v2) after 9 experiments. The actual cause was `env_curve: 2` injection by SoundLayer — a parameter that was present in engine messages but absent in raw test messages. When path A works and path B doesn't, diff the CONTENT at the boundary before diffing the CONTEXT. The investigation's raw tests lacked env_curve, so they worked — but the conclusion blamed execution context instead of message content.

--- a/artifacts/.anvi/dharana.md
+++ b/artifacts/.anvi/dharana.md
@@ -1,43 +1,69 @@
 # Dharana — Focused Attention: Sonic Pi Web
 
 Project-specific instantiation of global principles. Every entry carries ORIGIN/WHY/HOW.
-Derived from hetvabhasa (18 patterns), vyapti (14 invariants), krama (9 lifecycles).
+Derived from hetvabhasa (22 patterns, SP22 updated, SP21 partially invalidated), vyapti (15 invariants, SV15 SUPERSEDED), krama (10 lifecycles).
+
+> Every entry references the Ground Truth interpretation layer.
+> Internal: `artifacts/ref/GROUND_TRUTH_SONIC_PI_WEB.md` — our engine pipeline
+> External: `artifacts/ref/GROUND_TRUTH_{SUPERSONIC,DESKTOP_SP,SONIC_TAU}.md`
+> Source code: `artifacts/ref/sources/{supersonic,desktop-sp,sonic-tau}/`
+> Meta-prompt that generated Ground Truth docs: `artifacts/ref/GROUND_TRUTH_META_PROMPT.md`
+> Chain: dharana entry → REF → Ground Truth doc#stage → REF → source file:line
 
 ---
 
 ## 1. Project Boundaries
 
 ### B1: Transpiler ↔ Engine
+FILES: src/engine/TreeSitterTranspiler.ts, src/engine/RubyTranspiler.ts, src/engine/Transpiler.ts, src/engine/Sandbox.ts
 ORIGIN: SP7 (browser engine differences in strict mode variable binding).
 WHY: Transpiled JS must be valid across Chrome, Firefox, and Node. If transpiler output uses constructs one engine rejects, the failure is silent (syntax error inside `new Function()`). Removing this entry means transpiler regressions bypass detection until a user reports "works in Chrome, broken in Firefox."
 HOW: Transpiler outputs JS consumed by Sandbox. Observation targets: run transpiled output through Firefox AND Chrome. Check that `new Function()` doesn't throw.
 
 **Known silent-failure modes:** `var eval` / `let eval` silently fails in Firefox. Bare assignment semantics differ between strict and sloppy mode.
 **Observe THEIR side:** Execute the transpiled code in the target engine. Syntax errors inside `new Function()` are swallowed unless you catch them.
+**REF:** `Sandbox.ts:5-16` design: new Function + with() proxy, Firefox note; `Sandbox.ts:120-124` sloppy mode construction; `TreeSitterTranspiler.ts` + `RubyTranspiler.ts` transpiler implementations
 
 ### B2: AudioInterpreter ↔ SuperSonicBridge (was FATALITY — RESOLVED by SoundLayer)
+FILES: src/engine/interpreters/AudioInterpreter.ts, src/engine/SuperSonicBridge.ts, src/engine/SoundLayer.ts, src/engine/osc.ts
 ORIGIN: SP8, SP9, SP10, SP11, SP12 all cluster at this boundary. 5 patterns exceeds the 3+ fatality threshold.
 WHY: This is the single highest-concentration error boundary. Parameter names change meaning across it (SP9). Time units change across it (SP10). Observation granularity drops across it — event log (our side) diverges from audio output (their side) (SP8). Compiled defaults diverge from documented defaults (SP12). FX lifecycle semantics differ (SP11). Without this boundary tracked as fatality-level, each bug is diagnosed from scratch instead of recognized as a structural class.
 HOW: Consolidated into SoundLayer module (src/engine/SoundLayer.ts). All parameter transformation in one module. SuperSonicBridge is now pure OSC transport. Observation targets: for EVERY param change, verify the receiver's actual vocabulary and defaults.
 
 **Known silent-failure modes:** scsynth ignores unrecognized params without error. Compiled synthdef defaults differ from synthinfo.rb documentation. Missing params use compiled defaults, not Sonic Pi's intended defaults.
 **Observe THEIR side:** Capture WAV output and analyze. The event log is OUR side (inference). The audio is THEIR side (observation).
+**REF:** `SoundLayer.ts` — full normalization pipeline; `AudioInterpreter.ts:4` interpreter description; `SuperSonicBridge.ts:367-401` queueMessage + flushMessages
 
 ### B3: SuperSonicBridge ↔ scsynth WASM
+FILES: src/engine/SuperSonicBridge.ts, src/engine/osc.ts, src/engine/cdn-manifest.ts
 ORIGIN: SP5 (synthdef not loaded), SP9 (param name mismatch at synthdef level), SP12 (compiled default divergence).
 WHY: scsynth is a black box — no error on unrecognized params, no error on wrong defaults, no error on missing synthdefs until runtime. Without observation at this boundary, every audio discrepancy requires end-to-end debugging instead of boundary isolation.
 HOW: Observation targets: verify synthdef is loaded before `/s_new`. Verify param names match synthdef's actual params (not the DSL aliases). Compare our sent values against synthinfo.rb's documented defaults.
 
 **Known silent-failure modes:** `/s_new` with unloaded synthdef: scsynth logs "SynthDef not found" but JS gets no error. Unrecognized param names: silently ignored. Wrong bus routing: audio plays but doesn't reach output.
 **Observe THEIR side:** WAV analysis is the only observation of scsynth's actual output. No other tap point exists.
+**REF:** `SuperSonicBridge.ts:4` CDN note; `SuperSonicBridge.ts:477,561,657` /s_new calls to groups 100/101; `SuperSonicBridge.ts:183` loadedSynthDefs
 
 ### B4: SonicPiEngine ↔ VirtualTimeScheduler
+FILES: src/engine/SonicPiEngine.ts, src/engine/VirtualTimeScheduler.ts
 ORIGIN: SP1 (Promise resolution ordering), SP4 (hot-swap timing gap).
 WHY: Scheduler controls when async functions resume. If resolution ordering is non-deterministic (SP1) or hot-swap breaks timing continuity (SP4), the symptom is audio glitches — hard to distinguish from other audio bugs without isolating this boundary.
 HOW: Observation targets: verify task.virtualTime is monotonic after hot-swap. Verify resolution order is deterministic (sorted by virtualTime, then taskId).
 
 **Known silent-failure modes:** Non-deterministic ordering manifests as subtle timing drift — not an error, just wrong music. Hot-swap gap manifests as audible glitch on code change.
 **Observe THEIR side:** Compare event timestamps across runs (determinism check). Listen for glitch on re-evaluate.
+**REF:** `VirtualTimeScheduler.ts:89-103` deterministic ordering (SV1, SV3); `VirtualTimeScheduler.ts:147-148,192-198` hot-swap preserves virtualTime (SV6); `SonicPiEngine.ts:108` init lifecycle
+
+### B5: SonicPiEngine.init() ↔ AudioWorklet First process() — DOWNGRADED (was wrongly elevated)
+FILES: src/engine/SonicPiEngine.ts, src/engine/SuperSonicBridge.ts, src/app/App.ts
+ORIGIN: Silent prophet diagnosis v2 (SP22). 9 failed experiments led to wrong conclusion.
+**STATUS: DOWNGRADED.** The "cold-start timing gap" was not the actual bug. The real cause was `env_curve: 2` injection at B2 (SoundLayer). This boundary was elevated based on a misdiagnosis — the "poison node" model, CDP asymmetry, and WASM stabilization theory were all wrong. The init↔AudioWorklet boundary is not a fatality concern.
+WHY (revised): This boundary still exists (init timing matters for other reasons) but the specific cold-start failure attributed to it was actually a B2 issue (parameter content, not execution timing). Keeping as reference for investigation history.
+HOW (revised): No specific observation targets needed for cold-start. The original targets (measure init-to-process timing, warmup gates) would have been unnecessary complexity.
+
+**Lesson:** A misdiagnosed bug can elevate the wrong boundary. SP22's actual root cause was at B2 (SoundLayer param injection), not B5 (init timing). Always verify the boundary attribution before creating structural responses.
+
+**REF:** SP22 (updated — env_curve: 2, not cold-start); `artifacts/investigations/silent-prophet-diagnosis-v2.md` (conclusions invalidated)
 
 ---
 
@@ -71,21 +97,27 @@ HOW: Observation targets: verify task.virtualTime is monotonic after hot-swap. V
 **Span:** All observation code. Not a module boundary — an observation discipline.
 **Status:** ALIGNED as practice, enforced by Testing Protocol Level 3.
 
+### SV15: Cold-Start Warmup Required — SUPERSEDED
+**Status:** SUPERSEDED — the cold-start model was wrong. See vyapti SV15 (SUPERSEDED) and hetvabhasa SP22 (updated root cause: env_curve: 2, not timing).
+**Lesson:** A misalignment diagnosis based on an ungrounded hypothesis creates false architectural requirements. The "warmup gap" would have been unnecessary complexity.
+**REF:** SP22 (updated); SV15 (SUPERSEDED)
+
 ---
 
 ## 3. Lens Configuration
 
 ### Active Axes (ordered by frequency in this project)
-1. **Boundary** — 5 hetvabhasa patterns (SP8, SP9, SP10, SP11, SP12). Primary axis.
-2. **Timing/lifecycle** — 3 patterns (SP1, SP4, SP11). Secondary axis.
-3. **Data-flow** — 2 patterns (SP3, SP14). Tertiary.
-4. **Ownership** — 2 patterns (SP11, SP13). Tertiary.
+1. **Boundary** — 7 hetvabhasa patterns (SP8, SP9, SP10, SP11, SP12, SP21, SP22). Primary axis.
+2. **Content-vs-context** — 3 patterns (SP20, SP21, SP22). NEW axis replacing "cold-start". When path A works and path B doesn't, diff the MESSAGE CONTENT at the boundary before diffing the execution CONTEXT. The silent prophet investigation spent 20+ experiments on context (timing, CDP, Worker) when the answer was content (env_curve: 2 present vs absent).
+3. **Timing/lifecycle** — 3 patterns (SP1, SP4, SP11). Secondary axis. (SP22 removed — was not a timing issue.)
+4. **Data-flow** — 2 patterns (SP3, SP14). Tertiary.
+5. **Ownership** — 2 patterns (SP11, SP13). Tertiary.
 
 ### Instantiated Lens Steps
 
 **Diagnose phase 3 (scan boundaries) → for this project:**
 - B1 (transpiler↔engine): Does transpiled output parse in all target engines?
-- B2 (interpreter↔bridge): Do param names match synthdef vocabulary? Are time params scaled by BPM? Is env_curve sent? Are FX time params (phase, decay, max_phase) ALSO scaled?
+- B2 (interpreter↔bridge): Do param names match synthdef vocabulary? Are time params scaled by BPM? Is env_curve: 2 **NOT** sent (SP22 — causes silence for overlapping synths in WASM scsynth)? Are FX time params (phase, decay, max_phase) ALSO scaled?
 - B3 (bridge↔scsynth): Is synthdef loaded? Do sent values match synthinfo.rb expectations?
 - B4 (engine↔scheduler): Is virtual time monotonic? Is resolution order deterministic?
 
@@ -157,6 +189,19 @@ The 4 P0 fixes interact. These pairs need composition verification:
 | Fix A | Fix B | Interaction | Observation needed |
 |-------|-------|-------------|-------------------|
 | BPM scaling (G_NEW.1) | Symbol resolution (G_NEW.4) | Symbol resolves `decay_level: :sustain_level` THEN BPM scales the resolved value. Order matters. | Unit test: resolve symbols first, then scale. Verify scaled value = resolved_value × 60/BPM. |
-| BPM scaling (G_NEW.1) | env_curve injection (G_NEW.13) | env_curve is NOT a time param. BPM scaling must NOT scale it. | Unit test: env_curve value unchanged after BPM scaling pass. |
+| BPM scaling (G_NEW.1) | env_curve injection (G_NEW.13) | env_curve injection DISABLED (SP22 — causes silence for overlapping synths in WASM scsynth). Compiled default (linear) used instead. BPM scaling interaction no longer relevant. | Verify env_curve: 2 is NOT sent in OSC messages. |
 | BPM scaling (G_NEW.1) | FX persistence (G_NEW.2) | Persistent FX node created with BPM at creation time. FX time params (phase, decay, max_phase) ARE BPM-scaled — desktop Sonic Pi tags them :bpm_scale => true. Non-time FX params (room, damp, mix) are NOT scaled. | Capture: set BPM 130, verify echo phase is 0.25*60/130=0.115s, not 0.25s raw. |
 | FX persistence (G_NEW.2) | Symbol resolution (G_NEW.4) | FX params might contain symbol references. Resolution must happen before FX creation. | Unit test: FX opts with symbol refs resolve correctly at creation time. |
+
+---
+
+## 6. Ground Truth Inventory
+
+| System | Ground Truth Doc | Source Location | Last Verified | Opaque Regions |
+|--------|-----------------|-----------------|---------------|----------------|
+| **Sonic Pi Web** | GROUND_TRUTH_SONIC_PI_WEB.md | src/engine/ | 2026-04-03 | None (our code) |
+| SuperSonic | GROUND_TRUTH_SUPERSONIC.md | artifacts/ref/sources/supersonic/ | 2026-04-02 | WASM scsynth internals, AudioWorklet stabilization timing |
+| Desktop SP | GROUND_TRUTH_DESKTOP_SP.md | artifacts/ref/sources/desktop-sp/ | 2026-04-02 | scsynth C++ internals, SuperCollider UGen execution |
+| Sonic Tau | GROUND_TRUTH_SONIC_TAU.md | artifacts/ref/sources/sonic-tau/ | 2026-04-02 | WASM VM internals, bytecode format |
+
+Catalogue REFs point to internal source (our code). External GT docs consulted on demand for parity verification.

--- a/artifacts/.anvi/hetvabhasa.md
+++ b/artifacts/.anvi/hetvabhasa.md
@@ -1,54 +1,70 @@
 # Error Patterns — Sonic Pi Web
 
+> Every pattern references the Ground Truth interpretation layer.
+> Internal: `artifacts/ref/GROUND_TRUTH_SONIC_PI_WEB.md` — our engine pipeline
+> External: `artifacts/ref/GROUND_TRUTH_{SUPERSONIC,DESKTOP_SP,SONIC_TAU}.md`
+> Source code: `artifacts/ref/sources/{supersonic,desktop-sp,sonic-tau}/`
+> Chain: catalogue entry → REF → Ground Truth doc#stage → REF → source file:line
+
 ## SP1: Promise Resolution Ordering
 **Root cause:** Multiple tasks' Promises resolve in the same tick. The microtask queue processes them in an order the scheduler doesn't control.
 **Detection signal:** Non-deterministic event ordering across runs.
 **The trap:** Add setTimeout(0) between resolutions. Root fix: resolve in deterministic order (sort by virtualTime, then by taskId for ties).
+**REF:** `VirtualTimeScheduler.ts:91` SV3 deterministic ordering comment; `VirtualTimeScheduler.ts:103` monotonic counter for tiebreaking; `VirtualTimeScheduler.ts:324` tick resolves in deterministic order
 
 ## SP2: AudioContext User Gesture Requirement
 **Root cause:** Browser autoplay policy requires user interaction before AudioContext.resume().
 **Detection signal:** `init()` completes but no sound — AudioContext is in "suspended" state.
 **The trap:** Call init() on page load. Root fix: init() must be called from a click/tap handler. The editor's handlePlay is triggered by user click.
+**REF:** `SonicPiEngine.ts:108` async init()
 
 ## SP3: Virtual Time Drift from Floating Point
 **Root cause:** Repeated float addition (0.5 + 0.5 + 0.5...) accumulates error.
 **Detection signal:** After 1000 iterations, virtual time is 499.9999... instead of 500.
 **The trap:** Use tolerance checks. Root fix: use rational arithmetic or multiply beats * index instead of accumulating.
+**REF:** `VirtualTimeScheduler.ts:244-245` task.virtualTime += seconds (accumulation site); `VirtualTimeScheduler.ts:16` drift comment
 
 ## SP4: Hot-Swap Timing Gap
 **Root cause:** On re-evaluate, old loop is killed and new loop starts from virtualTime=0, creating a timing discontinuity.
 **Detection signal:** Audible glitch on code change — gap or overlap.
 **The trap:** Restart loop from beginning. Root fix: hot-swap preserves the current virtualTime position — new function, same clock.
+**REF:** `VirtualTimeScheduler.ts:147-148` hot-swap replaces asyncFn, preserves virtualTime (SV6); `VirtualTimeScheduler.ts:192-198` hotSwap() method; `VirtualTimeScheduler.ts:214-215` reconcileLoops hot-swap path
 
 ## SP5: SuperSonic SynthDef Not Loaded
 **Root cause:** User calls `use_synth("prophet")` but SynthDef hasn't been loaded yet.
 **Detection signal:** scsynth logs "SynthDef not found" but no JS error surfaces.
 **The trap:** Pre-load all 127 SynthDefs (slow init). Root fix: lazy-load on first use with await, cache loaded set.
+**REF:** `SuperSonicBridge.ts:183` loadedSynthDefs Set; `SuperSonicBridge.ts:408-411` lazy-load on first use + cache
 
 ## SP6: Capture Mode Infinite Loop
 **Root cause:** Fast-forward scheduler runs a live_loop that never calls sleep — infinite loop, browser hangs.
 **Detection signal:** Tab freezes during queryArc.
 **The trap:** Add timeout. Root fix: cap iterations per tick in capture mode. If a loop body has zero sleep, mark as non-capturable (Stratum 3).
+**REF:** `ProgramBuilder.ts:18-24` DEFAULT_LOOP_BUDGET + InfiniteLoopError class; `ProgramBuilder.ts:90-101` budget reset on sleep, throw on exhaustion; `VirtualTimeScheduler.ts:410-411` InfiniteLoopError handler stops loop; `QueryInterpreter.ts:167` zero-sleep guard
 
 ## SP7: Browser Engine Differences in Strict Mode Variable Binding
 **Root cause:** `var eval = undefined` and `let eval` are handled differently across browser engines. V8 (Chrome/Node) allows `var eval` in sloppy-mode `new Function()`. SpiderMonkey (Firefox) forbids it entirely, producing "missing ) in parenthetical" SyntaxError.
 **Detection signal:** Code works in Chrome but fails in Firefox with "missing ) in parenthetical". Also applies to `arguments` and `Function` as variable names.
 **The trap:** Shadow dangerous names via `let`/`var` declarations inside the function body. Root fix: don't try to shadow `eval`/`Function`/`arguments` as variable names at all. Use parameter-name shadowing for other globals (fetch, document, etc.) which works cross-browser. Accept that eval/Function remain accessible — they're low-risk for the Sonic Pi use case.
+**REF:** `Sandbox.ts:5-16` design comment: new Function + with() proxy, Firefox/SES note; `Sandbox.ts:120-124` sloppy mode + new Function construction; `Sandbox.ts:137` parameter-name variant
 
 ## SP8: Event Log Mistaken for Audio Observation
 **Root cause:** The event log (LOG panel text) shows what the JS scheduler intended. It does NOT show what scsynth actually played. Audio routing bugs (missing out_bus, FX not routing, mixer misconfigured) are invisible to the event log.
 **Detection signal:** Event log shows correct events, correct timing, correct patterns — but the recorded audio WAV has wrong volume, missing instruments, clipping, or wrong frequency content.
 **The trap:** Read the event log and declare "verified ✓". Root fix: ALWAYS capture and analyze the WAV file. Compare RMS, peak, clipping%, frequency content per beat against the original Sonic Pi reference. The event log is inference; the WAV is observation.
 **How it manifested:** In the OSC bundle session, event log showed drum_snare_hard events scheduled correctly for 5+ fix rounds. But the actual audio had zero snare frequency content because samples were missing `out_bus` (bypassed FX) and nested FX only applied innermost. Five rounds of "it's still broken" before the WAV was analyzed.
+**REF:** Epistemic pattern (no single source line). `SonicPiEngine.ts:34` SoundEventStream for event logging; WAV capture via `tools/capture.ts` for observation. See SV8 invariant.
 
 ## SP9: Parameter Name Mismatch at Layer Boundary
 **Root cause:** Sonic Pi's DSL uses one name (e.g., `cutoff`), but the scsynth synthdef expects a different name (e.g., `lpf`). The Ruby `sound.rb` layer aliases between them via `munge_opts`. Our engine sends the DSL name directly — scsynth ignores unrecognized params silently.
+**REF:** `SoundLayer.ts:178` perSynthParamAliasing; `SoundLayer.ts:191` full pipeline order; `SoundLayer.ts:197-211` normalizePlayParams
 **Detection signal:** Filter/effect has no audible impact despite correct parameter value. No error logged.
 **The trap:** Assume all parameter names pass through unchanged. Root fix: implement per-synth `munge_opts` aliasing. Known aliases: cutoff→lpf (sample players, sc808_snare, sc808_clap), cutoff_slide→lpf_slide, dpulse_width→pulse_width (DPulse).
 **How it manifested:** `sample :bd_tek, cutoff: 130` sent `cutoff: 130` to scsynth. The basic_stereo_player synthdef expects `lpf`. The filter never activated. Samples played unfiltered — brighter and louder than intended.
 
 ## SP10: Missing BPM Time Scaling
 **Root cause:** Sonic Pi's `scale_time_args_to_bpm!` multiplies ALL time-based params by `60/BPM`. This includes ADSR envelopes (attack, decay, sustain, release), ALL `*_slide` params, AND FX time params (phase, max_phase, delay, pre_delay). At 130 BPM, `release: 1` becomes 0.46s; echo `phase: 0.25` becomes 0.115s.
+**REF:** `SoundLayer.ts:20-28` TIME_PARAMS set; `SoundLayer.ts:466-482` scaleTimeParamsToBpm; `SoundLayer.ts:211,228,243,271` called from all four normalize functions
 **Detection signal:** Notes ring too long AND/OR FX timing wrong (echo too slow, slicer too wide) at non-60 BPM.
 **The trap:** (1) Assume time params are in seconds. (2) Assume FX params are NOT BPM-scaled — the comment "Sonic Pi passes arg_bpm_scaling: false for FX" was **wrong**. Desktop Sonic Pi's `trigger_fx` DOES call `scale_time_args_to_bpm!` (verified from source: `synthinfo.rb` tags echo phase/decay/max_phase with `:bpm_scale => true`).
 **Impact:** At 130 BPM, every unscaled time param is 2.17x too long/slow.
@@ -58,22 +74,26 @@
 **Root cause:** `fxAwareWrappedLiveLoop` adds `b.with_fx()` to the ProgramBuilder on every loop iteration. AudioInterpreter creates a new FX synth node each time. Desktop Sonic Pi creates top-level FX ONCE — the GC thread's `subthread.join` blocks on the live_loop, so the FX persists forever.
 **Detection signal:** Hundreds of FX nodes accumulate per minute. Volume may grow. CPU spikes. Audio gets washy from overlapping reverb/echo tails.
 **The trap:** Create FX inside the loop body wrapper. Root fix: for top-level `with_fx` wrapping `live_loop`, create the FX node at registration time, pass the bus/group as inherited state, never recreate.
+**REF:** `SonicPiEngine.ts:73` persistentFx Map; `SonicPiEngine.ts:305-332` first-iteration FX creation + persistentFx.set; `SonicPiEngine.ts:429-443` fxAwareWrappedLiveLoop
 
 ## SP12: SynthDef Compiled Default ≠ synthinfo.rb Default
 **Root cause:** The compiled .scsyndef file bakes in parameter defaults at compile time. synthinfo.rb documents different defaults that Sonic Pi sends explicitly. If our engine relies on the compiled default (by not sending a param), the behavior differs.
 **Detection signal:** Envelope shapes or filter behavior differs from desktop Sonic Pi despite sending the same user params.
-**The trap:** Assume the synthdef default matches what Sonic Pi intends. Root fix: send critical params explicitly. Known discrepancies: `env_curve` (compiled=1/linear, Sonic Pi sends 2/exponential), mixer `amp` (compiled=1, Sonic Pi sends 6), tb303 `attack` (compiled=0.01, Sonic Pi sends 0).
+**The trap:** Assume the synthdef default matches what Sonic Pi intends. Root fix: send critical params explicitly. Known discrepancies: mixer `amp` (compiled=1, Sonic Pi sends 6), tb303 `attack` (compiled=0.01, Sonic Pi sends 0). **EXCEPTION: `env_curve`** — Desktop SP sends env_curve: 2 (exponential), but WASM scsynth produces silence for overlapping synths with env_curve: 2 (SP22). Use compiled default (1/linear) until upstream fix. This is a known divergence from desktop behavior.
+**REF:** `SoundLayer.ts:343-348` injectEnvCurve (DISABLED — SP22); `SoundLayer.ts:11` design comment listing injection step; `SuperSonicBridge.ts:169` SONIC_PI_DEFAULT_AMP=6
 
 ## SP13: Nested Wrapper State Loss
 **Root cause:** A single variable (not a stack) captures wrapper context. Nested wrappers overwrite the outer context.
 **Detection signal:** Only the innermost wrapper takes effect. Outer wrappers are silently lost.
 **The trap:** Use a single `currentTopFx` variable. Root fix: use a stack (`topFxStack`). Push on enter, pop on exit. Apply ALL stacked wrappers to the live_loop.
 **How it manifested:** `with_fx :echo do; with_fx :reverb do; live_loop :clap` — only reverb was applied, echo was lost. Fixed by converting `currentTopFx` to `topFxStack`.
+**REF:** `SonicPiEngine.ts:387-389` topFxStack declaration; `SonicPiEngine.ts:408` push on enter; `SonicPiEngine.ts:417` pop on exit; `SonicPiEngine.ts:438-443` stack propagation to fxScopeChains
 
 ## SP14: Mixer Signal Doubling
 **Root cause:** sonic-pi-mixer synthdef sums `in(out_bus) + in(in_bus)`. If both are the same bus (e.g., both bus 0), the signal is read twice and doubled.
 **Detection signal:** Output is 2x louder than expected. Clipping increases.
 **The trap:** Set `in_bus: 0` (same as out_bus default). Root fix: allocate a SEPARATE private bus for `in_bus`. Desktop Sonic Pi uses `@mixer_bus = new_bus(:audio)`.
+**REF:** `SuperSonicBridge.ts:273-278` mixer signal chain comment + SEPARATE bus requirement; `SuperSonicBridge.ts:278` allocateBus() for private mixer in_bus
 
 ## SP15: on: Conditional Trigger Silently Ignored
 **Root cause:** Sonic Pi's `should_trigger?` checks the `on:` param and skips the synth/sample trigger entirely if falsy. Our SoundLayer stripped `on:` from params (correct — scsynth doesn't know it) but never checked its value. Every trigger fired regardless of `on:`.
@@ -81,6 +101,7 @@
 **The trap:** Treat `on:` as just another non-scsynth param to strip. Root fix: check `on` value in AudioInterpreter BEFORE triggering. If `on` is present and falsy (0, false), skip the play/sample entirely. Strip happens later in SoundLayer.
 **How it manifested:** Discovered during desktop vs web comparison — spread() patterns are a core Sonic Pi idiom used in every tutorial. The pattern played a flat stream of notes instead of the rhythmic Euclidean pattern.
 **Status:** FIXED — AudioInterpreter.ts checks `step.opts.on` before triggering (#53).
+**REF:** `AudioInterpreter.ts:72-73` should_trigger check for play; `AudioInterpreter.ts:107-108` should_trigger check for sample
 
 ## SP16: WASM scsynth Output Level Difference (CONFIRMED)
 
@@ -91,6 +112,7 @@
 **Note on clap+FX ratio:** The original 1.8x ratio for clap+FX was LOWER than drums (2.2x) partly because FX time params weren't BPM-scaled (SP10/issue #66) — echo was 2.17x too slow, spreading energy over more time and reducing RMS.
 **Workaround:** WASM_COMPENSATED_PRE_AMP = 0.2/2.3 in mixer.
 **Full investigation:** artifacts/ref/RESEARCH_WASM_OUTPUT_LEVEL.md, tools/audio_comparison/wasm_output_level_analysis.ipynb, tools/audio_comparison/raw_osc_test/RESULTS.md
+**REF:** `SuperSonicBridge.ts:123-136` WASM output level explanation; `SuperSonicBridge.ts:164` WASM_OUTPUT_LEVEL_FACTOR=2.3; `SuperSonicBridge.ts:179` WASM_COMPENSATED_PRE_AMP formula; `SuperSonicBridge.ts:284` compensated pre_amp in mixer creation
 
 ## SP17: Wrong Assumption Encoded as Truth (Meta-Pattern)
 **Root cause:** A wrong claim about desktop Sonic Pi's behavior ("FX params are NOT BPM-scaled, arg_bpm_scaling: false") was written in a code comment, propagated into unit tests (asserting the wrong behavior), and recorded in catalogue entries (SV12, dharana). No mechanism caught the divergence from the reference implementation until WAV temporal analysis revealed echo timing was 2.17x too slow.
@@ -99,6 +121,7 @@
 **Root fix:** Before claiming any normalization step "matches desktop," verify against the ACTUAL desktop source code (synthinfo.rb for param tags, sound.rb for the normalization chain). Never write "Sonic Pi does X" from inference — read the source. When A/B spectrogram analysis reveals temporal differences, check the param transformation pipeline for the specific FX/synth involved.
 **How it manifested:** Issue #66. `with_fx :echo, phase: 0.25` at 130 BPM produced echoes at 250ms (raw seconds) instead of 115ms (0.25 beats × 60/130). Discovered via spectrogram analysis showing clap+FX spectrograms looked "wildly different" while drums (no FX) matched.
 **Prevention:** Added to dharana observation targets: "For EVERY normalization rule, verify the claim against desktop source code (synthinfo.rb :bpm_scale tags, sound.rb normalization chain). Code comments are claims, not evidence."
+**REF:** `SoundLayer.ts:191` full pipeline order; `SoundLayer.ts:249-271` normalizeFxParams (the fix for the wrong assumption)
 
 ## SP18: Exotic Diagnosis Before Simple Observation (Meta-Pattern)
 **Root cause:** Console.rebuild() recreated 500 DOM elements on every log entry after the 500-entry buffer filled (~6s at 86 entries/sec). 43,000 DOM ops/sec blocking the main thread. The rebuild() path bypassed the rAF batching added in the same session.
@@ -107,9 +130,36 @@
 **Root fix:** (1) When adding optimization, grep ALL callers — especially overflow/error paths. (2) Measure the hot function (performance.now) BEFORE theorizing about engine internals.
 **How it manifested:** Issue #75. 12 experiments investigated V8 GC, scsynth WASM, SharedArrayBuffer, allocation rates — all wrong. Answer was Console.rebuild() in code edited that same session.
 **Full case study:** `artifacts/ref/CASE_STUDY_PERFORMANCE_INVESTIGATION.md`
+**REF:** Meta-pattern (no single source line). Full case study: `artifacts/ref/CASE_STUDY_PERFORMANCE_INVESTIGATION.md`
 
 ## SP19: Track Bus Mixer Bypass (was SP18)
 **Root cause:** allocateTrackBus assigned synth out_bus to buses 2,4,6... (track buses for per-loop visualization). The mixer only reads bus 0. All audio bypassed the mixer (Limiter.ar, gain staging) and reached speakers raw through the Web Audio ChannelMerger summing all 14 channels.
 **Detection signal:** RMS unchanged regardless of mixer settings. Clipping from hard clip at Web Audio output (not Limiter.ar).
 **The trap:** Assume the mixer processes all audio. Root fix: set task.outBus = 0 for all loops. Track buses used only for AnalyserNode taps, not audio routing. ChannelMerger connects only channels 0-1.
 **How it manifested:** Discovered during WASM output level investigation. Mixer amp=1 test would have shown no change if track buses were still active.
+**REF:** `SonicPiEngine.ts:269-272` allocateTrackBus call (visualization only); `SonicPiEngine.ts:379` task.outBus=0 (audio goes to mixer); `SuperSonicBridge.ts:198-201` trackBuses Map + nextTrackBus; `SuperSonicBridge.ts:300-301` only bus 0 carries audio
+
+## SP20: Ungrounded Hypothesis (Meta-Pattern)
+**Root cause:** Hypothesis formed from behavioral observation without reading relevant source code. Experiments fail because the mental model of the system's behavior is inferred, not read from source.
+**Detection signal:** Multiple experiments fail in succession. Each new theory addresses the last failure but not the root cause. The model keeps being wrong.
+**The trap:** "I've seen enough behavior to form a theory." Root fix: Read the source. Form the hypothesis from code understanding, not behavioral inference. Use the Ground Truth documents.
+**How it manifested:** Silent prophet investigation v1 blamed the prescheduler (wrong). v2 ran 9 experiments on timing/Worker/SAB theories (all wrong). v2's conclusion ("cold-start WASM AudioWorklet poison nodes") was ALSO wrong — a third round revealed the actual cause was `env_curve: 2` causing silence for overlapping synths. The investigation compared different execution CONTEXTS (CDP vs page) when the real difference was message CONTENT (env_curve: 2 present vs absent).
+**Recurrence note:** This exact meta-pattern recurred across three diagnosis rounds. v1: wrong boundary (prescheduler). v2: wrong mechanism (WASM cold-start). v3: found actual cause (env_curve param). Each round formed a plausible theory from observation without diffing the actual data at the boundary.
+**REF:** Meta-pattern (no single source line). Full investigation: `artifacts/investigations/silent-prophet-diagnosis-v2.md`
+
+## SP21: CDP Execution Context Asymmetry (PARTIALLY INVALIDATED)
+**Original claim:** Chrome DevTools Protocol injects JavaScript through V8's debugger task queue, creating different timing for postMessage delivery to AudioWorklet.
+**What was actually happening:** CDP tests used raw `sonic.send()` calls WITHOUT env_curve: 2 injection (bypassing SoundLayer). App code went through SoundLayer which injected env_curve: 2. The "asymmetry" was in the MESSAGE CONTENT, not the execution context. CDP worked because it sent different params, not because it used a different V8 task queue.
+**Detection signal (updated):** When path A works and path B doesn't, diff the CONTENT at the boundary before diffing the CONTEXT. If the messages differ, the execution context is irrelevant.
+**The trap (updated):** Investigating execution context differences when the actual difference is in the data being sent. Always diff the actual OSC messages/params at the boundary first.
+**What remains valid:** CDP and page event loops ARE different execution contexts. But for the silent prophet bug, this was a red herring — the difference that mattered was env_curve: 2 present vs absent.
+**REF:** `artifacts/investigations/silent-prophet-diagnosis-v2.md` Phase 7; `SoundLayer.ts:346-349` injectMandatoryDefaults (the actual divergence point)
+
+## SP22: env_curve: 2 Causes Silence for Overlapping Synths in WASM scsynth (was "Cold-Start Poison Nodes")
+**Root cause:** `env_curve: 2` (exponential envelope) sent to SuperSonic's WASM scsynth causes overlapping synth nodes to produce zero audio. The compiled default `env_curve: 1` (linear) works correctly. This is a WASM scsynth behavioral difference from desktop scsynth, where env_curve: 2 works fine with overlapping synths.
+**Detection signal:** Overlapping heavy synths (prophet, multiple notes ringing simultaneously) produce silence. Non-overlapping synths work. Same code works when env_curve: 2 is NOT injected (e.g., raw `sonic.send()` calls that bypass SoundLayer).
+**The trap:** (1) Blame the prescheduler (v1, wrong). (2) Blame WASM AudioWorklet cold-start timing (v2, wrong — the "poison node" model, CDP asymmetry explanation, and cold-start stabilization theory were all wrong). (3) Compare execution CONTEXTS (CDP vs page) instead of diffing message CONTENT at the boundary. Root fix: Don't inject env_curve: 2 for WASM scsynth. Use compiled default (env_curve: 1, linear). Minor timbre difference from Desktop SP until upstream SuperSonic fix.
+**What was wrong about v2's model:** The "cold-start" framing was incorrect. The bug wasn't timing-dependent — it occurred at any time when overlapping synths had env_curve: 2. CDP tests appeared to work because they bypassed SoundLayer (no env_curve injection), not because of execution context differences. The 9 failed experiments investigated the wrong dimension entirely.
+**Fix:** Skip env_curve: 2 injection in `SoundLayer.ts:346-349` injectMandatoryDefaults. Use compiled default (linear envelope).
+**REF:** `SoundLayer.ts:346-349` injectMandatoryDefaults (now disabled for env_curve); `artifacts/investigations/silent-prophet-diagnosis-v2.md` investigation history (conclusions invalidated)
+**Full investigation:** artifacts/investigations/silent-prophet-diagnosis-v2.md (note: v2 conclusions are WRONG — see this entry for actual root cause)

--- a/artifacts/.anvi/krama.md
+++ b/artifacts/.anvi/krama.md
@@ -1,5 +1,11 @@
 # Lifecycle Patterns — Sonic Pi Web
 
+> Every lifecycle references the Ground Truth interpretation layer.
+> Internal: `artifacts/ref/GROUND_TRUTH_SONIC_PI_WEB.md` — our engine pipeline
+> External: `artifacts/ref/GROUND_TRUTH_{SUPERSONIC,DESKTOP_SP,SONIC_TAU}.md`
+> Source code: `artifacts/ref/sources/{supersonic,desktop-sp,sonic-tau}/`
+> Chain: catalogue entry → REF → Ground Truth doc#stage → REF → source file:line
+
 ## SK1: SonicPiEngine Full Lifecycle
 1. `init()` — create SuperSonic, AudioContext, AnalyserNode, VirtualTimeScheduler — ASYNC
 2. `evaluate(code)` — transpile, create DSL context, execute code (registers live_loops), parse @viz comments — ASYNC
@@ -8,6 +14,7 @@
 5. Async functions resume at await points — trigger synths via SuperSonic OSC — SYNC per resolution
 6. `stop()` — scheduler.stop(), free all synth nodes — SYNC
 7. `dispose()` — stop + destroy SuperSonic + clear HapStream — SYNC
+**REF:** `SonicPiEngine.ts:108` init(); `SonicPiEngine.ts:169` evaluate guard; `SonicPiEngine.ts:685` scheduler.dispose(); `SonicPiEngine.ts:698-703` dispose() method
 
 ## SK2: VirtualTimeScheduler Tick Cycle
 1. setInterval fires (~25ms) — ASYNC (macrotask)
@@ -20,6 +27,7 @@
 8. Function suspends at next await — MICROTASK completes
 
 **Common violation:** Resolving Promises outside tick() (breaks SV2).
+**REF:** `VirtualTimeScheduler.ts:85-99` constructor + schedAheadTime; `VirtualTimeScheduler.ts:235-247` sleep() → Promise; `VirtualTimeScheduler.ts:323-331` tick() resolves entries; `VirtualTimeScheduler.ts:347` setInterval fires tick
 
 ## SK3: live_loop Registration and Execution
 1. evaluate() executes code — SYNC within eval scope
@@ -34,8 +42,11 @@
 10. Hot-swap: replace asyncFn reference, loopSynced persists, next iteration uses new fn — SYNC
 
 **Common violation:** Starting fn() before scheduler.start() (no tick to resolve sleeps).
+**REF:** `VirtualTimeScheduler.ts:139-164` registerLoop: creates task, starts async chain at sleep(0); `VirtualTimeScheduler.ts:277-293` cue/sync; `VirtualTimeScheduler.ts:147-148` hot-swap; `SonicPiEngine.ts:429-443` fxAwareWrappedLiveLoop registration
 
 ## SK4: Audio Message Pipeline (Sonic Pi's 3-layer model)
+**REF:** `SoundLayer.ts:191` pipeline order; `AudioInterpreter.ts:4` interpreter; `SuperSonicBridge.ts:367-401` queueMessage + flushMessages; `osc.ts` OSC encoding
+
 1. DSL play()/sample() called at virtual time T — SYNC
 2. ProgramBuilder creates Step data — SYNC
 3. AudioInterpreter processes step:
@@ -77,6 +88,7 @@
 7. setTimeout(kill_delay) → freeGroup + freeBus — ASYNC
 
 **This matches desktop:** top-level FX persists (GC blocked by subthread.join), inner FX is per-block.
+**REF:** `SonicPiEngine.ts:73,305-332` persistentFx (Path A); `AudioInterpreter.ts` fx step handling (Path B); `SuperSonicBridge.ts:630-657` createFxGroup + FX synth creation
 
 ## SK6: FX Lifecycle (Desktop Sonic Pi — target)
 1. with_fx allocates bus, creates container group + synth group inside — SYNC
@@ -87,6 +99,7 @@
 6. Block returns, delivers subthreads to GC — SYNC
 7. GC thread waits: subthread.join → tracker.block_until_finished → sleep(kill_delay) → group.kill — ASYNC
 8. For live_loop wrapping: subthread.join blocks FOREVER → FX persists until Stop
+**REF:** Reference target — describes Desktop SP behavior (not our code). Consult `GROUND_TRUTH_DESKTOP_SP.md#stage-8` when verifying parity.
 
 ## SK7: Capture Mode (Fast-Forward for queryArc)
 1. Create fresh scheduler in capture mode — SYNC
@@ -98,6 +111,7 @@
 7. Return collected events — SYNC
 
 **Common violation:** Infinite loop if live_loop body has no sleep (SP6 error pattern).
+**REF:** `QueryInterpreter.ts:2` QueryInterpreter description; `QueryInterpreter.ts:167` zero-sleep guard; `ProgramBuilder.ts:18-24` budget system for capture mode
 
 ## SK8: scsynth Node Tree (Current)
 ```
@@ -109,6 +123,7 @@ Root Group (0):
 Execution order: 100 → 101 → mixer. Correct for signal flow.
 
 **Gap:** Inner synths should go in the FX container's synth group (like desktop), not group 100.
+**REF:** `SuperSonicBridge.ts:265-269` group creation (mixer→101→100 order); `SuperSonicBridge.ts:477` synths go to group 100; `SuperSonicBridge.ts:657` FX goes to group 101
 
 ## SK9: scsynth Node Tree (Desktop Sonic Pi — target)
 ```
@@ -125,3 +140,36 @@ Root Group (0):
   STUDIO-MONITOR (after mixer)
     scope, amp_monitor, recorder
 ```
+**REF:** Reference target — describes Desktop SP node tree (not our code). Consult `GROUND_TRUTH_DESKTOP_SP.md#initialization-sequence` when verifying parity.
+
+## SK10: Cold-Start Init Lifecycle (Cross-Platform Comparison)
+
+**Desktop SP init (GROUND_TRUTH_DESKTOP_SP.md#initialization-sequence):**
+1. Boot scsynth as separate OS process — `scsynthexternal.rb:110`
+2. Poll `/status` every 1s until response — `scsynthexternal.rb:154`
+3. `/notify 1` — `server.rb:63`
+4. `/d_loadDir` all synthdefs, wait for `/done` — `server.rb:66`
+5. `/s_new "sonic-pi-server-info"` probe synth, wait for response — `server.rb:93`
+6. `/clearSched` + sleep 0.1 + `/g_freeAll 0` — `server.rb:169`
+7. Create 4 groups (SYNTHS, FX, MIXER, MONITOR) — `studio.rb:463-480`
+8. `/s_new "sonic-pi-mixer"` — `studio.rb:490`
+9. Root group PAUSED until first job starts — `studio.rb:394`
+→ User code runs AFTER all 9 steps complete. No cold-start possible.
+
+**Sonic Tau init (GROUND_TRUTH_SONIC_TAU.md#initialization-sequence):**
+1. Fetch + compile WASM on main thread
+2. Create AudioContext
+3. Register AudioWorklet, WASM instantiated synchronously in constructor — `tau_processor.js` constructor
+4. SuperSonic.init() + loadSynthDefs + createGroups + mixer
+5. Create OscChannel (SAB), transfer to AudioWorklet
+6. OscChannel is null-gated in process() — `tau_processor.js:477`
+→ VM cannot emit events before process() fires. Cold-start impossible by construction.
+
+**Sonic Pi Web init (our system):**
+1. `SonicPiEngine.init()` → SuperSonic constructor + sonic.init()
+2. loadSynthDefs (async)
+3. Create groups (100, 101) + mixer
+4. `evaluate(code)` → transpile → register loops
+5. `play()` → scheduler.start() → first tick → first `/s_new`
+→ ~~GAP: No warmup between step 3 and step 5.~~ RESOLVED: The "cold-start gap" was a misdiagnosis (SP22 updated). The actual issue was env_curve: 2 injection in SoundLayer causing silence for overlapping synths. No warmup needed.
+**REF:** SV15 (SUPERSEDED); SP22 (updated root cause: env_curve: 2, not init timing)

--- a/artifacts/.anvi/vyapti.md
+++ b/artifacts/.anvi/vyapti.md
@@ -1,70 +1,87 @@
 # Invariants — Sonic Pi Web
 
+> Every invariant references the Ground Truth interpretation layer.
+> Internal: `artifacts/ref/GROUND_TRUTH_SONIC_PI_WEB.md` — our engine pipeline
+> External: `artifacts/ref/GROUND_TRUTH_{SUPERSONIC,DESKTOP_SP,SONIC_TAU}.md`
+> Source code: `artifacts/ref/sources/{supersonic,desktop-sp,sonic-tau}/`
+> Chain: catalogue entry → REF → Ground Truth doc#stage → REF → source file:line
+
 ## SV1: Virtual Time Monotonicity
 **Statement:** For each task T, virtualTime(T) is non-decreasing and advances only on sleep() or sync().
 **Causal status:** STRUCTURAL — defines the temporal model.
 **Breaks when:** Never (by construction).
 **Implication:** All events between two sleeps share the same virtual timestamp (chord semantics).
+**REF:** `VirtualTimeScheduler.ts:89` SV1 comment; `VirtualTimeScheduler.ts:244-245` virtualTime advances only on sleep; `VirtualTimeScheduler.ts:293` virtualTime set on sync
 
 ## SV2: Scheduler-Exclusive Promise Resolution
 **Statement:** A Promise returned by sleep() can ONLY be resolved by the scheduler's tick() method.
 **Causal status:** CAUSAL — the Promise has no timeout, no microtask trigger.
 **Breaks when:** Someone adds a setTimeout fallback or resolves outside tick().
 **Implication:** The scheduler has complete control over when async functions resume.
+**REF:** `VirtualTimeScheduler.ts:85` core innovation comment; `VirtualTimeScheduler.ts:90` SV2 comment; `VirtualTimeScheduler.ts:235,247` sleep() returns Promise only tick() resolves; `VirtualTimeScheduler.ts:40` resolver only called by tick
 
 ## SV3: Determinism Under Same Inputs
 **Statement:** Given same code + same random seeds + same initial state, the event trace is identical across runs.
 **Causal status:** STRUCTURAL — follows from SV1 + seeded random + deterministic priority queue.
 **Breaks when:** Code uses Date.now(), Math.random(), or external I/O (Stratum 3).
 **Implication:** Capture mode produces identical events to real-time execution for Stratum 1-2.
+**REF:** `VirtualTimeScheduler.ts:91,103` deterministic ordering by (time, insertionOrder); `SeededRandom.ts:17-24` SeededRandom MT19937 matches Ruby; `VirtualTimeScheduler.ts:324` tick resolves in deterministic order
 
 ## SV4: Three-Clock Separation
 **Statement:** Wall clock (setInterval), audio clock (AudioContext.currentTime), and virtual clock (scheduler) are independent. Only schedAheadTime bridges virtual → audio.
 **Causal status:** STRUCTURAL — architecture design.
 **Breaks when:** Code reads wall clock directly or ties virtual time to real time.
 **Implication:** Wall clock jitter does not affect audio timing.
+**REF:** `VirtualTimeScheduler.ts:63` audioTime field on SchedulerEntry; `VirtualTimeScheduler.ts:99` schedAheadTime bridges virtual→audio; `VirtualTimeScheduler.ts:331` tick uses getAudioTime() + schedAheadTime; `VirtualTimeScheduler.ts:347` setInterval for wall clock tick
 
 ## SV5: sync Inherits Cue's Virtual Time
 **Statement:** When a task calls sync(:name) and a matching cue fires, the syncing task's virtual time is set to the cue's virtual time.
 **Causal status:** CAUSAL — this is how Sonic Pi keeps threads synchronized.
 **Breaks when:** sync just resumes without updating virtual time.
 **Implication:** After sync, the two tasks share the same beat position.
+**REF:** `VirtualTimeScheduler.ts:284` cueMap.set with task.virtualTime; `VirtualTimeScheduler.ts:293` waiterTask.virtualTime = task.virtualTime on sync resolution
 
 ## SV6: Hot-Swap Preserves Virtual Time
 **Statement:** When a live_loop's body is replaced (hot-swap), the task's virtual time position is preserved. Only the function changes.
 **Causal status:** STRUCTURAL — defines live coding behavior.
 **Breaks when:** Re-evaluate restarts loops from virtualTime=0.
 **Implication:** No timing discontinuity on code change.
+**REF:** `VirtualTimeScheduler.ts:147-148` hot-swap replaces asyncFn, preserves virtualTime; `VirtualTimeScheduler.ts:192-198` hotSwap() method preserves state (SV6)
 
 ## SV7: SuperSonic Node is Standard AudioWorkletNode
 **Statement:** sonic.node is a standard Web Audio AudioWorkletNode. It can be connected to any Web Audio node (AnalyserNode, GainNode, etc.).
 **Causal status:** STRUCTURAL — SuperSonic's architecture.
 **Breaks when:** N/A.
 **Implication:** Motif visualization pipeline (AnalyserNode tap) works identically to superdough.
+**REF:** `SuperSonicBridge.ts:26` sonic.node typed as AudioWorkletNode; `SuperSonicBridge.ts:189` analyserNode field; `SuperSonicBridge.ts:291-301` node connection chain
 
 ## SV8: WAV Observation Over Event Log Inference (Lokayata)
 **Statement:** The event log shows what the scheduler INTENDED. The WAV shows what scsynth PRODUCED. When they disagree, the WAV is truth.
 **Causal status:** EPISTEMIC — defines what counts as verification in this project.
 **Breaks when:** Event log is treated as sufficient proof of audio correctness.
 **Implication:** Every audio fix must be verified by capturing and analyzing the WAV file. Event log verification is necessary but not sufficient.
+**REF:** Epistemic invariant (no single source line). Enforced by Testing Protocol Level 3 in CLAUDE.md. `tools/capture.ts` implements WAV capture + analysis.
 
 ## SV9: Message Batching Per Sleep
 **Statement:** All play/sample/control calls between sleeps are queued and dispatched as ONE OSC bundle with a single NTP timetag. Events between sleeps share the same audio timestamp.
 **Causal status:** STRUCTURAL — matches Sonic Pi's `__schedule_delayed_blocks_and_messages!`.
 **Breaks when:** Messages are sent individually instead of batched.
 **Implication:** Chord notes (play 60; play 64; play 67; sleep 1) all trigger at the exact same sample boundary.
+**REF:** `SuperSonicBridge.ts:367-401` queueMessage + flushMessages; `SuperSonicBridge.ts:218` OSC bundle on sleep comment
 
 ## SV10: Mixer Inside scsynth
 **Statement:** The master mixer (limiter, gain staging, DC correction) runs as a synthdef INSIDE scsynth, not as Web Audio nodes outside.
 **Causal status:** STRUCTURAL — matches Sonic Pi's sonic-pi-mixer.
 **Breaks when:** Limiting/gain is done in Web Audio (different DSP, different latency).
 **Implication:** Audio output characteristics match desktop Sonic Pi exactly (same limiter algorithm, same gain staging).
+**REF:** `SuperSonicBridge.ts:265-284` mixer group creation + sonic-pi-mixer synthdef; `SuperSonicBridge.ts:273` signal chain: pre_amp→HPF→LPF→Limiter.ar→LeakDC→amp→ReplaceOut
 
 ## SV11: sync Waits for Fresh Cue Only
 **Statement:** `waitForSync(name)` always waits for a NEW cue event fired AFTER the sync call. It never resolves from stale cueMap entries.
 **Causal status:** CAUSAL — matches Sonic Pi's `sync` which waits for events strictly AFTER the current position.
 **Breaks when:** sync resolves from a pre-existing cueMap entry (stale cue).
 **Implication:** Synced loops wait for the sync target's NEXT iteration, not the current one.
+**REF:** `VirtualTimeScheduler.ts:305-307` waitForSync always waits for FRESH cue, comment explains never resolves from stale cueMap
 
 ## SV12: BPM Scales Time Parameters
 **Statement:** All time-based parameters — synth ADSR (attack, decay, sustain, release), ALL `*_slide` params, AND FX time params (phase, max_phase, delay, pre_delay) — must be multiplied by `60/BPM` before sending to scsynth. scsynth interprets them as seconds.
@@ -72,6 +89,7 @@
 **Breaks when:** Raw beat values are sent to scsynth as seconds. For FX: echo/delay phase is too slow, slicer/wobble/tremolo period is too wide.
 **Implication:** At BPM 130, `release: 1` becomes 0.4615 seconds; echo `phase: 0.25` becomes 0.115 seconds. Without this, all timing is ~2.17x too slow.
 **Status:** IMPLEMENTED — SoundLayer.scaleTimeParamsToBpm() for synths, samples, control, AND FX (#66).
+**REF:** `SoundLayer.ts:20-28` TIME_PARAMS set; `SoundLayer.ts:466-482` scaleTimeParamsToBpm; `SoundLayer.ts:211,228,243,271` called from all four normalize functions
 
 ## SV13: Top-Level FX Persists Across Loop Iterations
 **Statement:** A `with_fx` block wrapping a `live_loop` at the top level creates the FX node ONCE. The node persists for the lifetime of the live_loop. It is NOT recreated per iteration.
@@ -79,6 +97,7 @@
 **Breaks when:** FX is wrapped inside the loop body (recreated every iteration).
 **Implication:** One echo/reverb/etc. node, not hundreds. No FX zombie accumulation.
 **Status:** IMPLEMENTED — persistentFx in SonicPiEngine creates FX on first iteration, reuses across subsequent.
+**REF:** `SonicPiEngine.ts:73` persistentFx Map; `SonicPiEngine.ts:305-332` first-iteration creation + reuse
 
 ## SV14: Symbol References Resolve Before Normalization
 **Statement:** Symbolic defaults in synth params (e.g., `decay_level: :sustain_level`) resolve to their target param's value before BPM scaling or any other normalization.
@@ -86,3 +105,11 @@
 **Breaks when:** BPM scaling runs before symbol resolution (would scale a missing value instead of the resolved one).
 **Implication:** With `sustain_level: 0.5`, `decay_level` resolves to 0.5 (not the compiled default of 1.0). Order: resolve → inject defaults → alias → munge → BPM scale.
 **Status:** IMPLEMENTED — SoundLayer.resolveSymbolDefaults() in src/engine/SoundLayer.ts.
+**REF:** `SoundLayer.ts:331` resolveSymbolDefaults; `SoundLayer.ts:191` pipeline order comment; `SoundLayer.ts:206` resolve called before scale in normalizePlayParams
+
+## SV15: Cold-Start Warmup Required for Heavy Synths — SUPERSEDED
+**Original statement:** Heavy synth nodes require a warmup window after SuperSonic init.
+**Status:** SUPERSEDED — the "cold-start" model was wrong. The actual root cause was `env_curve: 2` (exponential) causing silence for overlapping synths in WASM scsynth (SP22 updated). Heavy synths do NOT need warmup. They need env_curve: 1 (linear, compiled default) instead of env_curve: 2 (exponential, injected by SoundLayer).
+**What invalidated this:** Re-investigation showed that removing env_curve: 2 injection fixed the "cold-start" bug entirely, regardless of timing or warmup. CDP tests worked because they bypassed SoundLayer (no env_curve injection), not because of execution context timing.
+**Lesson:** An invariant based on an ungrounded hypothesis (SP20) produces a false structural requirement. The "warmup window" would have been unnecessary complexity solving a non-existent problem.
+**REF:** SP22 (updated root cause); `SoundLayer.ts:346-349` injectMandatoryDefaults

--- a/src/engine/SoundLayer.ts
+++ b/src/engine/SoundLayer.ts
@@ -344,8 +344,12 @@ function resolveSymbolDefaults(params: Record<string, number>): Record<string, n
  * env_curve: compiled default is 1 (linear), Sonic Pi sends 2 (exponential).
  */
 function injectMandatoryDefaults(params: Record<string, number>): Record<string, number> {
-  if ('env_curve' in params) return params
-  return { ...params, env_curve: 2 }
+  // SP22 fix: Do NOT inject env_curve: 2 (exponential envelope).
+  // SuperSonic's WASM scsynth produces zero audio when env_curve: 2 is sent with
+  // overlapping synth nodes. The compiled default (env_curve: 1, linear) works.
+  // This is a minor timbre difference from Desktop Sonic Pi (which uses exponential).
+  // Filed upstream — remove this workaround when SuperSonic fixes env_curve: 2.
+  return params
 }
 
 /**
@@ -407,7 +411,7 @@ function injectSampleDefaults(params: Record<string, number>): Record<string, nu
     'sustain' in params || 'release' in params
   if (hasEnvelope) {
     const p = { ...params }
-    if (!('env_curve' in p)) p.env_curve = 2
+    // SP22: env_curve: 2 injection disabled — causes silence in WASM scsynth
     if (!('pre_amp' in p)) p.pre_amp = 1
     return p
   }

--- a/src/engine/__tests__/ReferenceParity.test.ts
+++ b/src/engine/__tests__/ReferenceParity.test.ts
@@ -281,9 +281,9 @@ describe('Reference parity: Synth params match desktop Sonic Pi', () => {
 
   it('env_curve is NOT BPM-scaled (it is a shape index, not time)', () => {
     // Source: synthinfo.rb — env_curve has no :bpm_scale tag
-    // Our injected default (env_curve: 2) must NOT be scaled
-    const result = normalizePlayParams('beep', { release: 1 }, BPM)
-    expect(result.env_curve).toBe(2)      // injected, not scaled
+    // env_curve injection disabled (SP22 workaround) — test with explicit user value
+    const result = normalizePlayParams('beep', { release: 1, env_curve: 2 }, BPM)
+    expect(result.env_curve).toBe(2)      // preserved from user, not scaled
     expect(result.release).toBeCloseTo(FACTOR, 10) // scaled
   })
 

--- a/src/engine/__tests__/SoundLayer.test.ts
+++ b/src/engine/__tests__/SoundLayer.test.ts
@@ -129,10 +129,12 @@ describe('symbol resolution', () => {
 // env_curve injection (G_NEW.13)
 // ---------------------------------------------------------------------------
 
-describe('env_curve injection', () => {
-  it('injects env_curve: 2 for synths when not set', () => {
+describe('env_curve injection — DISABLED (SP22 workaround)', () => {
+  // SP22: WASM scsynth produces silence when env_curve: 2 is sent with overlapping
+  // synth nodes. Injection disabled until upstream SuperSonic fix.
+  it('does NOT inject env_curve (uses compiled default 1/linear)', () => {
     const p = normalizePlayParams('beep', { note: 60 }, 60)
-    expect(p.env_curve).toBe(2)
+    expect(p.env_curve).toBeUndefined()
   })
 
   it('preserves explicit env_curve from user', () => {
@@ -140,9 +142,9 @@ describe('env_curve injection', () => {
     expect(p.env_curve).toBe(1)
   })
 
-  it('injects env_curve for samples with envelope params', () => {
+  it('does not inject env_curve for samples', () => {
     const p = normalizeSampleParams({ attack: 0.1, release: 0.5 }, 60)
-    expect(p.env_curve).toBe(2)
+    expect(p.env_curve).toBeUndefined()
   })
 
   it('does NOT inject env_curve for simple samples (no ADSR)', () => {


### PR DESCRIPTION
## Summary

- `env_curve: 2` (exponential envelope) injected by SoundLayer causes SuperSonic's WASM scsynth to produce zero audio for overlapping synth nodes
- Disabled injection — uses compiled default `env_curve: 1` (linear) instead
- Previously misdiagnosed as WASM AudioWorklet cold-start timing (#77, investigation v2)
- Found by diffing message content at the boundary: engine messages had env_curve: 2, raw tests did not

## Test plan

- [x] 737/737 unit tests pass
- [x] 10/10 E2E tests produce audio (4 were previously silent)
- [x] Overlapping prophet cold-start: Peak=0.39, RMS=0.05 (was Peak=0, RMS=0)
- [x] Non-overlapping prophet: Peak=1.0 (unchanged)
- [x] Catalogues updated — silent prophet error pattern rewritten, CDP asymmetry invalidated, cold-start warmup invariant superseded

Closes #80, closes #77