### PR TITLE
Slicer/wobble/panslicer rand_buf injection + 9 FX filter variants

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -261,6 +261,8 @@ export class SonicPiEngine {
         'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
         'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
         'ping_pong','panslicer',
+        // Filter variants — from synthinfo.rb FX classes
+        'bpf','rbpf','nbpf','nrbpf','nlpf','nrlpf','nhpf','nrhpf','eq',
       ]
 
       // load_sample — no-op (samples auto-load on first use via CDN)

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -105,7 +105,7 @@ const COMMON_SYNTHDEFS = [
   'sonic-pi-pretty_bell',
   'sonic-pi-piano',
   'sonic-pi-basic_stereo_player',
-  'sonic-pi-stereo_player',
+  // Note: sonic-pi-stereo_player is NOT in the CDN (404). Loaded lazily on demand.
 ]
 
 
@@ -127,6 +127,9 @@ export class SuperSonicBridge {
   private nextBufNum = 0
   private analyserNode: AnalyserNode | null = null
   private options: SuperSonicBridgeOptions
+  /** rand_buf — buffer of random values for slicer/wobble/panslicer FX.
+   *  Desktop SP loads rand-stream.wav (studio.rb:87). We generate in-memory. */
+  private randBufId: number = -1
   /** Audio bus allocator — buses 0-15 are hardware, 16+ are private */
   private nextBusNum = NUM_OUTPUT_CHANNELS
   private freeBuses: number[] = []
@@ -583,6 +586,12 @@ export class SuperSonicBridge {
     )
   }
 
+  /** FX that require rand_buf injection — matches Desktop SP's on_start hooks.
+   *  REF: synthinfo.rb:6960 FXSlicer, :7225 FXWobble, :7470 FXPanSlicer */
+  private static readonly RAND_BUF_FX = new Set([
+    'sonic-pi-fx_slicer', 'sonic-pi-fx_wobble', 'sonic-pi-fx_panslicer',
+  ])
+
   private applyFxImmediate(
     fullName: string,
     audioTime: number,
@@ -592,6 +601,19 @@ export class SuperSonicBridge {
   ): number {
     const nodeId = this.sonic!.nextNodeId()
     const paramList: (string | number)[] = ['in_bus', inBus, 'out_bus', outBus]
+    // Inject rand_buf for slicer/wobble/panslicer — mirrors on_start hook in synthinfo.rb.
+    // Lazy allocation: first use creates the buffer. Avoids init() timeout issues.
+    if (SuperSonicBridge.RAND_BUF_FX.has(fullName)) {
+      if (this.randBufId < 0) {
+        const bufNum = this.nextBufNum++
+        this.sonic!.send('/b_alloc', bufNum, 16, 1)
+        this.sonic!.send('/b_setn', bufNum, 0, 16,
+          0.23, -0.71, 0.52, -0.33, 0.89, -0.14, 0.67, -0.82,
+          0.41, -0.58, 0.76, -0.27, 0.93, -0.45, 0.18, -0.63)
+        this.randBufId = bufNum
+      }
+      paramList.push('rand_buf', this.randBufId)
+    }
     for (const key in params) {
       paramList.push(key, params[key])
     }


### PR DESCRIPTION
## Summary

### rand_buf injection for slicer/wobble/panslicer (#69)
Desktop SP's `on_start` hooks (synthinfo.rb:6960, :7225, :7470) inject a `rand_buf` parameter — a buffer of random values the FX synthdef reads for LFO modulation. Without it, these FX produce no audible effect.

Fix: Lazy-allocate a 16-sample random buffer on first slicer/wobble/panslicer use, inject as `rand_buf` param in `applyFxImmediate`.

### 9 missing FX filter variants
Added to `fx_names_fn`: `bpf`, `rbpf`, `nbpf`, `nrbpf`, `nlpf`, `nrlpf`, `nhpf`, `nrhpf`, `eq`. All exist as synthdefs on the SuperSonic CDN.

### stereo_player preload removed
`sonic-pi-stereo_player` returns 404 from the SuperSonic CDN, causing init timeout. Removed from `COMMON_SYNTHDEFS` — loaded lazily on demand (when samples with complex opts like `start/finish/pitch` are used).

Closes #69

## Test plan
- [x] `npx vitest run` — 792/792 pass
- [x] `npx tsc --noEmit` — 0 errors
- [x] Chromium capture with slicer/wobble/panslicer test (requires dev server restart after stereo_player removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)