### PR TITLE
fix(capture): hook engine for puts/cues instead of DOM slicing

### DIFF
--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -43,6 +43,12 @@ interface CaptureResult {
   appConsoleText: string
   appFullText: string
 
+  // Engine-level captures (issue #221) — hooked via __spw_engine setter
+  // BEFORE Run click, so we capture every puts/cue from app start without
+  // depending on Console ring-buffer scrollback or DOM textContent slicing.
+  puts: { t: number; msg: string }[]
+  cues: { t: number; name: string; audioTime: number }[]
+
   // Screenshots
   screenshotBefore: string  // path
   screenshotAfter: string   // path
@@ -135,6 +141,36 @@ async function captureRun(
   await editor.fill(code)
   await page.waitForTimeout(200)
 
+  // Engine-level hook (issue #221) — install BEFORE Run click. The App
+  // exposes `__spw_engine` after init; intercept the assignment so we can
+  // chain into the App's already-installed printHandler/cueHandler.
+  // Captures every puts/cue regardless of Console ring-buffer pruning.
+  // Passed as a string to side-step tsx's __name closure rewriting that
+  // otherwise breaks page.evaluate of arrow-function source.
+  await page.evaluate(`(function() {
+    var _engine = null;
+    window.__capturedPuts = [];
+    window.__capturedCues = [];
+    window.__capturedStartedAt = Date.now();
+    Object.defineProperty(window, '__spw_engine', {
+      configurable: true,
+      get: function() { return _engine; },
+      set: function(e) {
+        _engine = e;
+        var origPrint = e.printHandler;
+        e.printHandler = function(msg) {
+          window.__capturedPuts.push({ t: Date.now() - window.__capturedStartedAt, msg: msg });
+          if (origPrint) origPrint(msg);
+        };
+        var origCue = e.cueHandler;
+        e.cueHandler = function(name, audioTime) {
+          window.__capturedCues.push({ t: Date.now() - window.__capturedStartedAt, name: name, audioTime: audioTime });
+          if (origCue) origCue(name, audioTime);
+        };
+      }
+    });
+  })()`)
+
   // Click Run and wait for audio engine to be ready
   const runBtn = page.locator('.spw-btn-label:has-text("Run")')
   await runBtn.click()
@@ -209,6 +245,13 @@ async function captureRun(
 
   // Capture app state
   const appFullText = await page.locator('#app').textContent() ?? ''
+
+  // Read engine-level captures (issue #221). String-form to side-step tsx's
+  // __name rewriting of arrow-function closures.
+  const engineHooks = await page.evaluate(`({
+    puts: window.__capturedPuts || [],
+    cues: window.__capturedCues || []
+  })`) as { puts: { t: number; msg: string }[]; cues: { t: number; name: string; sourceLoop: string }[] }
 
   // Try to isolate the console pane text (everything after "Audio engine ready" or "Happy live coding")
   let appConsoleText = ''
@@ -307,6 +350,8 @@ async function captureRun(
     audioStats,
     errorSummary,
     warningsSummary,
+    puts: engineHooks.puts,
+    cues: engineHooks.cues,
   }
 }
 
@@ -371,10 +416,32 @@ function writeCaptureReport(result: CaptureResult, outputPath: string): void {
     lines.push('')
   }
 
-  // App console (the real diagnostic gold)
+  // App console (engine-level puts hook — issue #221).
+  // The previous DOM-textContent slice was unreliable: Console ring buffer
+  // pruned old entries, and the slice contained UI chrome. The engine hook
+  // captures every puts call without depending on DOM rendering.
   lines.push('## App Console Output')
   lines.push('```')
-  lines.push(result.appConsoleText || '(empty)')
+  if (result.puts.length === 0) {
+    lines.push('(empty)')
+  } else {
+    for (const p of result.puts) {
+      lines.push(`[${p.t}ms] ${p.msg}`)
+    }
+  }
+  lines.push('```')
+  lines.push('')
+
+  // Cue log (engine-level cue hook — issue #221).
+  lines.push('## Cue Log')
+  lines.push('```')
+  if (result.cues.length === 0) {
+    lines.push('(empty)')
+  } else {
+    for (const c of result.cues) {
+      lines.push(`[${c.t}ms] cue :${c.name}  (audioTime ${c.audioTime.toFixed(3)}s)`)
+    }
+  }
   lines.push('```')
   lines.push('')
 


### PR DESCRIPTION
## Summary
- Replaces the unreliable DOM-textContent slice (which always returned \`(empty)\` for long runs because the Console ring buffer prunes the anchor strings) with a direct hook on the engine's \`printHandler\` and \`cueHandler\`.
- Adds a clean \`## Cue Log\` section to the capture report with audioTime per cue.
- Surfaces every \`puts\` from user code with wall-clock timing, regardless of how long the run is.

## How it works

\`Object.defineProperty\` on \`globalThis.__spw_engine\` is installed BEFORE the Run click. When the App later assigns \`window.__spw_engine = this.engine\`, our setter fires and wraps the App's already-installed handlers, chaining captures into \`window.__capturedPuts\` / \`__capturedCues\` while still calling the App's original handlers (so the in-app Console keeps rendering normally). String-form \`page.evaluate\` is used to side-step tsx's \`__name\` rewriting of arrow-function closures.

## Evidence

Probe fixture:
\`\`\`ruby
puts "[boot] hello from top-level"

live_loop :ticker do
  puts "[ticker] beat"
  sleep 0.5
end

live_loop :other, sync: :ticker do
  puts "[other] saw cue"
  sleep 1
end
\`\`\`

Report (was \`(empty)\` before):
\`\`\`
## App Console Output
[1670ms] [boot] hello from top-level
[1670ms] [ticker] beat
[1845ms] [other] saw cue
[1845ms] [ticker] beat
[2346ms] [ticker] beat
[2845ms] [other] saw cue
...

## Cue Log
[1670ms] cue :ticker  (audioTime 1.323s)
[1670ms] cue :other  (audioTime 1.323s)
[1845ms] cue :ticker  (audioTime 1.499s)
...
\`\`\`

## Why this matters

This is the gap that cost ~30 min of detour during PR #220's verification — the report kept saying \`(empty)\` even though debug puts were clearly firing in the in-app console panel. Forced fallback to screenshot scraping for diagnosis. Future captures (especially Tier B verification work) will have a clean, programmatic observation channel.

## Test plan

- [x] \`npx tsc --noEmit\` — 0 errors
- [x] Probe capture against \`/tmp/probe.rb\` — both sections render correctly with timing
- [x] Existing capture invocations (e.g. PR #220's welcome-buffer 180s run) still work — backwards compatible since legacy \`appConsoleText\` is retained for runtime-error grep

Closes #221