### PR TITLE
fix(#208): note_info() + uppercase-symbol NaN

### DIFF
--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -25,7 +25,7 @@ export const DSL_NAMES = [
   'rrand', 'rrand_i', 'rand', 'rand_i', 'choose', 'dice', 'one_in', 'rdist',
   'chord', 'scale', 'chord_invert', 'note', 'note_range',
   'chord_degree', 'degree', 'chord_names', 'scale_names',
-  'noteToMidi', 'midiToFreq', 'noteToFreq',
+  'noteToMidi', 'midiToFreq', 'noteToFreq', 'note_info',
   'hz_to_midi', 'midi_to_hz',
   'quantise', 'quantize', 'octs',
   'current_bpm',

--- a/src/engine/NoteToFreq.ts
+++ b/src/engine/NoteToFreq.ts
@@ -62,3 +62,37 @@ export function hzToMidi(freq: number): number {
 export function noteToFreq(note: string | number): number {
   return midiToFreq(noteToMidi(note))
 }
+
+const PITCH_CLASS_NAMES = ['C', 'Cs', 'D', 'Ds', 'E', 'F', 'Fs', 'G', 'Gs', 'A', 'As', 'B']
+
+/**
+ * SonicPi::Note-like object returned by `note_info`. Mirrors Ruby's
+ * method-call semantics — Sonic Pi user code writes `.midi_note` (a method
+ * call without parens), and our TreeSitter transpiler emits `.midi_note()`.
+ */
+export class NoteInfo {
+  private _midi: number
+  constructor(midi: number) {
+    this._midi = midi
+  }
+  midi_note(): number {
+    return this._midi
+  }
+  octave(): number {
+    return Math.floor(Math.round(this._midi) / 12) - 1
+  }
+  pitch_class(): string {
+    return PITCH_CLASS_NAMES[((Math.round(this._midi) % 12) + 12) % 12]
+  }
+  to_s(): string {
+    return `${this.pitch_class()}${this.octave()}`
+  }
+}
+
+/**
+ * Sonic Pi's `note_info(name_or_midi)` — returns a NoteInfo with method
+ * accessors `.midi_note()`, `.octave()`, `.pitch_class()`, `.to_s()`.
+ */
+export function noteInfo(n: string | number): NoteInfo {
+  return new NoteInfo(noteToMidi(n))
+}

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -10,7 +10,7 @@
 
 import type { Step, Program } from './Program'
 import { SeededRandom } from './SeededRandom'
-import { noteToMidi, midiToFreq, hzToMidi } from './NoteToFreq'
+import { noteToMidi, midiToFreq, hzToMidi, noteInfo } from './NoteToFreq'
 import { ring, knit, range, line, Ring } from './Ring'
 import { spread } from './EuclideanRhythm'
 import { chord, scale, chord_invert, note, note_range, chord_degree, degree, chord_names, scale_names } from './ChordScale'
@@ -693,6 +693,7 @@ export class ProgramBuilder {
   note_range = note_range
   noteToMidi = noteToMidi
   midiToFreq = midiToFreq
+  note_info = noteInfo
 
   noteToFreq(n: string | number): number {
     return midiToFreq(noteToMidi(n))

--- a/src/engine/Sandbox.ts
+++ b/src/engine/Sandbox.ts
@@ -149,7 +149,7 @@ export function createIsolatedExecutor(
   // JS can't do operator overloading, so the transpiler emits __spAdd/__spSub/__spMul
   // instead of raw +/-/* operators. These helpers detect types at runtime and dispatch.
   const spOperatorPolyfill = [
-    'var __spNoteRe = /^[a-g][sb#]?\\d*$/;',
+    'var __spNoteRe = /^[a-g][sb#]?\\d*$/i;',
     'function __spIsNote(v) { return typeof v === "string" && __spNoteRe.test(v); }',
     'function __spToNum(v) { return __spIsNote(v) && typeof note === "function" ? note(v) : v; }',
     'function __spIsRing(v) { return v != null && typeof v === "object" && typeof v.toArray === "function" && typeof v.tick === "function"; }',

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -25,7 +25,7 @@ import { SoundEventStream } from './SoundEventStream'
 import { ring, knit, range, line } from './Ring'
 import { MidiBridge } from './MidiBridge'
 import { spread } from './EuclideanRhythm'
-import { noteToMidi, midiToFreq, noteToFreq, hzToMidi } from './NoteToFreq'
+import { noteToMidi, midiToFreq, noteToFreq, hzToMidi, noteInfo } from './NoteToFreq'
 import { chord, scale, chord_invert, note, note_range, chord_degree, degree, chord_names, scale_names } from './ChordScale'
 import { getSampleNames, getCategories } from './SampleCatalog'
 import { loadAllCustomSamples, type CustomSampleRecord } from './CustomSampleStore'
@@ -822,7 +822,7 @@ export class SonicPiEngine {
         tlRrand, tlRrandI, tlRand, tlRandI, tlChoose, tlDice, tlOneIn, tlRdist,
         chord, scale, chord_invert, note, note_range,
         chord_degree, degree, chord_names, scale_names,
-        noteToMidi, midiToFreq, noteToFreq,
+        noteToMidi, midiToFreq, noteToFreq, noteInfo,
         hzToMidi, midiToFreq,
         quantise, quantize, octs,
         current_bpm,

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -236,7 +236,7 @@ const BUILDER_METHODS = new Set([
   'hz_to_midi', 'midi_to_hz', 'quantise', 'quantize', 'octs',
   'kill', 'play_chord', 'play_pattern',
   'with_octave', 'with_random_seed', 'with_density',
-  'noteToMidi', 'midiToFreq', 'noteToFreq',
+  'noteToMidi', 'midiToFreq', 'noteToFreq', 'note_info',
   // Data constructors
   'ring', 'knit', 'range', 'line', 'spread',
   'chord', 'scale', 'chord_invert', 'note', 'note_range',

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { SeededRandom } from '../SeededRandom'
 import { Ring, ring } from '../Ring'
 import { spread } from '../EuclideanRhythm'
-import { noteToMidi, midiToFreq, noteToFreq } from '../NoteToFreq'
+import { noteToMidi, midiToFreq, noteToFreq, noteInfo } from '../NoteToFreq'
 import { MidiBridge } from '../MidiBridge'
 
 describe('SeededRandom', () => {
@@ -178,6 +178,47 @@ describe('NoteToFreq', () => {
 
   it('noteToFreq combines both', () => {
     expect(noteToFreq('a4')).toBeCloseTo(440, 1)
+  })
+
+  it('noteToMidi accepts uppercase note names (issue #208)', () => {
+    expect(noteToMidi('C3')).toBe(48)
+    expect(noteToMidi('Fs5')).toBe(78)
+    expect(noteToMidi('Eb4')).toBe(63)
+  })
+})
+
+describe('noteInfo (issue #208 — Sonic Pi note_info parity)', () => {
+  // Methods (not properties) because the TreeSitter transpiler emits
+  // Ruby's `.foo` as JS method call `.foo()`.
+  it(':c4 → midi 60, octave 4, pitch_class C', () => {
+    const info = noteInfo('c4')
+    expect(info.midi_note()).toBe(60)
+    expect(info.octave()).toBe(4)
+    expect(info.pitch_class()).toBe('C')
+    expect(info.to_s()).toBe('C4')
+  })
+
+  it('uppercase :C3 also resolves', () => {
+    expect(noteInfo('C3').midi_note()).toBe(48)
+  })
+
+  it('accepts a MIDI integer', () => {
+    const info = noteInfo(72)
+    expect(info.midi_note()).toBe(72)
+    expect(info.octave()).toBe(5)
+    expect(info.pitch_class()).toBe('C')
+  })
+
+  it('handles sharps', () => {
+    expect(noteInfo('fs5').pitch_class()).toBe('Fs')
+    expect(noteInfo('fs5').octave()).toBe(5)
+  })
+
+  it('handles low octaves (b3 below c4 boundary)', () => {
+    const info = noteInfo('b3')
+    expect(info.midi_note()).toBe(59)
+    expect(info.octave()).toBe(3)
+    expect(info.pitch_class()).toBe('B')
   })
 })
 

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -70,6 +70,7 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['noteToMidi',       'Pure.'],
   ['midiToFreq',       'Pure.'],
   ['noteToFreq',       'Pure.'],
+  ['note_info',        'Pure: name/midi → SonicPi::Note-like {midi_note, octave, pitch_class}.'],
   ['hz_to_midi',       'Pure.'],
   ['midi_to_hz',       'Pure.'],
   ['quantise',         'Pure.'],

--- a/src/engine/__tests__/Sandbox.test.ts
+++ b/src/engine/__tests__/Sandbox.test.ts
@@ -226,4 +226,32 @@ describe('Sandbox', () => {
     await execute((v: unknown) => { result = v })
     expect(result).toBe(42)
   })
+
+  // --- Issue #208: __spIsNote regex must be case-insensitive ---
+  // Symptom: `:C3 + 0` produced string "C30" instead of MIDI 48,
+  // poisoning downstream subtraction with NaN (bass_foundation note: NaN).
+  it('uppercase symbols (e.g. :C3) flow through __spAdd as numeric MIDI', async () => {
+    let result: unknown = null
+    // Mimics the transpiled form of: g_grundton = :C3; g_note = g_grundton + 0; out(g_note - 24)
+    const execute = createSandboxedExecutor(
+      'var g = "C3"; var n = __spAdd(g, 0); var out = __spSub(n, 24); storeResult(out)',
+      ['storeResult', 'note']
+    )
+    await execute(
+      (v: unknown) => { result = v },
+      (s: string) => { // note() implementation
+        const str = s.toLowerCase()
+        const map: Record<string, number> = { c: 0, d: 2, e: 4, f: 5, g: 7, a: 9, b: 11 }
+        const m = str.match(/^([a-g])(s|b|#)?(\d+)?$/)
+        if (!m) return 60
+        const base = map[m[1]]
+        const oct = m[3] ? parseInt(m[3]) : 4
+        let midi = (oct + 1) * 12 + base
+        if (m[2] === 's' || m[2] === '#') midi += 1
+        if (m[2] === 'b') midi -= 1
+        return midi
+      }
+    )
+    expect(result).toBe(24) // 48 - 24, NOT NaN
+  })
 })

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -7,7 +7,7 @@ export type { EngineComponents } from './SonicPiEngine'
 // Music theory helpers — available inside live_loop via the DSL and externally
 export { ring, knit, range, line } from './Ring'
 export { spread } from './EuclideanRhythm'
-export { noteToMidi, midiToFreq, noteToFreq, hzToMidi } from './NoteToFreq'
+export { noteToMidi, midiToFreq, noteToFreq, hzToMidi, noteInfo, NoteInfo } from './NoteToFreq'
 export { chord, scale, chord_invert, note, note_range, chord_degree, degree, chord_names, scale_names } from './ChordScale'
 
 // Event types


### PR DESCRIPTION
## Summary

Closes #208 — two independent gaps that surfaced in `39_blues_machine.rb` after PR #187 fixed `Hash#values`:

1. **Gap 2 — `bass_foundation note: NaN`.** Root cause: the Sandbox runtime's `__spIsNote` regex was case-sensitive. `:C3` (Ruby preserves case) became string `"C3"`, fell through gatekeeper, hit `"C3" + 0 → "C30"`, then `- 24 → NaN`. **Fix:** add `i` flag to `__spNoteRe` so the gatekeeper accepts the same case range its receiver (`noteToMidi`, already lowercases) handles. Aligns boundary-pair vocabulary (SV14).

2. **Gap 1 — `note_info is not a function`.** Root cause: missing DSL function. **Fix:** new `NoteInfo` class + `noteInfo()` factory in `NoteToFreq.ts` with method-style accessors (`.midi_note()`, `.octave()`, `.pitch_class()`, `.to_s()`) — methods because TreeSitter emits Ruby's `.foo` as JS `.foo()`. Wired through the standard 5-layer DSL exposure (`DslNames` whitelist → `ProgramBuilder` binding → `SonicPiEngine` globals → `TreeSitterTranspiler` whitelist).

## Verification

| Layer | Result |
|---|---|
| Level 1 — `npx tsc --noEmit` | clean |
| Level 1 — `npx vitest run` | 763 passed (756 baseline + 7 new) |
| Level 2 — event log | `bass_foundation` events show valid MIDI (24/31/36) instead of NaN; no `note_info is not a function` console errors |
| Level 3 — WAV capture | `39_blues_machine.rb` for 12s: Peak 1.0, RMS 0.1478, clipping 0.38%, 11.04s playback, **No errors detected** |

Two atomic commits:
- `c570779` 🩹 fix: __spIsNote regex case-insensitive (#208 G2)
- `c5211f8` ✨ feat: note_info() — SonicPi::Note-like accessor (closes #208)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 763/763 pass
- [x] Level 3 WAV capture of `tests/book-examples/in-thread-forum/39_blues_machine.rb` shows no errors and audible blues progression with bass at proper pitch
- [ ] Reviewer can re-run: `BASE_URL=http://localhost:4000 npx tsx tools/capture.ts --file tests/book-examples/in-thread-forum/39_blues_machine.rb --duration 12000`