### PR TITLE
🎯 Per-loop audio isolation — loopBus + monitor synth + scope per live_loop

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -334,10 +334,12 @@ export class SonicPiEngine {
           syncTarget = (builderFnOrOpts.sync as string) ?? null
           builderFn = maybeFn!
         }
-        // Allocate track bus for per-loop AnalyserNode (visualization only).
-        // Synths write to bus 0 so the scsynth mixer (Limiter.ar, gain staging) processes them.
-        // Track buses are NOT used as outBus — that would bypass the mixer entirely.
-        this.bridge?.allocateTrackBus(name)
+        // Per-loop audio isolation: create a monitor synth that reads this
+        // loop's private loopBus and fans out to bus 0 (mixer) + trackBus
+        // (per-track AnalyserNode for scope visualization). Synths in this
+        // loop write to loopBus via task.outBus; the monitor ensures audio
+        // still reaches the mixer without bypassing it. See issue #177.
+        const loopBus = this.bridge?.createLoopMonitor(name) ?? 0
 
         // Store builder function for capture path
         this.loopBuilders.set(name, builderFn)
@@ -450,7 +452,7 @@ export class SonicPiEngine {
           if (task) {
             task.bpm = defaultBpm
             task.currentSynth = defaultSynth
-            task.outBus = 0
+            task.outBus = loopBus
           }
         }
       }
