### PR TITLE
feat(capture): add --batch <dir> mode for fixture-folder runs

### DIFF
--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -12,12 +12,13 @@
  *   npx tsx tools/capture.ts --file path/to/code.rb   # run from file
  *   npx tsx tools/capture.ts --example "Minimal Techno"  # run built-in example
  *   npx tsx tools/capture.ts --all-examples            # run all built-in examples
+ *   npx tsx tools/capture.ts --batch tests/book-examples/community  # batch a fixture dir
  *   npx tsx tools/capture.ts --duration 15000          # run for 15 seconds
  */
 
 import { chromium, firefox, type Browser } from '@playwright/test'
-import { writeFileSync, readFileSync, mkdirSync, statSync } from 'fs'
-import { resolve, dirname } from 'path'
+import { writeFileSync, readFileSync, mkdirSync, statSync, readdirSync } from 'fs'
+import { resolve, dirname, basename, extname, relative } from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -480,6 +481,36 @@ function writeCaptureReport(result: CaptureResult, outputPath: string): void {
 // CLI
 // ---------------------------------------------------------------------------
 
+/**
+ * Discover Ruby fixtures at a path. Path may be:
+ *  - A directory → recursively collects all `*.rb` files
+ *  - A single .rb file → returns just that one
+ * Returns sorted by relative path so output ordering is stable.
+ */
+function discoverFixtures(path: string): { name: string; code: string; relPath: string }[] {
+  const stat = statSync(path)
+  const baseDir = stat.isDirectory() ? path : dirname(path)
+  const files: string[] = []
+  if (stat.isFile()) {
+    files.push(path)
+  } else {
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = resolve(dir, entry.name)
+        if (entry.isDirectory()) walk(full)
+        else if (entry.isFile() && extname(entry.name) === '.rb') files.push(full)
+      }
+    }
+    walk(path)
+  }
+  files.sort()
+  return files.map((f) => ({
+    name: basename(f, '.rb'),
+    code: readFileSync(f, 'utf-8'),
+    relPath: relative(baseDir, f) || basename(f),
+  }))
+}
+
 async function main() {
   const args = process.argv.slice(2)
   mkdirSync(CAPTURES_DIR, { recursive: true })
@@ -488,6 +519,7 @@ async function main() {
   let name = 'default'
   let duration = DEFAULT_DURATION
   let runAllExamples = false
+  let batchPath: string | null = null
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--file') {
@@ -498,6 +530,8 @@ async function main() {
       duration = parseInt(args[++i])
     } else if (args[i] === '--all-examples') {
       runAllExamples = true
+    } else if (args[i] === '--batch') {
+      batchPath = args[++i]
     } else if (args[i] === '--example') {
       name = args[++i]
       // Will be loaded from the app's example selector
@@ -508,7 +542,7 @@ async function main() {
   }
 
   // Default code if nothing specified
-  if (!code && !runAllExamples) {
+  if (!code && !runAllExamples && !batchPath) {
     code = `live_loop :test do
   play [:c4, :e4, :g4].choose
   sleep 0.5
@@ -532,7 +566,68 @@ end`
         args: ['--autoplay-policy=no-user-gesture-required'],
       })
 
-  if (runAllExamples) {
+  if (batchPath) {
+    // --batch <dir-or-file> — fan out across .rb fixtures, share one browser
+    const fixtures = discoverFixtures(batchPath)
+    if (fixtures.length === 0) {
+      console.log(`No .rb fixtures found at ${batchPath}`)
+      await browser.close()
+      return
+    }
+    console.log(`Found ${fixtures.length} fixtures at ${batchPath}`)
+
+    const summaryLines: string[] = [
+      `# Batch Capture Summary`,
+      ``,
+      `- Source: \`${batchPath}\``,
+      `- Fixtures: ${fixtures.length}`,
+      `- Duration per fixture: ${duration}ms`,
+      `- Started: ${new Date().toISOString()}`,
+      ``,
+      `| # | Fixture | Status | Errors | Report |`,
+      `|---|---------|--------|--------|--------|`,
+    ]
+
+    let okCount = 0
+    let errorCount = 0
+    const t0 = Date.now()
+    for (let i = 0; i < fixtures.length; i++) {
+      const fx = fixtures[i]
+      const tag = `[${i + 1}/${fixtures.length}]`
+      process.stdout.write(`  ${tag} ${fx.relPath}... `)
+      try {
+        const result = await captureRun(browser, fx.code, { duration, name: fx.name })
+        const reportPath = resolve(CAPTURES_DIR, `batch_${fx.name}.md`)
+        writeCaptureReport(result, reportPath)
+        const errs = result.errorSummary.length
+        const status = errs === 0 ? 'OK' : 'FAIL'
+        if (errs === 0) okCount++; else errorCount++
+        console.log(`${status}${errs ? ` (${errs} errors)` : ''}`)
+        summaryLines.push(`| ${i + 1} | \`${fx.relPath}\` | ${status} | ${errs} | [report](batch_${fx.name}.md) |`)
+        if (errs > 0) {
+          for (const e of result.errorSummary) {
+            summaryLines.push(`|   |   |   |   | ${e.replace(/\|/g, '\\|')} |`)
+          }
+        }
+      } catch (err) {
+        errorCount++
+        console.log(`CRASH (${(err as Error).message})`)
+        summaryLines.push(`| ${i + 1} | \`${fx.relPath}\` | CRASH | — | ${(err as Error).message.replace(/\|/g, '\\|')} |`)
+      }
+    }
+    const elapsed = Math.round((Date.now() - t0) / 1000)
+    summaryLines.push(``)
+    summaryLines.push(`## Results`)
+    summaryLines.push(``)
+    summaryLines.push(`- OK: ${okCount}/${fixtures.length}`)
+    summaryLines.push(`- Failures: ${errorCount}/${fixtures.length}`)
+    summaryLines.push(`- Elapsed: ${elapsed}s`)
+
+    const summaryPath = resolve(CAPTURES_DIR, 'BATCH_SUMMARY.md')
+    writeFileSync(summaryPath, summaryLines.join('\n'))
+    console.log(`\nBatch complete: ${okCount}/${fixtures.length} OK, ${errorCount} failures in ${elapsed}s`)
+    console.log(`Summary: ${summaryPath}`)
+  } else if (runAllExamples) {
     // Run each built-in example
     const examples = [
       { name: 'Hello Beep', code: 'play 60\nsleep 1\nplay 64\nsleep 1\nplay 67' },


### PR DESCRIPTION
## Summary
- Adds \`--batch <path>\` flag to \`tools/capture.ts\`. Path may be a directory (recursive \`*.rb\` discovery) or a single \`.rb\` file.
- Shares one browser instance across fixtures (each gets its own context for state isolation).
- Writes per-fixture reports with \`batch_\` filename prefix and a \`BATCH_SUMMARY.md\` table with status / errors / quick links.
- Crash-safe: per-fixture try/catch so one bad fixture doesn't abort the run.

## Why

Today's regression-check workflow against the 49 forum fixtures (\`tests/book-examples/community/\`) needed either 49 separate \`--file\` invocations (each launching a new Chromium, ~25 min total) or an ad-hoc shell wrapper. \`captureRun(browser, code, opts)\` already accepted a shared browser parameter — the fan-out was never wired.

## Speedup

Forecast for the 49-fixture set at 8s duration: **~10 min** (was ~25 min). About 2.5× faster from browser-launch sharing alone. Further speedup possible by sharing the page/context too, but that risks state leaking between fixtures and is out of scope here.

## Verification

3-fixture probe (\`/tmp/batch-test\`):

\`\`\`
$ npx tsx tools/capture.ts --batch /tmp/batch-test --duration 5000
Launching Chromium (headed, audio capture)...
Found 3 fixtures at /tmp/batch-test
  [1/3] 01_tilburg_2.rb... OK
  [2/3] 02_shufflit.rb... OK
  [3/3] 03_blimp_zones.rb... OK

Batch complete: 3/3 OK, 0 failures in 38s
\`\`\`

\`BATCH_SUMMARY.md\` excerpt:

\`\`\`
| # | Fixture | Status | Errors | Report |
|---|---------|--------|--------|--------|
| 1 | \`01_tilburg_2.rb\` | OK | 0 | [report](batch_01_tilburg_2.md) |
| 2 | \`02_shufflit.rb\` | OK | 0 | [report](batch_02_shufflit.md) |
| 3 | \`03_blimp_zones.rb\` | OK | 0 | [report](batch_03_blimp_zones.md) |

## Results
- OK: 3/3
- Failures: 0/3
- Elapsed: 38s
\`\`\`

Single-file mode (\`--batch <file.rb>\`) also verified — discoverFixtures handles both shapes.

## Test plan

- [x] \`npx tsc --noEmit\` — 0 errors
- [x] Directory batch (3 fixtures) — all pass, summary written
- [x] Single-file batch — works
- [x] Existing flows (\`--file\`, \`--all-examples\`, inline) unchanged
- [x] Per-fixture failures don't abort the run (try/catch around captureRun)

Closes #223