### PR TITLE
🎯 P2 credibility: use_real_time, MIDI cue paths, wildcard sync, sound_in mic

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,16 @@ export default defineConfig({
     {
       name: 'firefox',
       use: { browserName: 'firefox' },
+      testIgnore: /p2-credibility\.spec\.ts/,
+    },
+    {
+      // P2 credibility tests require Web MIDI + getUserMedia mocks that only
+      // install under Chromium. Runs headed because the SuperSonic CDN import
+      // hangs in Chromium headless_shell — the same limitation that keeps
+      // tools/capture.ts headed for audio verification.
+      name: 'chromium',
+      use: { browserName: 'chromium', headless: false },
+      testMatch: /p2-credibility\.spec\.ts/,
     },
   ],
   webServer: {

--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -23,6 +23,7 @@ export type Step =
   | { tag: 'stop' }
   | { tag: 'kill'; nodeRef: number }
   | { tag: 'oscSend'; host: string; port: number; path: string; args: unknown[] }
+  | { tag: 'useRealTime' }
 
 export type Program = Step[]
 

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -479,6 +479,12 @@ export class ProgramBuilder {
     return this
   }
 
+  /** Set schedule-ahead time to 0 for this thread — responsive MIDI input (#149). */
+  use_real_time(): this {
+    this.steps.push({ tag: 'useRealTime' })
+    return this
+  }
+
   /**
    * Control whether time params (release, attack, phase, etc.) are automatically
    * BPM-scaled. Default: true (matching Desktop Sonic Pi).

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -141,13 +141,19 @@ export class SonicPiEngine {
 
     await Promise.all([bridgeInit, treeSitterInit])
 
-    // Wire MIDI input events → scheduler cues so `sync '/midi/note_on'` works.
-    // The handler reads this.scheduler at fire-time (always the current scheduler).
+    // Wire MIDI input events → scheduler cues.
+    // Desktop SP format: `/midi:device_name:channel/event_type` (#151).
+    // We use `*` as the device name since WebMIDI device names don't match
+    // Desktop SP's naming convention. Also fire the short `/midi/event_type`
+    // for backward compatibility — both forms resolve via wildcard sync (#150).
     this.midiBridge.onMidiEvent((event) => {
       const sched = this.scheduler
       if (!sched) return
-      const cueName = `/midi/${event.type}`
-      sched.fireCue(cueName, '__midi__', [event])
+      const ch = event.channel ?? 1
+      // Desktop SP format: /midi:*:channel/type
+      sched.fireCue(`/midi:*:${ch}/${event.type}`, '__midi__', [event])
+      // Short format for backward compatibility
+      sched.fireCue(`/midi/${event.type}`, '__midi__', [event])
     })
 
     this.initialized = true
@@ -695,6 +701,8 @@ export class SonicPiEngine {
         'use_sample_bpm',
         // Debug (no-op in browser — silences log output in Desktop SP)
         'use_debug',
+        // Latency — set schedule-ahead to 0 for responsive MIDI input (#149)
+        'use_real_time',
       ]
       const dslValues = [
         topLevelBuilder,
@@ -733,6 +741,8 @@ export class SonicPiEngine {
         (name: string) => topLevelBuilder.use_sample_bpm(name),
         // Debug (no-op in browser)
         (_val?: boolean) => { /* no-op — use_debug controls log verbosity in Desktop SP */ },
+        // Latency — no-op at top level; inside loops it's handled by ProgramBuilder + AudioInterpreter
+        () => { /* use_real_time: no-op at top level — only meaningful inside live_loops (#149) */ },
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -233,6 +233,21 @@ export class SonicPiEngine {
         this.transpileCache.set(code, transpiledCode)
       }
 
+      // Reconcile live audio (mic) streams against the new code (#152).
+      // On hot-swap, if the old code used `synth :sound_in` but the new one
+      // doesn't, the mic would otherwise stay connected and the browser's
+      // recording indicator would stay lit across the edit. Check the
+      // transpiled source for each sound_in variant; stop any stream whose
+      // name no longer appears.
+      if (this.bridge) {
+        const stillUsed = {
+          sound_in: /['"]sound_in['"]/.test(transpiledCode),
+          sound_in_stereo: /['"]sound_in_stereo['"]/.test(transpiledCode),
+        }
+        if (!stillUsed.sound_in) this.bridge.stopLiveAudio('sound_in')
+        if (!stillUsed.sound_in_stereo) this.bridge.stopLiveAudio('sound_in_stereo')
+      }
+
       // Top-level DSL state
       let defaultBpm = 60
       let defaultSynth = 'beep'
@@ -835,6 +850,9 @@ export class SonicPiEngine {
     // Free all scsynth nodes for clean silence
     if (this.bridge) {
       this.bridge.freeAllNodes()
+      // Release mic / line-in tracks so the browser's recording indicator
+      // clears and nothing keeps feeding scsynth's input channel (#152).
+      this.bridge.stopAllLiveAudio()
     }
     this.nodeRefMap.clear()
 

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -567,12 +567,28 @@ export class SonicPiEngine {
       }
 
       // ----- Global store (get/set) -----
-      // get[:key] returns the stored value (or nil). get is a Proxy so get[:key] works.
-      // set(:key, value) stores it. Shared across all loops.
+      // Shared across all loops. Supports both forms used in Sonic Pi:
+      //   get(:key)  → function call (transpiles to get("key"))
+      //   get[:key]  → bracket access (transpiles to get["key"])
+      // The bracket form needs a Proxy — a plain function has no "key" property,
+      // so `get["key"]` would return undefined. The Proxy routes property access
+      // through the store while leaving `get(...)` calls and standard function
+      // internals (name, length, call, apply, Symbol.toPrimitive, ...) alone.
       const set = (key: string | symbol, value: unknown): void => {
         this.globalStore.set(key, value)
       }
-      const get = (key: string | symbol): unknown => this.globalStore.get(key) ?? null
+      const storeGet = (key: string | symbol): unknown => this.globalStore.get(key) ?? null
+      const getFn = (key: string | symbol): unknown => storeGet(key)
+      const get = new Proxy(getFn, {
+        get(target, property, receiver) {
+          // Symbols and real function properties fall through to the target
+          // so Reflect / Function internals keep working.
+          if (typeof property === 'symbol' || property in target) {
+            return Reflect.get(target, property, receiver)
+          }
+          return storeGet(property)
+        },
+      })
 
       // ----- MIDI input readers -----
       const get_cc = (controller: number, channel: number = 1): number =>

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -139,6 +139,8 @@ export class SuperSonicBridge {
   private freeBuses: number[] = []
   /** Live audio (mic/line-in) streams keyed by name */
   private liveAudioStreams = new Map<string, { stream: MediaStream, source: MediaStreamAudioSourceNode }>()
+  /** Names whose startLiveAudio getUserMedia is currently in-flight — race lock (#152) */
+  private pendingLiveAudio = new Set<string>()
   /** Per-track AnalyserNodes keyed by track name */
   private trackAnalysers = new Map<string, AnalyserNode>()
   /** Track name → scsynth bus pair (stereo, starting at bus 2) */
@@ -666,34 +668,68 @@ export class SuperSonicBridge {
   }
 
   /**
+   * Returns true if a live audio stream under this name is currently active
+   * OR mid-acquisition. Used by AudioInterpreter to avoid re-starting the
+   * mic on every `synth :sound_in` dispatch inside a live_loop (#152).
+   */
+  isLiveAudioStreaming(name: string): boolean {
+    return this.liveAudioStreams.has(name) || this.pendingLiveAudio.has(name)
+  }
+
+  /**
    * Start capturing live audio from the system input (microphone/line-in).
-   * The stream is connected to the master analyser → gain → speakers chain.
-   * Disables browser audio processing for clean pass-through.
+   * The stream is connected to the scsynth AudioWorkletNode so SoundIn.ar
+   * inside the `sonic-pi-sound_in` synthdef can read the mic signal.
+   *
+   * **Idempotent and race-safe** (#152): if a stream already exists under
+   * this name, or a `getUserMedia` call is in-flight for it, returns
+   * immediately. Without this the AudioInterpreter's per-dispatch auto-start
+   * would tear down and re-acquire the mic ~10×/sec inside a live_loop,
+   * making the browser indicator flicker and the audio drop out.
    */
   async startLiveAudio(name: string, opts?: { stereo?: boolean }): Promise<void> {
     if (!this.sonic) throw new Error('SuperSonic not initialized')
 
-    // If already running under this name, stop it first
-    this.stopLiveAudio(name)
+    // Already running or mid-acquisition — skip. Callers that genuinely want
+    // to reconfigure (mono ↔ stereo) must stopLiveAudio(name) first.
+    if (this.liveAudioStreams.has(name) || this.pendingLiveAudio.has(name)) return
 
-    const stream = await navigator.mediaDevices.getUserMedia({
-      audio: {
-        echoCancellation: false,
-        noiseSuppression: false,
-        autoGainControl: false,
-        channelCount: opts?.stereo ? 2 : 1,
-      } as MediaTrackConstraints,
-    })
+    this.pendingLiveAudio.add(name)
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false,
+          channelCount: opts?.stereo ? 2 : 1,
+        } as MediaTrackConstraints,
+      })
 
-    const audioCtx = this.sonic.audioContext
-    const source = audioCtx.createMediaStreamSource(stream)
-    // Connect mic INTO the scsynth AudioWorkletNode so SoundIn.ar(bus) can
-    // read it. The synthdef `sonic-pi-sound_in` reads from bus 0 (hardware
-    // input), which maps to the WorkletNode's first input channel (#152).
-    const workletNode = this.sonic.node as AudioNode
-    source.connect(workletNode)
+      // Another caller may have stopped/disposed during the await — bail out
+      // if we're no longer supposed to be acquiring.
+      if (!this.pendingLiveAudio.has(name)) {
+        stream.getTracks().forEach(t => t.stop())
+        return
+      }
 
-    this.liveAudioStreams.set(name, { stream, source })
+      const audioCtx = this.sonic.audioContext
+      const source = audioCtx.createMediaStreamSource(stream)
+      // Connect mic INTO the scsynth AudioWorkletNode so SoundIn.ar(bus) can
+      // read it. The synthdef `sonic-pi-sound_in` reads from bus 0 (hardware
+      // input), which maps to the WorkletNode's first input channel (#152).
+      //
+      // SuperSonic's `.node` is a wrapper object (see its docs/GUIDE.md:80 —
+      // `micSource.connect(supersonic.node.input)`). The real AudioNode lives
+      // at `.input`; using `.node` directly throws "Overload resolution failed".
+      // Mirror the pattern already used in init() at line 242.
+      const nodeWrapper = this.sonic.node as unknown as Record<string, AudioNode>
+      const workletNode = nodeWrapper.input ?? (this.sonic.node as unknown as AudioNode)
+      source.connect(workletNode)
+
+      this.liveAudioStreams.set(name, { stream, source })
+    } finally {
+      this.pendingLiveAudio.delete(name)
+    }
   }
 
   /** Stop a named live audio stream and release its resources. */
@@ -703,6 +739,22 @@ export class SuperSonicBridge {
       entry.source.disconnect()
       entry.stream.getTracks().forEach(t => t.stop())
       this.liveAudioStreams.delete(name)
+    }
+  }
+
+  /**
+   * Stop every active live audio stream and release mic tracks (#152).
+   * Called on engine stop so the browser's mic indicator clears and the
+   * mic stops feeding scsynth's input channel between runs.
+   *
+   * Also clears pendingLiveAudio so any in-flight getUserMedia call
+   * detects the cancellation after its await and tears down the stream
+   * it just acquired instead of racing past the stop.
+   */
+  stopAllLiveAudio(): void {
+    this.pendingLiveAudio.clear()
+    for (const name of Array.from(this.liveAudioStreams.keys())) {
+      this.stopLiveAudio(name)
     }
   }
 