@@ -810,13 +812,14 @@ export class SonicPiEngine {
         // Commit: hot-swap same-named, stop removed, start new
         scheduler.reEvaluate(pendingLoops, { bpm: defaultBpm, synth: defaultSynth })
 
-        // Apply per-loop defaults (synths write to bus 0 for mixer processing)
+        // Apply per-loop defaults (synths write to their loop's private bus
+        // so the monitor can fan out to master + per-track analyser)
         for (const [name, defaults] of pendingDefaults) {
           const task = scheduler.getTask(name)
           if (task) {
             task.bpm = defaults.bpm
             task.currentSynth = defaults.synth
-            task.outBus = 0
+            task.outBus = this.bridge?.getLoopBus(name) ?? 0
           }
         }
 

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -8,11 +8,12 @@
 
 import { audioTimeToNTP, encodeSingleBundle as fallbackEncodeSingleBundle, encodeBundle as fallbackEncodeBundle } from './osc'
 import { normalizeSampleParams, selectSamplePlayer, translateSampleOpts } from './SoundLayer'
+import { buildTrackMonitorSynthDef } from './buildTrackMonitorSynthDef'
 
 // SuperSonic types — declared here since we load it at runtime via CDN
 interface SuperSonic {
   init(): Promise<void>
-  send(address: string, ...args: (string | number)[]): void
+  send(address: string, ...args: (string | number | Uint8Array)[]): void
   sendOSC(data: Uint8Array, options?: Record<string, unknown>): void
   loadSynthDef(name: string): Promise<void>
   loadSynthDefs(names: string[]): Promise<void>
@@ -150,6 +151,10 @@ export class SuperSonicBridge {
   private splitter: ChannelSplitterNode | null = null
   private masterMerger: ChannelMergerNode | null = null
   private masterGainNode: GainNode | null = null
+  /** Per-loop monitor state: loopBus (internal routing) + monitorNodeId (scsynth node) */
+  private loopMonitors = new Map<string, { loopBus: number; monitorNodeId: number }>()
+  /** Whether the track-monitor SynthDef has been loaded via /d_recv */
+  private monitorSynthDefLoaded = false
   /** scsynth mixer node ID — for controlling master volume via /n_set */
   private mixerNodeId = 0
   /** Optional callback for OSC trace logging — receives formatted trace strings like desktop Sonic Pi. */
@@ -210,12 +215,22 @@ export class SuperSonicBridge {
     }
 
     // Create scsynth group structure matching Sonic Pi's studio.rb:
-    //   STUDIO-MIXER (head of root) → STUDIO-FX (before mixer) → STUDIO-SYNTHS (before FX)
-    // Execution order: synths → FX → mixer (head-to-tail, depth-first)
+    //   STUDIO-MIXER (head of root) → MONITORS → STUDIO-FX → STUDIO-SYNTHS
+    // Execution order: synths (100) → FX (101) → monitors (102) → mixer
+    //
+    // Group 102 (monitors) sits BETWEEN FX and mixer so monitors read
+    // loopBus AFTER FX has written to it. This gives post-FX per-loop
+    // audio taps — the scope shows what the user actually hears.
     const mixerGroupId = this.sonic.nextNodeId()
     this.sonic.send('/g_new', mixerGroupId, 0, 0)  // mixer group at head of root
-    this.sonic.send('/g_new', 101, 2, mixerGroupId) // FX group before mixer
+    this.sonic.send('/g_new', 102, 2, mixerGroupId) // monitors group before mixer
+    this.sonic.send('/g_new', 101, 2, 102)          // FX group before monitors
     this.sonic.send('/g_new', 100, 2, 101)          // synths group before FX
+
+    // Load the track-monitor SynthDef via /d_recv — hand-compiled binary,
+    // no CDN dependency. Must load BEFORE any /s_new for it (SP5 trap).
+    this.sonic.send('/d_recv', buildTrackMonitorSynthDef())
+    this.monitorSynthDefLoaded = true
 
     // Load and create the master mixer synth — same synthdef as desktop Sonic Pi.
     // Signal chain: in_bus+out_bus → pre_amp → HPF → LPF → Limiter.ar(0.99) → LeakDC → amp → ReplaceOut
@@ -806,6 +821,90 @@ export class SuperSonicBridge {
     return this.trackAnalysers
   }
 
+  // ── Per-loop audio isolation (monitor synths) ────────────────
+  //
+  // Each live_loop gets:
+  //   1. A loopBus (internal scsynth bus, from the 128-bus pool)
+  //   2. A monitor synth in group 102 (reads loopBus, writes to
+  //      bus 0 for the mixer AND to a trackBus output channel
+  //      for the per-track AnalyserNode)
+  //
+  // task.outBus is set to loopBus so all synths + FX in that loop
+  // write there. The monitor fans out post-FX.
+  //
+  // Bare code (no live_loop) keeps outBus = 0, no monitor.
+
+  /**
+   * Create a per-loop monitor synth. Returns the loopBus number that
+   * the loop's synths should write to (via task.outBus).
+   *
+   * If a monitor already exists for this name (hot-swap), reuses it.
+   * The monitor persists across loop iterations (SP11 pattern — same
+   * lifecycle as persistentFx).
+   */
+  createLoopMonitor(name: string): number {
+    const existing = this.loopMonitors.get(name)
+    if (existing) return existing.loopBus
+
+    if (!this.sonic || !this.monitorSynthDefLoaded) return 0 // fallback
+
+    // Allocate internal bus for this loop's audio
+    const loopBus = this.allocateBus()
+
+    // Allocate output channel for the per-track AnalyserNode tap.
+    // allocateTrackBus also creates the WebAudio AnalyserNode.
+    // Falls back to 0 (master) if out of output channels.
+    const trackBus = this.allocateTrackBus(name)
+
+    // Create monitor synth in group 102 (after FX, before mixer).
+    // addAction 1 = addToTail so it executes after any existing monitors.
+    // Param names must match the SynthDef exactly (SP9 trap).
+    const monitorNodeId = this.sonic.nextNodeId()
+    this.sonic.send('/s_new', 'sonic_pi_track_monitor', monitorNodeId, 1, 102,
+      'in_bus', loopBus,
+      'out_bus_master', 0,
+      'out_bus_track', trackBus,
+      'amp', 1,
+    )
+
+    this.loopMonitors.set(name, { loopBus, monitorNodeId })
+    return loopBus
+  }
+
+  /**
+   * Get the loopBus for a named loop (0 if no monitor exists).
+   * The engine uses this to set task.outBus.
+   */
+  getLoopBus(name: string): number {
+    return this.loopMonitors.get(name)?.loopBus ?? 0
+  }
+
+  /**
+   * Free a specific loop's monitor synth and return its bus to the pool.
+   * Called when a loop is removed during hot-swap.
+   */
+  freeLoopMonitor(name: string): void {
+    const monitor = this.loopMonitors.get(name)
+    if (!monitor) return
+    this.sonic?.send('/n_free', monitor.monitorNodeId)
+    this.freeBus(monitor.loopBus)
+    this.loopMonitors.delete(name)
+  }
+
+  /**
+   * Free all monitor synths (called on stop / re-evaluate).
+   * The loopBus numbers are returned to the pool so they can be
+   * reused on the next run. Monitor synths are also freed via
+   * /g_freeAll 102 in freeAllNodes(), but we clean the map here
+   * so createLoopMonitor() knows to recreate them.
+   */
+  private clearLoopMonitors(): void {
+    for (const [, { loopBus }] of this.loopMonitors) {
+      this.freeBus(loopBus)
+    }
+    this.loopMonitors.clear()
+  }
+
   /** Allocate a private audio bus for FX routing. */
   allocateBus(): number {
     if (this.freeBuses.length > 0) return this.freeBuses.pop()!
@@ -848,11 +947,13 @@ export class SuperSonicBridge {
     return this.sampleDurations.get(name)
   }
 
-  /** Free all synth and FX nodes (clean slate for re-evaluate). */
+  /** Free all synth, FX, and monitor nodes (clean slate for re-evaluate). */
   freeAllNodes(): void {
     if (!this.sonic) return
     this.sonic.send('/g_freeAll', 100)  // synths group
     this.sonic.send('/g_freeAll', 101)  // FX group
+    this.sonic.send('/g_freeAll', 102)  // monitors group
+    this.clearLoopMonitors()            // return loopBuses to pool + clear map
   }
 
   /** Create a new group inside the FX group (101). Returns group ID. */
@@ -875,7 +976,7 @@ export class SuperSonicBridge {
   }
 
   /** Send raw OSC message to SuperSonic (immediate, no timestamp). */
-  send(address: string, ...args: (string | number)[]): void {
+  send(address: string, ...args: (string | number | Uint8Array)[]): void {
     this.sonic?.send(address, ...args)
   }
 

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -78,10 +78,10 @@ describe('SuperSonicBridge', () => {
 
     expect(mockSonic.init).toHaveBeenCalled()
     expect(mockSonic.loadSynthDefs).toHaveBeenCalled()
-    // Mixer group at head of root, FX before mixer, synths before FX
+    // Mixer group at head of root, monitors before mixer, FX before monitors, synths before FX
     const sendCalls = mockSonic.send.mock.calls
     const gNewCalls = sendCalls.filter((c: unknown[]) => c[0] === '/g_new')
-    expect(gNewCalls.length).toBe(3) // mixer group, FX group, synths group
+    expect(gNewCalls.length).toBe(4) // mixer group, monitors group (102), FX group (101), synths group (100)
     // Mixer synthdef loaded and triggered
     expect(mockSonic.loadSynthDef).toHaveBeenCalledWith('sonic-pi-mixer')
     expect(mockSonic.sync).toHaveBeenCalled()

--- a/src/engine/buildTrackMonitorSynthDef.ts
+++ b/src/engine/buildTrackMonitorSynthDef.ts
@@ -1,0 +1,204 @@
+/**
+ * Builds the `sonic_pi_track_monitor` SynthDef binary (SCgf v1 format).
+ *
+ * This is a hand-compiled SynthDef — no sclang needed. The graph is
+ * trivial enough that building the binary in JS is straightforward:
+ *
+ *   arg in_bus=0, out_bus_master=0, out_bus_track=0, amp=1;
+ *   var sig = In.ar(in_bus, 2);
+ *   Out.ar(out_bus_master, sig * amp);
+ *   Out.ar(out_bus_track, sig * amp);
+ *
+ * The monitor reads stereo audio from an internal scsynth bus (loopBus),
+ * multiplies by amp, and writes to TWO output buses:
+ *   - out_bus_master (bus 0) → mixer chain → speakers
+ *   - out_bus_track (output channel 2+) → AudioWorklet → AnalyserNode
+ *
+ * This eliminates the need to compile the SynthDef with Desktop
+ * SuperCollider or upload it to the SuperSonic CDN. Load via /d_recv
+ * at session startup.
+ *
+ * SCgf v1 format reference:
+ *   https://doc.sccode.org/Reference/Synth-Definition-File-Format.html
+ *
+ * UGen graph (6 nodes):
+ *   0: Control (kr, 0 in, 4 out)  → in_bus, out_bus_master, out_bus_track, amp
+ *   1: In      (ar, 1 in, 2 out)  → reads stereo from in_bus
+ *   2: BinaryOpUGen (ar, *, 2 in, 1 out) → In.L * amp
+ *   3: BinaryOpUGen (ar, *, 2 in, 1 out) → In.R * amp
+ *   4: Out     (ar, 3 in, 0 out)  → out_bus_master, scaled_L, scaled_R
+ *   5: Out     (ar, 3 in, 0 out)  → out_bus_track, scaled_L, scaled_R
+ */
+
+const RATE_SCALAR = 0
+const RATE_CONTROL = 1
+const RATE_AUDIO = 2
+
+const BINOP_MULTIPLY = 2
+
+/** Write a Pascal-style string (1-byte length prefix + ASCII bytes). */
+function writePstring(view: DataView, offset: number, s: string): number {
+  view.setUint8(offset, s.length)
+  offset += 1
+  for (let i = 0; i < s.length; i++) {
+    view.setUint8(offset + i, s.charCodeAt(i))
+  }
+  return offset + s.length
+}
+
+/** Write a UGen spec and return the new offset. */
+function writeUGen(
+  view: DataView,
+  offset: number,
+  name: string,
+  rate: number,
+  inputs: Array<[number, number]>,  // [ugenIndex, outputIndex] pairs
+  numOutputs: number,
+  outputRate: number,
+  special: number = 0,
+): number {
+  offset = writePstring(view, offset, name)
+  view.setInt8(offset, rate);                    offset += 1
+  view.setInt16(offset, inputs.length, false);   offset += 2  // BE
+  view.setInt16(offset, numOutputs, false);      offset += 2
+  view.setInt16(offset, special, false);         offset += 2
+
+  for (const [ugenIdx, outIdx] of inputs) {
+    view.setInt16(offset, ugenIdx, false);       offset += 2
+    view.setInt16(offset, outIdx, false);        offset += 2
+  }
+
+  for (let i = 0; i < numOutputs; i++) {
+    view.setInt8(offset, outputRate);            offset += 1
+  }
+
+  return offset
+}
+
+/** Write a named parameter entry and return the new offset. */
+function writeParamName(
+  view: DataView,
+  offset: number,
+  name: string,
+  index: number,
+): number {
+  offset = writePstring(view, offset, name)
+  view.setInt16(offset, index, false)
+  return offset + 2
+}
+
+/**
+ * Build the complete `sonic_pi_track_monitor` SynthDef as a Uint8Array.
+ *
+ * Returns bytes suitable for `/d_recv`:
+ *   bridge.send('/d_recv', buildTrackMonitorSynthDef())
+ */
+export function buildTrackMonitorSynthDef(): Uint8Array {
+  // Pre-calculate exact size to avoid over-allocation.
+  //
+  // Header:       4 (magic) + 4 (version) + 2 (count) = 10
+  // Name:         1 + 22 = 23  ("sonic_pi_track_monitor")
+  // Constants:    2 (count=0)
+  // Params:       2 (count=4) + 4*4 (defaults) = 18
+  // Param names:  2 (count=4) + (1+6+2) + (1+14+2) + (1+13+2) + (1+3+2) = 2 + 9+17+16+6 = 50
+  // UGens header: 2 (count=6)
+  //   UGen 0 (Control):      1+7 + 1 + 2+2+2 + 0 + 4 = 19
+  //   UGen 1 (In):           1+2 + 1 + 2+2+2 + 1*4 + 2 = 16
+  //   UGen 2 (BinaryOpUGen): 1+12 + 1 + 2+2+2 + 2*4 + 1 = 29
+  //   UGen 3 (BinaryOpUGen): 1+12 + 1 + 2+2+2 + 2*4 + 1 = 29
+  //   UGen 4 (Out):          1+3 + 1 + 2+2+2 + 3*4 + 0 = 23
+  //   UGen 5 (Out):          1+3 + 1 + 2+2+2 + 3*4 + 0 = 23
+  // Variants:     2 (count=0)
+  //
+  // Total: 10 + 23 + 2 + 18 + 50 + 2 + 19+16+29+29+23+23 + 2 = 246
+
+  const buf = new ArrayBuffer(246)
+  const view = new DataView(buf)
+  let o = 0
+
+  // ── File header ──────────────────────────────────────────────
+  // Magic: "SCgf"
+  view.setUint8(o, 0x53); o += 1  // S
+  view.setUint8(o, 0x43); o += 1  // C
+  view.setUint8(o, 0x67); o += 1  // g
+  view.setUint8(o, 0x66); o += 1  // f
+  // Version: 1
+  view.setInt32(o, 1, false); o += 4
+  // Number of SynthDefs: 1
+  view.setInt16(o, 1, false); o += 2
+
+  // ── SynthDef name ────────────────────────────────────────────
+  o = writePstring(view, o, 'sonic_pi_track_monitor')
+
+  // ── Constants ────────────────────────────────────────────────
+  view.setInt16(o, 0, false); o += 2  // 0 constants
+
+  // ── Parameters ───────────────────────────────────────────────
+  view.setInt16(o, 4, false); o += 2  // 4 params
+  // Initial values (float32 BE)
+  view.setFloat32(o, 0.0, false); o += 4  // in_bus = 0
+  view.setFloat32(o, 0.0, false); o += 4  // out_bus_master = 0
+  view.setFloat32(o, 0.0, false); o += 4  // out_bus_track = 0
+  view.setFloat32(o, 1.0, false); o += 4  // amp = 1
+
+  // ── Parameter names ──────────────────────────────────────────
+  view.setInt16(o, 4, false); o += 2  // 4 param names
+  o = writeParamName(view, o, 'in_bus', 0)
+  o = writeParamName(view, o, 'out_bus_master', 1)
+  o = writeParamName(view, o, 'out_bus_track', 2)
+  o = writeParamName(view, o, 'amp', 3)
+
+  // ── UGens ────────────────────────────────────────────────────
+  view.setInt16(o, 6, false); o += 2  // 6 UGens
+
+  // UGen 0: Control (kr, 0 inputs, 4 outputs)
+  // Outputs the 4 named parameters at control rate.
+  o = writeUGen(view, o, 'Control', RATE_CONTROL,
+    [],                // no inputs
+    4, RATE_CONTROL)   // 4 outputs, all kr
+
+  // UGen 1: In (ar, 1 input, 2 outputs)
+  // Reads stereo audio from in_bus.
+  o = writeUGen(view, o, 'In', RATE_AUDIO,
+    [[0, 0]],          // input: Control.in_bus
+    2, RATE_AUDIO)     // 2 outputs (stereo), ar
+
+  // UGen 2: BinaryOpUGen * (ar, 2 inputs, 1 output)
+  // Left channel × amp
+  o = writeUGen(view, o, 'BinaryOpUGen', RATE_AUDIO,
+    [[1, 0], [0, 3]],  // In.L, Control.amp
+    1, RATE_AUDIO,
+    BINOP_MULTIPLY)
+
+  // UGen 3: BinaryOpUGen * (ar, 2 inputs, 1 output)
+  // Right channel × amp
+  o = writeUGen(view, o, 'BinaryOpUGen', RATE_AUDIO,
+    [[1, 1], [0, 3]],  // In.R, Control.amp
+    1, RATE_AUDIO,
+    BINOP_MULTIPLY)
+
+  // UGen 4: Out (ar, 3 inputs, 0 outputs)
+  // Write scaled stereo to master bus.
+  o = writeUGen(view, o, 'Out', RATE_AUDIO,
+    [[0, 1], [2, 0], [3, 0]],  // Control.out_bus_master, scaled_L, scaled_R
+    0, RATE_AUDIO)
+
+  // UGen 5: Out (ar, 3 inputs, 0 outputs)
+  // Write scaled stereo to track bus (per-loop AnalyserNode tap).
+  o = writeUGen(view, o, 'Out', RATE_AUDIO,
+    [[0, 2], [2, 0], [3, 0]],  // Control.out_bus_track, scaled_L, scaled_R
+    0, RATE_AUDIO)
+
+  // ── Variants ─────────────────────────────────────────────────
+  view.setInt16(o, 0, false); o += 2  // 0 variants
+
+  // Sanity check — we should have used exactly 250 bytes.
+  if (o !== 246) {
+    throw new Error(
+      `SynthDef binary size mismatch: wrote ${o} bytes, expected 246. ` +
+      `This is a bug in buildTrackMonitorSynthDef().`
+    )
+  }
+
+  return new Uint8Array(buf)
+}


### PR DESCRIPTION
## Summary

Each `live_loop` now gets its own isolated audio bus and a dedicated `AnalyserNode` for per-loop scope visualization. Previously all synths wrote to bus 0 — the per-track AnalyserNodes existed on the WebAudio side but read silence because nothing in scsynth routed audio to them.

**This makes SonicPi.js the first Sonic Pi implementation with per-loop audio isolation.** Neither Desktop Sonic Pi nor Sonic Tau has it.

## How it works

```
Group 100 (synths):   all synths write to their loop's private loopBus
Group 101 (FX):       FX chains terminate at loopBus (via task.outBus)
Group 102 (monitors): reads loopBus → fans out to bus 0 + trackBus
Mixer group:          reads bus 0 (sum of all monitors), unchanged
```

The monitor SynthDef (`sonic_pi_track_monitor`) is **hand-compiled in JavaScript** as a 246-byte SCgf v1 binary — no sclang dependency, no CDN upload. Loaded via `/d_recv` at session startup.

```
UGen graph (6 nodes):
  Control(4 params) → In.ar(loopBus, stereo) → ×amp → Out.ar(master) + Out.ar(trackBus)
```

## What was already built (WebAudio side — unchanged)

- SuperSonic boots with `numOutputBusChannels: 14` (6 stereo track pairs + master)
- `ChannelSplitter` → per-track `AnalyserNode` per loop
- `allocateTrackBus()` / `getTrackAnalyser()` / `getAllTrackAnalysers()` API

## What's new (scsynth side)

- `buildTrackMonitorSynthDef.ts` — 246-byte binary builder with size assertion
- Group 102 (monitors) created at init between FX and mixer
- `/d_recv` loads the monitor SynthDef at boot (before any `/s_new` — SP5 trap)
- `createLoopMonitor(name)` — allocates loopBus + creates monitor in group 102
- `getLoopBus(name)` — returns the loopBus for `task.outBus`
- `freeLoopMonitor(name)` / `clearLoopMonitors()` — cleanup on stop/re-evaluate
- `task.outBus = loopBus` (was `0`) in both initial and re-evaluate paths

## Verification

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 717/717 pass (SuperSonicBridge test updated: 3→4 groups)
- [x] SynthDef binary: hexdump + UGen graph decode — byte-verified
- [x] Level 3 WAV capture: Peak 0.9778, RMS 0.2009, 0% clipping (audio reaches speakers through monitors)
- [x] Per-track AnalyserNode diagnostic: drums RMS 0.21-0.44, melody RMS 0.42-0.75 — **different isolated signals per loop**
- [x] `with_fx` nested routing: reverb `out_bus=15` (loopBus, not 0) — FX chain terminates at loopBus automatically via `task.outBus` propagation
- [x] **49-composition regression suite: 49/49 pass, 0 silent, 0 errors** — zero regressions from bus rerouting

## Test plan

- [x] All existing tests pass (717/717)
- [x] Two-loop smoke test (drums + melody) produces audio
- [x] Per-track AnalyserNodes receive non-zero, loop-specific signal
- [x] Nested `with_fx` inside a loop routes correctly
- [x] Full 49-composition regression suite passes
- [ ] Hot-swap (re-Run) preserves monitors — manual test needed
- [ ] Scope UI draws per-loop waveforms — separate phase (plumbing done, drawing not)

Closes #177