@@ -833,9 +885,7 @@ export class SuperSonicBridge {
 
   dispose(): void {
     // Stop all live audio streams
-    for (const name of this.liveAudioStreams.keys()) {
-      this.stopLiveAudio(name)
-    }
+    this.stopAllLiveAudio()
     if (this.masterGainNode) {
       this.masterGainNode.disconnect()
       this.masterGainNode = null

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -687,8 +687,11 @@ export class SuperSonicBridge {
 
     const audioCtx = this.sonic.audioContext
     const source = audioCtx.createMediaStreamSource(stream)
-    // Connect to the analyser node (which feeds into master gain → destination)
-    source.connect(this.analyserNode ?? audioCtx.destination)
+    // Connect mic INTO the scsynth AudioWorkletNode so SoundIn.ar(bus) can
+    // read it. The synthdef `sonic-pi-sound_in` reads from bus 0 (hardware
+    // input), which maps to the WorkletNode's first input channel (#152).
+    const workletNode = this.sonic.node as AudioNode
+    source.connect(workletNode)
 
     this.liveAudioStreams.set(name, { stream, source })
   }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -224,8 +224,8 @@ const BUILDER_METHODS = new Set([
   // Synth defaults / BPM / synth blocks
   'use_synth_defaults', 'use_sample_defaults', 'with_synth_defaults', 'with_sample_defaults',
   'with_bpm', 'with_synth', 'use_density',
-  // Debug
-  'use_debug',
+  // Debug + latency
+  'use_debug', 'use_real_time',
   // BPM scaling control
   'use_arg_bpm_scaling', 'with_arg_bpm_scaling',
   // Utility

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -321,18 +321,24 @@ export class VirtualTimeScheduler {
   /**
    * Broadcast a cue event. Any tasks waiting via waitForSync
    * are woken and inherit the cuer's virtual time (SV5).
+   *
+   * `taskId` may identify a real scheduler task (normal DSL cue from inside
+   * a live_loop) OR a synthetic external source (e.g. `'__midi__'` from the
+   * MIDI bridge, `'__osc__'` from incoming OSC — #151). When the task does
+   * not exist, fall back to the current audio time so external sources still
+   * wake sync waiters instead of silently returning.
    */
   fireCue(name: string, taskId: string, args: unknown[] = []): void {
     const task = this.tasks.get(taskId)
-    if (!task) return
+    const cueVirtualTime = task?.virtualTime ?? this.getAudioTime()
 
-    this.cueMap.set(name, { time: task.virtualTime, args })
+    this.cueMap.set(name, { time: cueVirtualTime, args })
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({
       type: 'cue',
       taskId,
-      virtualTime: task.virtualTime,
+      virtualTime: cueVirtualTime,
       audioTime: this.getAudioTime(),
       params: { name, args },
     })
@@ -347,7 +353,7 @@ export class VirtualTimeScheduler {
         const waiterTask = this.tasks.get(waiter.taskId)
         if (waiterTask) {
           // Inherit cue's virtual time (SV5)
-          waiterTask.virtualTime = task.virtualTime
+          waiterTask.virtualTime = cueVirtualTime
         }
         waiter.resolve(args)
       }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -1,6 +1,29 @@
 import { MinHeap } from './MinHeap'
 
 // ---------------------------------------------------------------------------
+// Cue glob matching (#150) — supports * and ? wildcards in sync targets
+// ---------------------------------------------------------------------------
+
+/**
+ * Match a sync pattern against a fired cue name.
+ * Exact match is the fast path; glob matching activates only when the
+ * pattern contains `*` or `?`.
+ *
+ * `*` matches any sequence of characters (including empty).
+ * `?` matches exactly one character.
+ *
+ * Used by fireCue to wake sync waiters whose patterns glob-match the cue.
+ */
+function cueGlobMatch(pattern: string, name: string): boolean {
+  if (pattern === name) return true
+  if (!pattern.includes('*') && !pattern.includes('?')) return false
+  // Convert glob to regex: escape special regex chars, then replace glob tokens
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp('^' + escaped.replace(/\*/g, '.*').replace(/\?/g, '.') + '$')
+  return re.test(name)
+}
+
+// ---------------------------------------------------------------------------
 // Scheduling constants
 // ---------------------------------------------------------------------------
 
@@ -314,9 +337,12 @@ export class VirtualTimeScheduler {
       params: { name, args },
     })
 
-    // Wake any tasks waiting for this cue
-    const waiters = this.syncWaiters.get(name)
-    if (waiters && waiters.length > 0) {
+    // Wake any tasks waiting for this cue.
+    // Supports exact match AND glob patterns (*, ?) in sync targets (#150).
+    // Example: `sync "/midi:*:*/note_on"` matches a cue named `/midi:*:1/note_on`.
+    for (const [pattern, waiters] of this.syncWaiters) {
+      if (waiters.length === 0) continue
+      if (!cueGlobMatch(pattern, name)) continue
       for (const waiter of waiters) {
         const waiterTask = this.tasks.get(waiter.taskId)
         if (waiterTask) {
@@ -325,7 +351,7 @@ export class VirtualTimeScheduler {
         }
         waiter.resolve(args)
       }
-      this.syncWaiters.delete(name)
+      this.syncWaiters.delete(pattern)
     }
   }
 

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -81,6 +81,13 @@ export async function runProgram(
         const nodeRef = nextNodeRef++
 
         if (ctx.bridge) {
+          // Auto-start mic input when sound_in / sound_in_stereo is used (#152).
+          // getUserMedia is async but idempotent — only requests permission once.
+          if (synth === 'sound_in' || synth === 'sound_in_stereo') {
+            ctx.bridge.startLiveAudio(synth, { stereo: synth === 'sound_in_stereo' })
+              .catch((err: Error) => ctx.printHandler?.(`Mic input failed: ${err.message}`))
+          }
+
           // Mutate step.opts directly — normalizePlayParams copies internally.
           // Avoids 3 object spreads per event that cause GC pressure (#75).
           step.opts.note = step.note
@@ -153,6 +160,12 @@ export async function runProgram(
       case 'useBpm':
         currentBpm = step.bpm
         if (task) task.bpm = step.bpm
+        break
+
+      case 'useRealTime':
+        // Set schedule-ahead to 0 for responsive MIDI input (#149).
+        // Desktop SP Ch 11.1: use_real_time disables latency for current thread.
+        ctx.schedAheadTime = 0
         break
 
       case 'control': {

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -81,9 +81,14 @@ export async function runProgram(
         const nodeRef = nextNodeRef++
 
         if (ctx.bridge) {
-          // Auto-start mic input when sound_in / sound_in_stereo is used (#152).
-          // getUserMedia is async but idempotent — only requests permission once.
-          if (synth === 'sound_in' || synth === 'sound_in_stereo') {
+          // Auto-start mic input on the FIRST dispatch of sound_in per run (#152).
+          // The live_loop re-dispatches every ~100ms; without this gate the mic
+          // would churn (stop → getUserMedia → reconnect) 10×/sec and the
+          // browser's recording indicator would flicker. The bridge is already
+          // idempotent + race-safe, but the cheap sync check here also avoids
+          // spamming "Mic input failed" from the .catch on every dispatch.
+          if ((synth === 'sound_in' || synth === 'sound_in_stereo') &&
+              !ctx.bridge.isLiveAudioStreaming(synth)) {
             ctx.bridge.startLiveAudio(synth, { stereo: synth === 'sound_in_stereo' })
               .catch((err: Error) => ctx.printHandler?.(`Mic input failed: ${err.message}`))
           }

--- a/tests/p2-credibility.spec.ts
+++ b/tests/p2-credibility.spec.ts
@@ -1,0 +1,398 @@
+/**
+ * P2 credibility E2E tests — PR #166.
+ *
+ * Automated Playwright coverage for the 4 P2 features so they can be verified
+ * without MIDI hardware or a real microphone:
+ *
+ *   #149 use_real_time       — smoke test: runs inside live_loop without crashing
+ *   #150 wildcard sync/cue   — * and ? match globs, exact non-match never fires
+ *   #151 MIDI cue path dual  — /midi:*:ch/type AND /midi/type both resolve from one event
+ *   #152 sound_in mic input  — synth :sound_in triggers getUserMedia, routes to worklet
+ *
+ * Strategy
+ * --------
+ * - Chromium is required: Web MIDI API is Chromium-only, and we stub
+ *   `navigator.requestMIDIAccess` + `navigator.mediaDevices.getUserMedia`
+ *   in addInitScript so the tests run with zero hardware.
+ * - The Web MIDI mock returns one fake input "Mock MIDI Keyboard" and
+ *   exposes `window.__fireMidi([status, data1, data2])` to synthesise
+ *   incoming messages. It also exposes `window.__midiListenerCount()` so
+ *   we can assert the bridge actually wired a listener.
+ * - The getUserMedia mock returns a silent MediaStream from a fresh
+ *   AudioContext's MediaStreamDestination — real enough that
+ *   createMediaStreamSource in the app doesn't throw.
+ * - MIDI tests drive the real UI to call MidiBridge.selectInput (there is
+ *   no public JS hook on the engine), by clicking the MIDI toolbar button
+ *   open→close→open to trigger lazy init + rebuild, then clicking the
+ *   mock input row.
+ *
+ * These tests are Level-2 observation (events/console), not Level-3 audio
+ * — they verify the feature wiring, not audio output. Audio verification
+ * for sound_in would require `tools/capture.ts` + WAV analysis.
+ */
+import { test, expect, Page } from '@playwright/test'
+
+// Browser is pinned to Chromium via the dedicated project in playwright.config.ts.
+
+const selectAll = process.platform === 'darwin' ? 'Meta+a' : 'Control+a'
+
+/**
+ * Return just the Log-pane portion of the app text, stripping the editor
+ * source and toolbar so `expect(...).not.toContain(...)` doesn't match
+ * literals in the user's code.
+ */
+function logPaneText(fullAppText: string): string {
+  const marker = 'Happy live coding!'
+  const idx = fullAppText.indexOf(marker)
+  return idx >= 0 ? fullAppText.slice(idx + marker.length) : fullAppText
+}
+
+// ---------------------------------------------------------------------------
+// Pre-navigation stubs: Web MIDI + getUserMedia
+// ---------------------------------------------------------------------------
+
+async function installMocks(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // ---- Web MIDI mock ---------------------------------------------------
+    const listeners = new Set<(evt: { data: Uint8Array }) => void>()
+
+    const mockInput = {
+      id: 'mock-keyboard-1',
+      name: 'Mock MIDI Keyboard',
+      manufacturer: 'PlaywrightMock',
+      type: 'input' as const,
+      state: 'connected' as const,
+      connection: 'open' as const,
+      version: '1.0',
+      onmidimessage: null as ((e: unknown) => void) | null,
+      addEventListener(type: string, cb: (evt: { data: Uint8Array }) => void) {
+        if (type === 'midimessage') listeners.add(cb)
+      },
+      removeEventListener(type: string, cb: (evt: { data: Uint8Array }) => void) {
+        if (type === 'midimessage') listeners.delete(cb)
+      },
+      open() { return Promise.resolve(this) },
+      close() { return Promise.resolve(this) },
+      dispatchEvent() { return true },
+    }
+
+    const inputs = new Map<string, typeof mockInput>()
+    inputs.set(mockInput.id, mockInput)
+    const outputs = new Map()
+
+    const midiAccess = {
+      inputs,
+      outputs,
+      sysexEnabled: false,
+      onstatechange: null as ((e: unknown) => void) | null,
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() { return true },
+    }
+
+    Object.defineProperty(navigator, 'requestMIDIAccess', {
+      value: () => Promise.resolve(midiAccess),
+      writable: true,
+      configurable: true,
+    })
+
+    ;(window as unknown as { __fireMidi: (bytes: number[]) => number }).__fireMidi = (bytes) => {
+      const evt = { data: new Uint8Array(bytes) }
+      let fired = 0
+      for (const cb of listeners) {
+        try { cb(evt); fired++ } catch { /* don't crash on bad listener */ }
+      }
+      return fired
+    }
+    ;(window as unknown as { __midiListenerCount: () => number }).__midiListenerCount = () => listeners.size
+
+    // ---- getUserMedia mock: silent MediaStream via MediaStreamDestination
+    ;(window as unknown as { __gumCalls: string[] }).__gumCalls = []
+    if (navigator.mediaDevices) {
+      const mockGUM = async (constraints: MediaStreamConstraints): Promise<MediaStream> => {
+        ;(window as unknown as { __gumCalls: string[] }).__gumCalls.push(JSON.stringify(constraints))
+        const Ctx = (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)
+        const ctx = new Ctx()
+        const dst = ctx.createMediaStreamDestination()
+        // Silent source — just keeps the track alive
+        const osc = ctx.createOscillator()
+        const gain = ctx.createGain()
+        gain.gain.value = 0
+        osc.connect(gain).connect(dst)
+        osc.start()
+        return dst.stream
+      }
+      Object.defineProperty(navigator.mediaDevices, 'getUserMedia', {
+        value: mockGUM,
+        writable: true,
+        configurable: true,
+      })
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function gotoAndWaitBanner(page: Page): Promise<void> {
+  await page.goto('/')
+  // The startup banner is printed before the engine is lazily initialised.
+  await page.waitForFunction(
+    () => (document.querySelector('#app')?.textContent ?? '').includes('Happy live coding'),
+    { timeout: 15000 }
+  )
+}
+
+/**
+ * Paste code, click Run, and wait for the engine to finish initialising
+ * (the "Audio engine ready" log line) before returning. The engine is
+ * created lazily on the first Run click, so CDN + scsynth setup happens here.
+ */
+async function runCode(page: Page, code: string): Promise<void> {
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press(selectAll)
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(code)
+  await page.waitForTimeout(200)
+
+  // Click the Run button explicitly — matches capture.ts and p0-smoke convention.
+  // Keyboard shortcut (Ctrl+Enter) has intermittent focus issues in headed Chromium.
+  const runBtn = page.locator('.spw-btn-label:has-text("Run")')
+  await runBtn.click()
+
+  // Engine creation is lazy — first Run click triggers CDN import + scsynth init.
+  // Poll for readiness with a longer window than the default test timeout allows.
+  await page.waitForFunction(
+    () => (document.querySelector('#app')?.textContent ?? '').includes('Audio engine ready'),
+    { timeout: 60000 }
+  )
+}
+
+async function stopCode(page: Page): Promise<void> {
+  await page.keyboard.press('Escape')
+  await page.waitForTimeout(300)
+}
+
+/**
+ * Call engine.midiBridge.init() + selectInput() directly via the globally
+ * exposed `globalThis.__spw_engine` (App.ts:897 sets it for diagnostics).
+ * This avoids the brittle UI dropdown dance and works regardless of the
+ * toolbar's lazy-init race.
+ */
+async function enableMockMidiInput(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const engine = (globalThis as unknown as { __spw_engine?: {
+      midiBridge: {
+        init: () => Promise<boolean>
+        getDevices: () => { id: string; name: string; type: string }[]
+        selectInput: (id: string) => boolean
+      }
+    } }).__spw_engine
+    if (!engine) throw new Error('__spw_engine not exposed — app did not complete engine init')
+    const ok = await engine.midiBridge.init()
+    if (!ok) throw new Error('midiBridge.init() returned false — mock requestMIDIAccess not installed?')
+    const devices = engine.midiBridge.getDevices().filter(d => d.type === 'input')
+    if (devices.length === 0) throw new Error('No mock MIDI input devices visible to bridge')
+    const attached = engine.midiBridge.selectInput(devices[0].id)
+    if (!attached) throw new Error(`selectInput(${devices[0].id}) returned false`)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// The engine is created lazily on first Run: CDN import + scsynth init adds
+// 10–40s per test on top of normal exercise time. Bump the per-test timeout
+// well above the config default.
+test.describe.configure({ timeout: 120_000 })
+
+test.describe('P2 credibility (PR #166)', () => {
+
+  test('#150 wildcard sync — * and ? match, exact non-match never fires', async ({ page }) => {
+    await installMocks(page)
+    await gotoAndWaitBanner(page)
+
+    await runCode(page, `
+live_loop :ticker do
+  cue "/foo/bar/tick"
+  sleep 0.4
+end
+
+live_loop :star_match do
+  sync "/foo/*/tick"
+  puts "STAR_OK"
+end
+
+live_loop :question_match do
+  sync "/foo/?ar/tick"
+  puts "QUESTION_OK"
+end
+
+live_loop :exact_nonmatch do
+  sync "/foo/baz/tick"
+  puts "EXACT_NONMATCH_FAIL"
+end
+`)
+
+    await page.waitForTimeout(2500)
+    const appText = await page.locator('#app').textContent() ?? ''
+    await stopCode(page)
+
+    const log = logPaneText(appText)
+    expect(log).toContain('STAR_OK')
+    expect(log).toContain('QUESTION_OK')
+    expect(log).not.toContain('EXACT_NONMATCH_FAIL')
+    expect(log).not.toContain('Error in loop')
+    expect(log).not.toContain('not a function')
+  })
+
+  test('#149 use_real_time runs inside live_loop without crashing', async ({ page }) => {
+    await installMocks(page)
+    await gotoAndWaitBanner(page)
+
+    // use_real_time inside a live_loop should flip schedAheadTime to 0 for
+    // that task. We can't easily observe the latency change wall-clock, but
+    // we can assert the keyword transpiles, runs, and the loop resumes on cue.
+    await runCode(page, `
+live_loop :rt do
+  use_real_time
+  sync "/trigger"
+  puts "RT_RESUMED"
+end
+
+live_loop :driver do
+  sleep 0.3
+  cue "/trigger"
+end
+`)
+
+    await page.waitForTimeout(2000)
+    const appText = await page.locator('#app').textContent() ?? ''
+    await stopCode(page)
+
+    const log = logPaneText(appText)
+    expect(log).toContain('RT_RESUMED')
+    expect(log).not.toContain('Error in loop')
+    expect(log).not.toContain('not a function')
+    expect(log).not.toContain("isn't available")
+    expect(log).not.toContain('SyntaxError')
+  })
+
+  test('#149 use_real_time at top level is a safe no-op', async ({ page }) => {
+    await installMocks(page)
+    await gotoAndWaitBanner(page)
+
+    await runCode(page, `
+use_real_time
+live_loop :top do
+  puts "TOP_LEVEL_OK"
+  sleep 0.3
+end
+`)
+
+    await page.waitForTimeout(1500)
+    const appText = await page.locator('#app').textContent() ?? ''
+    await stopCode(page)
+
+    const log = logPaneText(appText)
+    expect(log).toContain('TOP_LEVEL_OK')
+    expect(log).not.toContain('Error in loop')
+    expect(log).not.toContain('not a function')
+  })
+
+  test('#151 MIDI event dual-fires /midi:*:channel/type and /midi/type', async ({ page }) => {
+    await installMocks(page)
+    await gotoAndWaitBanner(page)
+
+    // Two loops sync on different cue-path formats. A single mocked MIDI
+    // note_on must wake BOTH — that's what the dual fireCue in
+    // SonicPiEngine.init's midiBridge.onMidiEvent handler guarantees.
+    // A third loop syncs on channel 2 and must NOT wake from a channel 1 event.
+    await runCode(page, `
+live_loop :desktop_format do
+  sync "/midi:*:1/note_on"
+  puts "DESKTOP_FORMAT_OK"
+end
+
+live_loop :short_format do
+  sync "/midi/note_on"
+  puts "SHORT_FORMAT_OK"
+end
+
+live_loop :wrong_channel do
+  sync "/midi:*:2/note_on"
+  puts "WRONG_CHANNEL_FAIL"
+end
+`)
+
+    // Let loops park at sync points
+    await page.waitForTimeout(800)
+
+    // Attach the mock MIDI input via the engine's public midiBridge
+    await enableMockMidiInput(page)
+
+    // The bridge should now have attached a listener to the mock input
+    const listenerCount = await page.evaluate(
+      () => (window as unknown as { __midiListenerCount: () => number }).__midiListenerCount()
+    )
+    expect(listenerCount).toBeGreaterThan(0)
+
+    // Fire note_on on channel 1: status = 0x90 | (1-1) = 0x90, note 60, vel 100
+    await page.evaluate(() => {
+      ;(window as unknown as { __fireMidi: (b: number[]) => number }).__fireMidi([0x90, 60, 100])
+    })
+    await page.waitForTimeout(800)
+
+    // Fire once more so the loops cycle a second time through sync
+    await page.evaluate(() => {
+      ;(window as unknown as { __fireMidi: (b: number[]) => number }).__fireMidi([0x90, 62, 100])
+    })
+    await page.waitForTimeout(800)
+
+    const appText = await page.locator('#app').textContent() ?? ''
+    await stopCode(page)
+
+    const log = logPaneText(appText)
+    expect(log).toContain('DESKTOP_FORMAT_OK')
+    expect(log).toContain('SHORT_FORMAT_OK')
+    expect(log).not.toContain('WRONG_CHANNEL_FAIL')
+    expect(log).not.toContain('Error in loop')
+  })
+
+  test('#152 sound_in triggers getUserMedia and runs without mic errors', async ({ page }) => {
+    await installMocks(page)
+    // Chromium also gates getUserMedia on permission — grant it pre-emptively
+    // even though our mock bypasses the real mic path.
+    await page.context().grantPermissions(['microphone'])
+    await gotoAndWaitBanner(page)
+
+    await runCode(page, `
+live_loop :mic_in do
+  use_real_time
+  synth :sound_in, amp: 0.5
+  sleep 0.2
+end
+`)
+
+    await page.waitForTimeout(2000)
+    const appText = await page.locator('#app').textContent() ?? ''
+    const gumCalls = await page.evaluate(
+      () => (window as unknown as { __gumCalls: string[] }).__gumCalls
+    )
+    await stopCode(page)
+
+    // The AudioInterpreter's sound_in handler calls bridge.startLiveAudio
+    // which calls getUserMedia — assert it was invoked at least once.
+    expect(gumCalls.length).toBeGreaterThan(0)
+    const log = logPaneText(appText)
+    // The PR's whole point is the routing fix — must not log the failure path
+    expect(log).not.toContain('Mic input failed')
+    expect(log).not.toContain('Error in loop')
+    expect(log).not.toContain('not a function')
+    expect(log).not.toContain("isn't available")
+  })
+})


### PR DESCRIPTION
## Summary

Closes #149, #150, #151, #152.

Four P2 credibility features matching Desktop Sonic Pi tutorial chapters:

- **#149 `use_real_time`** (Ch 11.1) — sets schedule-ahead to 0 for responsive MIDI input. New `useRealTime` step in Program/ProgramBuilder, handled by AudioInterpreter.
- **#151 MIDI cue paths** (Ch 11) — fires both Desktop format (`/midi:*:1/note_on`) and short format (`/midi/note_on`). Tutorial examples using either form now match.
- **#150 Wildcard sync** (Ch 10.3) — `sync "/osc*/trigger"` works via glob matching (`*`, `?`) in `fireCue`. Iterates all sync waiters instead of exact Map lookup.
- **#152 sound_in mic input** (Ch 13.1) — `synth :sound_in` auto-requests mic permission via `getUserMedia` and routes the MediaStreamSource to scsynth's AudioWorkletNode input. `sound_in_stereo` requests stereo.

## Review bugs caught + fixed

Building an E2E test harness for the four features surfaced **four real engine bugs** that the original commit didn't catch. All fixed on this branch before merge, each with its own issue:

| Issue | Bug | Commit |
|---|---|---|
| #167 | `synth :sound_in` threw `Failed to execute 'connect' on 'AudioNode'` every dispatch — `source.connect(sonic.node)` instead of `sonic.node.input`. SuperSonic's `.node` is a wrapper; the real AudioNode lives at `.input` (confirmed in the SuperSonic guide + existing line-242 pattern). | `f8fdf12` |
| #168 | MIDI dual-fire silently dropped every event. `fireCue` early-returned at `if (!task) return` because the new `'__midi__'` synthetic taskId isn't a real scheduler task. Fix: fall through with `getAudioTime()` as the cue virtual time. | `416b85e` |
| #169 | `sound_in` lifecycle broken in three ways: (a) Stop didn't release the mic track — indicator stayed lit; (b) `live_loop { synth :sound_in; sleep 0.1 }` re-acquired the mic 10×/sec, flickering the indicator; (c) hot-swap from sound_in code to non-sound_in code leaked the stream. Fix: idempotent + race-safe `startLiveAudio` with a pending-acquisition lock; reconcile `liveAudioStreams` against the transpiled code on every `evaluate()`; wire `stopAllLiveAudio` into `engine.stop()`. | `f8fdf12` |
| #170 | `get[:key]` bracket form silently returned `undefined` for every key — the docstring promised a Proxy that was never implemented. Any `if get[:flag] ... end` branch silently took the `else` path forever. (Pre-existing bug, not introduced by this PR — found while testing real compositions.) Fix: wrap `get` in a real Proxy. | `33c3b9a` |

## Automated test coverage

New suite: `tests/p2-credibility.spec.ts` — 5 Playwright tests running under a new Chromium project (required because Web MIDI is Chromium-only and headless_shell hangs the SuperSonic CDN import).

| Test | What it verifies | Mocks used |
|---|---|---|
| #150 wildcard sync | `/foo/*/tick` and `/foo/?ar/tick` both match; `/foo/baz/tick` never fires on a `/foo/bar/tick` cue | none |
| #149 inside live_loop | `use_real_time` + sync/cue — runs without crashing, loop resumes | none |
| #149 at top level | safe no-op | none |
| #151 MIDI dual-fire | A single mocked `[0x90, 60, 100]` wakes both `/midi:*:1/note_on` and `/midi/note_on` sync waiters but NOT `/midi:*:2/note_on` | `navigator.requestMIDIAccess` → fake MIDIAccess with `window.__fireMidi([bytes])` for message injection |
| #152 sound_in | `synth :sound_in` in a live_loop triggers `getUserMedia` and produces zero `Mic input failed` errors | `navigator.mediaDevices.getUserMedia` → silent MediaStreamDestination |

Tests bypass the MIDI toolbar dropdown entirely and drive the engine directly via `globalThis.__spw_engine` (exposed at `App.ts:897` for diagnostics).

## Level 2 vs Level 3

These are Level-2 tests (event/DOM/OSC inference). They catch routing, lifecycle, and scheduler regressions deterministically, but they do NOT measure perceptual qualities:

- **#149 `use_real_time`**: verified the keyword transpiles and the loop resumes. Did NOT measure the actual latency drop from `schedAheadTime=0` — that needs either real MIDI hardware or a differential-onset test in `tools/capture.ts`.
- **#152 sound_in**: verified `getUserMedia` is called, the `source.connect(workletNode)` no longer throws, and no "Mic input failed" messages appear. Did NOT verify mic audio actually flows through scsynth's input channel and out to the speaker — that needs a real mic or a test-tone mic mock with WAV FFT analysis.

Both are tracked as follow-up (`tools/level3-p2.ts`). Manual verification with real hardware has been done in-session and works as designed — see the commit messages in #167 and #169 for the verification notes.

## Changed files (full stack across original commit + review fixes)

| File | Change |
|---|---|
| `Program.ts` | New `useRealTime` step type |
| `ProgramBuilder.ts` | `use_real_time()` method |
| `AudioInterpreter.ts` | `useRealTime` handler + idempotent auto-startLiveAudio gate for sound_in |
| `SonicPiEngine.ts` | MIDI dual-cue paths + `use_real_time` in dslNames + `get[]` Proxy + reconcile-on-evaluate + stop() → stopAllLiveAudio |
| `SuperSonicBridge.ts` | `.input ?? .node` routing fix + idempotent race-safe `startLiveAudio` + new `stopAllLiveAudio` / `isLiveAudioStreaming` + pending-acquisition lock |
| `VirtualTimeScheduler.ts` | `cueGlobMatch` + glob iteration in `fireCue` + external-taskId fallback |
| `TreeSitterTranspiler.ts` | `use_real_time` in BUILDER_METHODS |
| `tests/p2-credibility.spec.ts` | **NEW** — 5-test Playwright suite |
| `playwright.config.ts` | New chromium project scoped to P2 tests (headed) |

## Test plan

- [x] `npx vitest run` — 717 passed, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test tests/p2-credibility.spec.ts --project=chromium` — 5/5 passed
- [x] `npx playwright test --project=firefox` — 46/46 passed (existing E2E, no regressions from fireCue/scheduler changes)
- [x] Manual: `synth :sound_in` → mic permission prompt + live audio through scsynth, Stop releases the track, hot-swap removal releases the track, no rapid on/off
- [x] Manual: sync/cue + wildcard matching verified through a real composition
- [x] Manual: `use_real_time` verified via real composition (perceptual latency drop not measured — Level 3 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)