### PR TITLE
DSL Tier B PR #2 — ring + introspection + tuplets + defonce (8 fns)

### DIFF
--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -90,6 +90,12 @@ export const DSL_NAMES = [
   // Tier B PR #2 — pure ring constructors (#233). Both delegate to each
   // other for negative counts (matches upstream `core.rb:1919-1970`).
   'doubles', 'halves',
+  // Tier B PR #2 — defaults / setting introspection (#233). Inside live_loops
+  // these route via __b for per-task reads; at top level they read the
+  // topLevelBuilder's state. current_arg_checks returns constant true (we
+  // don't validate arg names yet — see ProgramBuilder).
+  'current_synth_defaults', 'current_sample_defaults',
+  'current_arg_checks', 'current_debug',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -87,6 +87,9 @@ export const DSL_NAMES = [
   // SoundLayer param normalization), so the WAV captures exactly what the
   // user hears. Top-level dslValues entries forward to topLevelBuilder.
   'recording_start', 'recording_stop', 'recording_save', 'recording_delete',
+  // Tier B PR #2 — pure ring constructors (#233). Both delegate to each
+  // other for negative counts (matches upstream `core.rb:1919-1970`).
+  'doubles', 'halves',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -96,6 +96,12 @@ export const DSL_NAMES = [
   // don't validate arg names yet — see ProgramBuilder).
   'current_synth_defaults', 'current_sample_defaults',
   'current_arg_checks', 'current_debug',
+  // Tier B PR #2 — block-form tuplet scheduling (#233). The transpiler
+  // routes `tuplets [...] do |x| ... end` to __b.tuplets(list, opts, cb),
+  // resolving the list/opts at build time then pushing N play+sleep step
+  // pairs per the block (one per leaf element). Density wraps each
+  // sub-list so N elements fit in `duration` beats.
+  'tuplets',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -102,6 +102,13 @@ export const DSL_NAMES = [
   // pairs per the block (one per leaf element). Density wraps each
   // sub-list so N elements fit in `duration` beats.
   'tuplets',
+  // Tier B PR #2 — defonce (#212 / #233). The transpiler emits a bare
+  // assignment `name = defonce("name", opts, (__b) => { ...; return last })`
+  // so the cached value lands in proxy storage. The runtime registrar caches
+  // against engine.defonceCache; opts.override re-runs the body. Cached
+  // values are spread into persistedFns at the next eval so removing the
+  // defonce line doesn't break still-running live_loops that read `name`.
+  'defonce',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -532,11 +532,22 @@ export class ProgramBuilder {
   /** Return the current synth name. */
   get current_synth_name(): string { return this.currentSynth }
 
-  /** Return the current synth defaults hash. */
-  get current_synth_defaults_hash(): Record<string, number> { return { ...this._synthDefaults } }
-
-  /** Return the current sample defaults hash. */
-  get current_sample_defaults_hash(): Record<string, number> { return { ...this._sampleDefaults } }
+  /**
+   * Tier B PR #2 (#233) — defaults / setting introspection. All four are
+   * called bare (`puts current_debug`) so they're methods returning a value,
+   * not getters — see BARE_CALLABLE in TreeSitterTranspiler.ts which emits
+   * `__b.NAME()` with parens.
+   */
+  current_synth_defaults(): Record<string, number> { return { ...this._synthDefaults } }
+  current_sample_defaults(): Record<string, number> { return { ...this._sampleDefaults } }
+  current_debug(): boolean { return this._debug }
+  /**
+   * We don't validate synth arg names against synthinfo — unknown args are
+   * silently dropped at SoundLayer normalization. Returning the upstream
+   * default (`true`) keeps existing user code that branches on this read
+   * working. When `use_arg_checks` ships in Tier C, this becomes a real read.
+   */
+  current_arg_checks(): boolean { return true }
 
   /** Deferred set — fires at runtime (interleaved with sleeps). */
   set(key: string | symbol, value: unknown): this {

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -529,6 +529,71 @@ export class ProgramBuilder {
     return this
   }
 
+  /**
+   * Tier B PR #2 (#233) — block-form tuplet scheduling.
+   *
+   * `tuplets [70, [72, 72], 70, [82, 82, 82]] do |n| play n end`
+   *   - Bare element → `block.call(n); sleep duration` (default 1 beat).
+   *   - Sub-list of size N → fits N `block + sleep` calls into `duration`
+   *     beats by wrapping in `with_density(N)`.
+   *
+   * Optional `swing:` opt offsets every Nth tuplet by that many beats via
+   * `at([swing], …)`. Swing is density-scaled inside sub-lists so the
+   * offset stays proportional to the local pulse. Mirrors upstream
+   * `core.rb:486-512`. Pre-resolved at build time (the block runs N times
+   * synchronously, pushing N play+sleep step pairs); the resulting steps
+   * fire at scheduled virtual time exactly like a hand-written sequence.
+   */
+  tuplets<T = unknown>(
+    tuplet_list: ReadonlyArray<T | ReadonlyArray<T>> | Ring<T | T[]>,
+    optsOrFn:
+      | { duration?: number; swing?: number; swing_pulse?: number; swing_offset?: number }
+      | ((b: ProgramBuilder, value: T) => void),
+    maybeFn?: (b: ProgramBuilder, value: T) => void,
+  ): this {
+    const opts = typeof optsOrFn === 'function' ? {} : optsOrFn
+    const fn = typeof optsOrFn === 'function' ? optsOrFn : maybeFn
+    if (typeof fn !== 'function') {
+      throw new Error('tuplets requires a block')
+    }
+
+    const duration = opts.duration ?? 1
+    const swing = opts.swing ?? 0
+    const swing_pulse = opts.swing_pulse ?? 2
+    const swing_offset = (opts.swing_offset ?? 0) + 1
+
+    const items = tuplet_list instanceof Ring
+      ? tuplet_list.toArray()
+      : Array.from(tuplet_list)
+
+    for (const el of items) {
+      if (Array.isArray(el)) {
+        const n = el.length
+        this.with_density(n, b => {
+          el.forEach((tuplet, idx) => {
+            const should_swing =
+              swing !== 0 &&
+              (n % swing_pulse === 0) &&
+              ((idx + swing_offset) % swing_pulse === 0)
+            if (should_swing) {
+              // Density-scale the swing so the offset stays proportional
+              // to the local pulse (mirrors upstream's __with_spider_time_density
+              // which time-scales everything inside the block).
+              b.at([swing / n], null, inner => fn(inner, tuplet as T))
+            } else {
+              fn(b, tuplet as T)
+            }
+            b.sleep(duration)
+          })
+        })
+      } else {
+        fn(this, el as T)
+        this.sleep(duration)
+      }
+    }
+    return this
+  }
+
   /** Return the current synth name. */
   get current_synth_name(): string { return this.currentSynth }
 

--- a/src/engine/Ring.ts
+++ b/src/engine/Ring.ts
@@ -254,6 +254,44 @@ export function stretch<T>(arr: T[] | Ring<T>, n: number): Ring<T> {
 }
 
 /**
+ * `doubles(start, n)` → ring of successive doubling: `doubles(60, 4)` → `Ring([60, 120, 240, 480])`.
+ * Negative count delegates to `halves(start, -n)`.
+ * Mirrors upstream `core.rb:1950-1960`.
+ */
+export function doubles(start: number, num_doubles: number = 1): Ring<number> {
+  if (typeof start !== 'number') {
+    throw new Error(`Start value for doubles needs to be a number, got: ${String(start)}`)
+  }
+  if (num_doubles < 0) return halves(start, -num_doubles)
+  const out: number[] = []
+  let v = start
+  for (let i = 0; i < num_doubles; i++) {
+    out.push(v)
+    v *= 2
+  }
+  return new Ring(out)
+}
+
+/**
+ * `halves(start, n)` → ring of successive halving: `halves(60, 4)` → `Ring([60, 30, 15, 7.5])`.
+ * Negative count delegates to `doubles(start, -n)`.
+ * Mirrors upstream `core.rb:1919-1929`.
+ */
+export function halves(start: number, num_halves: number = 1): Ring<number> {
+  if (typeof start !== 'number') {
+    throw new Error(`Start value for halves needs to be a number, got: ${String(start)}`)
+  }
+  if (num_halves < 0) return doubles(start, -num_halves)
+  const out: number[] = []
+  let v = start
+  for (let i = 0; i < num_halves; i++) {
+    out.push(v)
+    v /= 2
+  }
+  return new Ring(out)
+}
+
+/**
  * Line: generate a line of N values between start and end.
  * line(60, 72, 5) → Ring([60, 63, 66, 69, 72])
  */

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1060,6 +1060,16 @@ export class SonicPiEngine {
         () => topLevelBuilder.current_sample_defaults(),
         () => topLevelBuilder.current_arg_checks(),
         () => topLevelBuilder.current_debug(),
+        // Tier B PR #2 — block-form tuplets (#233). Forwards to topLevelBuilder
+        // so steps land on the top-level program. Inside live_loops the
+        // transpiler emits `__b.tuplets(...)` directly via BUILDER_METHODS.
+        (list: unknown, optsOrFn: unknown, maybeFn?: unknown) => {
+          topLevelBuilder.tuplets(
+            list as readonly unknown[],
+            optsOrFn as Parameters<typeof topLevelBuilder.tuplets>[1],
+            maybeFn as Parameters<typeof topLevelBuilder.tuplets>[2],
+          )
+        },
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -128,6 +128,9 @@ export class SonicPiEngine {
    *  next eval's scopeBase so removing a `define` line from the buffer does not
    *  break a still-running live_loop that calls it. (#215) */
   private definedFns = new Map<string, (...args: unknown[]) => unknown>()
+  /** Cached `defonce` values (#212 / #233). Survive across re-evals — that's
+   *  the whole point. Cleared only on full engine reset / dispose. */
+  private defonceCache = new Map<string, unknown>()
   /** Host-provided OSC send handler. Engine fires this; host wires to actual transport. */
   private oscHandler: ((host: string, port: number, path: string, ...args: unknown[]) => void) | null = null
   /** Active Recorder instance (#228). Null when not recording. */
@@ -1070,6 +1073,21 @@ export class SonicPiEngine {
             maybeFn as Parameters<typeof topLevelBuilder.tuplets>[2],
           )
         },
+        // Tier B PR #2 — defonce (#212 / #233). Cache lookup; runs body once
+        // (or again on `override: true`). The transpiler emits a bare
+        // assignment `name = defonce(...)` so the Sandbox proxy captures the
+        // cached value into scope-isolated storage. Spread back into
+        // persistedFns above so `name` reads still work after the line is
+        // removed from the buffer (matches define persistence #215).
+        (name: string, opts: { override?: boolean }, fn: (b: ProgramBuilder) => unknown) => {
+          if (typeof name !== 'string' || typeof fn !== 'function') return undefined
+          if (!opts?.override && this.defonceCache.has(name)) {
+            return this.defonceCache.get(name)
+          }
+          const value = fn(topLevelBuilder)
+          this.defonceCache.set(name, value)
+          return value
+        },
       ]
 
       const codeWarnings = validateCode(transpiledCode)
@@ -1078,9 +1096,15 @@ export class SonicPiEngine {
         else console.warn('[SonicPi]', warning)
       }
 
-      // Seed prior `define`-bound functions so they remain callable even if
-      // the user removes the define line from the buffer. (#215)
-      const persistedFns = Object.fromEntries(this.definedFns)
+      // Seed prior `define`-bound functions and `defonce`-cached values so
+      // they remain callable / readable even if the user removes the line
+      // from the buffer. defonceCache is spread first so a same-named define
+      // wins (defines are functions; conflicts are user error either way).
+      // (#215 + #233)
+      const persistedFns: Record<string, unknown> = {
+        ...Object.fromEntries(this.defonceCache),
+        ...Object.fromEntries(this.definedFns),
+      }
       const sandbox = createIsolatedExecutor(transpiledCode, dslNames, persistedFns)
       scopeHandle = sandbox.scopeHandle
       await sandbox.execute(...dslValues)
@@ -1182,6 +1206,7 @@ export class SonicPiEngine {
     this.loopSynced.clear()
     this.globalStore.clear()
     this.definedFns.clear()
+    this.defonceCache.clear()
     this.persistentFx.clear()
     this.reusableFx.clear()
     this.loopFxScope.clear()
@@ -1218,6 +1243,7 @@ export class SonicPiEngine {
     this.loopSeeds.clear()
     this.globalStore.clear()
     this.definedFns.clear()
+    this.defonceCache.clear()
   }
 
   /** Register a handler for runtime errors inside `live_loop` bodies. */

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -23,7 +23,7 @@ const CLAMP_WARN_RE = /clamped to .+ \((min|max)\)$/
 import { friendlyError, formatFriendlyError, type FriendlyError } from './FriendlyErrors'
 import { detectStratum, Stratum } from './Stratum'
 import { SoundEventStream } from './SoundEventStream'
-import { ring, knit, range, line, Ring } from './Ring'
+import { ring, knit, range, line, doubles, halves, Ring } from './Ring'
 import { assert, assert_equal, assert_similar, assert_not, assert_error, inc, dec } from './Asserts'
 import { MidiBridge } from './MidiBridge'
 import { spread } from './EuclideanRhythm'
@@ -1051,6 +1051,8 @@ export class SonicPiEngine {
         (...args: unknown[]) => { topLevelBuilder.recording_stop(...args) },
         (...args: unknown[]) => { topLevelBuilder.recording_save(...args) },
         (...args: unknown[]) => { topLevelBuilder.recording_delete(...args) },
+        // Tier B PR #2 — pure ring constructors (#233)
+        doubles, halves,
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1053,6 +1053,13 @@ export class SonicPiEngine {
         (...args: unknown[]) => { topLevelBuilder.recording_delete(...args) },
         // Tier B PR #2 — pure ring constructors (#233)
         doubles, halves,
+        // Tier B PR #2 — defaults / setting introspection (#233). Forward
+        // to topLevelBuilder so the value reflects top-level use_*_defaults
+        // calls. Inside live_loops the transpiler routes through __b.
+        () => topLevelBuilder.current_synth_defaults(),
+        () => topLevelBuilder.current_sample_defaults(),
+        () => topLevelBuilder.current_arg_checks(),
+        () => topLevelBuilder.current_debug(),
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -251,6 +251,10 @@ const BUILDER_METHODS = new Set([
   // Tier B — PRNG inspection (#227). Per-task RNG mutations — route through
   // __b so they hit the calling builder's seeded random stream.
   'current_random_seed', 'rand_back', 'rand_skip', 'rand_reset',
+  // Tier B PR #2 — defaults / setting introspection (#233). Per-task pure
+  // reads — route through __b so per-loop use_*_defaults are visible.
+  'current_synth_defaults', 'current_sample_defaults',
+  'current_arg_checks', 'current_debug',
   // Deferred-step DSL contract (issue #193 — must mirror methods on
   // ProgramBuilder so they fire at scheduled virtual time, not build time).
   'stop_loop', 'set_volume', 'use_osc', 'osc',
@@ -337,6 +341,10 @@ const BARE_CALLABLE = new Set([
   // so it doesn't need this list — but including it means a bare
   // `recording_save` (forgotten filename) trips the arity guard at build.
   'recording_start', 'recording_stop', 'recording_delete', 'recording_save',
+  // Tier B PR #2 — defaults / setting introspection (#233). Routinely called
+  // bare in user code (`puts current_debug`, `if current_arg_checks`).
+  'current_synth_defaults', 'current_sample_defaults',
+  'current_arg_checks', 'current_debug',
 ])
 
 /**

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -234,7 +234,7 @@ const BUILDER_METHODS = new Set([
   // Utility
   'factor_q', 'bools', 'play_pattern_timed', 'sample_duration', 'stretch', 'ramp',
   'hz_to_midi', 'midi_to_hz', 'quantise', 'quantize', 'octs',
-  'kill', 'play_chord', 'play_pattern',
+  'kill', 'play_chord', 'play_pattern', 'tuplets',
   'with_octave', 'with_random_seed', 'with_density',
   'noteToMidi', 'midiToFreq', 'noteToFreq', 'note_info',
   // Data constructors
@@ -1063,6 +1063,11 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
       return transpileTimeWarp(argsNode, blockNode, ctx)
     }
 
+    // tuplets [list], opts do |x| ... end  (#233)
+    if (methodName === 'tuplets') {
+      return transpileTuplets(argsNode, blockNode, ctx)
+    }
+
     // assert_error do … end → assert_error((__b) => { … })  (#216)
     if (methodName === 'assert_error' && blockNode) {
       const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
@@ -1849,6 +1854,52 @@ function transpileTimeWarp(
   const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
   const bodyStr = transpileBlockBody(blockNode, bodyCtx)
   return `${prefix}at([${offset}], null, (__b) => {\n${bodyStr}\n${ctx.indent}})`
+}
+
+/**
+ * `tuplets [list], opts do |x| ... end`  (#233)
+ *
+ *   tuplets [70, [72, 72]], swing: 0.2 do |n| play n end
+ *     →  __b.tuplets([70, [72, 72]], { swing: 0.2 }, (__b, n) => { __b.play(n) })
+ *
+ * The first positional arg is the list. Remaining keyword pairs become an
+ * options object. Block params come through as additional callback args.
+ */
+function transpileTuplets(
+  argsNode: any, blockNode: any, ctx: TranspileContext
+): string {
+  if (!blockNode) {
+    const line = argsNode?.startPosition?.row != null ? argsNode.startPosition.row + 1 : '?'
+    ctx.errors.push(`Parse error at line ${line}: tuplets is missing 'do ... end' block`)
+    return `/* parse error: tuplets missing block */`
+  }
+
+  const args = argsNode?.namedChildren ?? []
+  const positional = args.filter((a: any) => a.type !== 'pair').map((a: any) => transpileNode(a, ctx))
+  const pairs = args.filter((a: any) => a.type === 'pair')
+
+  const listExpr = positional[0] ?? '[]'
+  const optsExpr = pairs.length > 0
+    ? '{ ' + pairs.map((p: any) => {
+        const key = p.namedChildren[0]
+        const val = p.namedChildren[1]
+        const keyName = key.type === 'hash_key_symbol'
+          ? key.text.replace(/:$/, '')
+          : key.type === 'simple_symbol'
+          ? key.text.slice(1)
+          : transpileNode(key, ctx)
+        return `${keyName}: ${transpileNode(val, ctx)}`
+      }).join(', ') + ' }'
+    : '{}'
+
+  const prefix = ctx.insideLoop ? '__b.' : ''
+  const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
+  const params = blockNode.namedChildren.find((c: any) => c.type === 'block_parameters')
+  const paramNames = params?.namedChildren.map((c: any) => c.text) ?? []
+  const bodyStr = transpileBlockBody(blockNode, bodyCtx)
+  const paramStr = paramNames.length > 0 ? ', ' + paramNames.join(', ') : ''
+
+  return `${prefix}tuplets(${listExpr}, ${optsExpr}, (__b${paramStr}) => {\n${bodyStr}\n${ctx.indent}})`
 }
 
 function transpileDensity(

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -937,7 +937,7 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     // `comment` and `uncomment` are control-flow (like if-true/if-false), NOT
     // structural blocks. They stay in bareCode so their content gets the __b.
     // prefix when wrapped. Separating them would produce bare `play()` at top level.
-    } else if (method && !isBareFxNode && (method === 'live_loop' || method === 'define' || method === 'ndefine' || method === 'with_fx' ||
+    } else if (method && !isBareFxNode && (method === 'live_loop' || method === 'define' || method === 'ndefine' || method === 'defonce' || method === 'with_fx' ||
                           method === 'in_thread' || isBareLoopNode)) {
       blocks.push(child)
     } else {
@@ -1041,6 +1041,11 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
     // define :name do |args| ... end  (and ndefine — same surface, doesn't persist; #211/#215)
     if (methodName === 'define' || methodName === 'ndefine') {
       return transpileDefine(node, argsNode, blockNode, ctx, methodName)
+    }
+
+    // defonce :name, override: true do ... end  (#212 / #233)
+    if (methodName === 'defonce') {
+      return transpileDefonce(node, argsNode, blockNode, ctx)
     }
 
     // with_fx :name, opts do ... end
@@ -1640,6 +1645,71 @@ function transpileDefine(
     return `${decl};\n${ctx.indent}define(${JSON.stringify(name)}, ${name})`
   }
   return decl
+}
+
+/**
+ * `defonce :name, override: true do ... end`  (#212 / #233)
+ *
+ *   defonce :pad do
+ *     chord(:c, :major)
+ *   end
+ *     →  pad = defonce("pad", {}, (__b) => {
+ *          return __b.chord("c", "major")
+ *        })
+ *
+ * Bare assignment so the Sandbox proxy captures the cached value into
+ * scope-isolated storage (let/const bypass the proxy). The last block
+ * statement is wrapped as `return EXPR` so the caller gets the value
+ * Ruby's implicit-last-expr-return convention would have produced.
+ *
+ * The runtime registrar `defonce(name, opts, fn)` lives in dslValues and
+ * caches against `engine.defonceCache`. Re-evaluating the buffer skips
+ * the body unless `override: true`, mirroring upstream core.rb:2722-2738.
+ */
+function transpileDefonce(
+  node: any, argsNode: any, blockNode: any, ctx: TranspileContext
+): string {
+  const args = argsNode?.namedChildren ?? []
+  let name = 'unnamed'
+  const optPairs: string[] = []
+  for (const arg of args) {
+    if (arg.type === 'simple_symbol') {
+      name = arg.text.slice(1)
+    } else if (arg.type === 'pair') {
+      const key = arg.namedChildren[0]
+      const val = arg.namedChildren[1]
+      const keyName = key.type === 'hash_key_symbol'
+        ? key.text.replace(/:$/, '')
+        : key.type === 'simple_symbol'
+        ? key.text.slice(1)
+        : transpileNode(key, ctx)
+      optPairs.push(`${keyName}: ${transpileNode(val, ctx)}`)
+    }
+  }
+
+  if (!blockNode) {
+    const line = node.startPosition?.row != null ? node.startPosition.row + 1 : '?'
+    ctx.errors.push(`Parse error at line ${line}: defonce :${name} is missing 'do ... end' block`)
+    return `/* parse error: defonce :${name} missing block */`
+  }
+
+  const bodyChildren = blockNode.namedChildren.filter((c: any) => c.type !== 'block_parameters')
+  if (bodyChildren.length === 0) {
+    return `${name} = defonce(${JSON.stringify(name)}, ${optPairs.length > 0 ? `{ ${optPairs.join(', ')} }` : '{}'}, (__b) => undefined)`
+  }
+
+  const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
+  const lastIdx = bodyChildren.length - 1
+  const stmts = bodyChildren.map((c: any, i: number) => {
+    const expr = transpileNode(c, bodyCtx)
+    return i === lastIdx
+      ? `${ctx.indent}  return ${expr}`
+      : `${ctx.indent}  ${expr}`
+  })
+
+  const optsStr = optPairs.length > 0 ? `{ ${optPairs.join(', ')} }` : '{}'
+
+  return `${name} = defonce(${JSON.stringify(name)}, ${optsStr}, (__b) => {\n${stmts.join('\n')}\n${ctx.indent}})`
 }
 
 function transpileWithBlock(

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -219,6 +219,44 @@ describe('doubles / halves (#233 Tier B PR #2)', () => {
   })
 })
 
+describe('introspection (#233 Tier B PR #2)', () => {
+  it('current_synth_defaults reflects use_synth_defaults', () => {
+    const b = new ProgramBuilder()
+    expect(b.current_synth_defaults()).toEqual({})
+    b.use_synth_defaults({ amp: 0.5, cutoff: 80 })
+    expect(b.current_synth_defaults()).toEqual({ amp: 0.5, cutoff: 80 })
+  })
+
+  it('current_sample_defaults reflects use_sample_defaults', () => {
+    const b = new ProgramBuilder()
+    expect(b.current_sample_defaults()).toEqual({})
+    b.use_sample_defaults({ rate: 0.5 })
+    expect(b.current_sample_defaults()).toEqual({ rate: 0.5 })
+  })
+
+  it('current_synth_defaults returns a copy (mutations do not leak)', () => {
+    const b = new ProgramBuilder()
+    b.use_synth_defaults({ amp: 0.5 })
+    const snapshot = b.current_synth_defaults()
+    snapshot.amp = 99
+    expect(b.current_synth_defaults().amp).toBe(0.5)
+  })
+
+  it('current_debug defaults to true and reflects use_debug', () => {
+    const b = new ProgramBuilder()
+    expect(b.current_debug()).toBe(true)
+    b.use_debug(false)
+    expect(b.current_debug()).toBe(false)
+    b.use_debug(true)
+    expect(b.current_debug()).toBe(true)
+  })
+
+  it('current_arg_checks returns true (matches Desktop SP default)', () => {
+    const b = new ProgramBuilder()
+    expect(b.current_arg_checks()).toBe(true)
+  })
+})
+
 describe('Ring helpers (#211 Tier A)', () => {
   it('stretch repeats each element n times', () => {
     const r = stretch([1, 2, 3], 2)

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -219,6 +219,69 @@ describe('doubles / halves (#233 Tier B PR #2)', () => {
   })
 })
 
+describe('defonce engine integration (#212 / #233 Tier B PR #2)', () => {
+  it('runs body and caches return value', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`defonce :pad do
+  42
+end`)
+    const cache = (engine as unknown as { defonceCache: Map<string, unknown> }).defonceCache
+    expect(cache.get('pad')).toBe(42)
+    engine.dispose()
+  })
+
+  it('override: true re-runs body and updates cache', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`defonce :counter do
+  1
+end`)
+    const cache = (engine as unknown as { defonceCache: Map<string, unknown> }).defonceCache
+    expect(cache.get('counter')).toBe(1)
+
+    // Re-eval with override: true and a different return value
+    await engine.evaluate(`defonce :counter, override: true do
+  99
+end`)
+    expect(cache.get('counter')).toBe(99)
+    engine.dispose()
+  })
+
+  it('cache survives across re-evals without override', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`defonce :seed do
+  123
+end`)
+    const cache = (engine as unknown as { defonceCache: Map<string, unknown> }).defonceCache
+    expect(cache.get('seed')).toBe(123)
+
+    // Same name, different body — body should NOT execute, cache untouched.
+    await engine.evaluate(`defonce :seed do
+  456
+end`)
+    expect(cache.get('seed')).toBe(123)
+    engine.dispose()
+  })
+
+  it('cache cleared on dispose()', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`defonce :gone do
+  7
+end`)
+    const cache = (engine as unknown as { defonceCache: Map<string, unknown> }).defonceCache
+    expect(cache.size).toBe(1)
+    engine.dispose()
+    expect(cache.size).toBe(0)
+  })
+})
+
 describe('tuplets (#233 Tier B PR #2)', () => {
   it('bare elements emit play + sleep at full duration', () => {
     const b = new ProgramBuilder()

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { SeededRandom } from '../SeededRandom'
-import { Ring, ring, ramp, stretch, Ramp } from '../Ring'
+import { Ring, ring, ramp, stretch, doubles, halves, Ramp } from '../Ring'
 import { spread } from '../EuclideanRhythm'
 import { noteToMidi, midiToFreq, noteToFreq, noteInfo } from '../NoteToFreq'
 import { MidiBridge } from '../MidiBridge'
@@ -169,6 +169,53 @@ describe('Global tick context (#211 Tier A)', () => {
     b.tick('foo'); b.tick('foo') // counter at 1
     expect(b.look('foo', 5)).toBe(6)
     expect(b.look('foo')).toBe(1) // still 1
+  })
+})
+
+describe('doubles / halves (#233 Tier B PR #2)', () => {
+  it('doubles produces successive doubling', () => {
+    expect(doubles(60, 4).toArray()).toEqual([60, 120, 240, 480])
+  })
+
+  it('halves produces successive halving', () => {
+    expect(halves(60, 4).toArray()).toEqual([60, 30, 15, 7.5])
+  })
+
+  it('doubles defaults to count 1', () => {
+    expect(doubles(7).toArray()).toEqual([7])
+  })
+
+  it('halves defaults to count 1', () => {
+    expect(halves(7).toArray()).toEqual([7])
+  })
+
+  it('doubles with negative count delegates to halves', () => {
+    expect(doubles(60, -3).toArray()).toEqual(halves(60, 3).toArray())
+  })
+
+  it('halves with negative count delegates to doubles', () => {
+    expect(halves(10, -3).toArray()).toEqual(doubles(10, 3).toArray())
+  })
+
+  it('doubles returns a Ring (cyclic indexing)', () => {
+    const r = doubles(1, 3)
+    expect(r.at(0)).toBe(1)
+    expect(r.at(1)).toBe(2)
+    expect(r.at(2)).toBe(4)
+    expect(r.at(3)).toBe(1) // cycles
+  })
+
+  it('doubles rejects non-numeric start', () => {
+    expect(() => doubles('hi' as unknown as number, 2)).toThrow(/needs to be a number/)
+  })
+
+  it('halves rejects non-numeric start', () => {
+    expect(() => halves('hi' as unknown as number, 2)).toThrow(/needs to be a number/)
+  })
+
+  it('count 0 returns empty ring', () => {
+    expect(doubles(60, 0).toArray()).toEqual([])
+    expect(halves(60, 0).toArray()).toEqual([])
   })
 })
 

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -219,6 +219,80 @@ describe('doubles / halves (#233 Tier B PR #2)', () => {
   })
 })
 
+describe('tuplets (#233 Tier B PR #2)', () => {
+  it('bare elements emit play + sleep at full duration', () => {
+    const b = new ProgramBuilder()
+    b.tuplets([60, 62, 64], (b2, n) => { b2.play(n) })
+    const program = b.build()
+    // play, sleep, play, sleep, play, sleep
+    expect(program.length).toBe(6)
+    expect(program[0].tag).toBe('play')
+    expect(program[1].tag).toBe('sleep')
+    expect((program[1] as { tag: 'sleep'; beats: number }).beats).toBe(1)
+    expect((program[0] as { tag: 'play'; note: number }).note).toBe(60)
+    expect((program[2] as { tag: 'play'; note: number }).note).toBe(62)
+    expect((program[4] as { tag: 'play'; note: number }).note).toBe(64)
+  })
+
+  it('sub-list scales sleep by density factor 1/N', () => {
+    const b = new ProgramBuilder()
+    b.tuplets([[60, 62, 64]], (b2, n) => { b2.play(n) })
+    const program = b.build()
+    // 3 (play, sleep) pairs inside density 3
+    expect(program.length).toBe(6)
+    // Each sleep is duration / density = 1 / 3
+    const sleeps = program.filter(s => s.tag === 'sleep') as { tag: 'sleep'; beats: number }[]
+    expect(sleeps.length).toBe(3)
+    for (const s of sleeps) expect(s.beats).toBeCloseTo(1 / 3, 6)
+  })
+
+  it('mixed bare + sub-list produces correct step ordering', () => {
+    const b = new ProgramBuilder()
+    b.tuplets([70, [72, 72], 70], (b2, n) => { b2.play(n) })
+    const program = b.build()
+    // 70 → play, sleep(1)
+    // [72, 72] → density 2 → play, sleep(0.5), play, sleep(0.5)
+    // 70 → play, sleep(1)
+    expect(program.length).toBe(8)
+    const sleeps = program.filter(s => s.tag === 'sleep') as { tag: 'sleep'; beats: number }[]
+    expect(sleeps[0].beats).toBe(1)
+    expect(sleeps[1].beats).toBeCloseTo(0.5, 6)
+    expect(sleeps[2].beats).toBeCloseTo(0.5, 6)
+    expect(sleeps[3].beats).toBe(1)
+  })
+
+  it('duration opt overrides default beat-per-element', () => {
+    const b = new ProgramBuilder()
+    b.tuplets([60, 62], { duration: 0.5 }, (b2, n) => { b2.play(n) })
+    const program = b.build()
+    const sleeps = program.filter(s => s.tag === 'sleep') as { tag: 'sleep'; beats: number }[]
+    expect(sleeps[0].beats).toBe(0.5)
+    expect(sleeps[1].beats).toBe(0.5)
+  })
+
+  it('swing opt produces an at-block on swung beats', () => {
+    const b = new ProgramBuilder()
+    // [72, 72] is size 2 (matches default swing_pulse 2), swing_offset+1=1,
+    // so idx 1 swings: ((1+1)%2 === 0). Element at idx 0 plays straight.
+    b.tuplets([[72, 72]], { swing: 0.1 }, (b2, n) => { b2.play(n) })
+    const program = b.build()
+    const tags = program.map(s => s.tag)
+    expect(tags).toContain('thread') // at(...) uses thread step
+  })
+
+  it('Ring as input is accepted', () => {
+    const b = new ProgramBuilder()
+    b.tuplets(ring(60, 62, 64), (b2, n) => { b2.play(n) })
+    expect(b.build().length).toBe(6)
+  })
+
+  it('throws when block is missing', () => {
+    const b = new ProgramBuilder()
+    expect(() => (b as unknown as { tuplets: (...a: unknown[]) => void }).tuplets([60, 62])).toThrow(/requires a block/)
+    expect(() => b.tuplets([60, 62], {} as never)).toThrow(/requires a block/)
+  })
+})
+
 describe('introspection (#233 Tier B PR #2)', () => {
   it('current_synth_defaults reflects use_synth_defaults', () => {
     const b = new ProgramBuilder()

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -66,6 +66,14 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['spread',           'Pure Euclidean-rhythm constructor.'],
   ['doubles',          'Pure: ring of successive doubling.'],
   ['halves',           'Pure: ring of successive halving.'],
+  // Tier B PR #2 — defaults / setting introspection (#233). All four are
+  // pure reads of builder state; inside live_loops the transpiler routes
+  // through __b.* via BUILDER_METHODS, so the per-task builder fulfils the
+  // method-presence requirement. Listed here for top-level dslValues entries.
+  ['current_synth_defaults',  'Pure read of builder._synthDefaults.'],
+  ['current_sample_defaults', 'Pure read of builder._sampleDefaults.'],
+  ['current_arg_checks',      'Constant true — we do not validate arg names yet (Tier C).'],
+  ['current_debug',           'Pure read of builder._debug.'],
   // Pure math
   ['note',             'Pure: note name → MIDI number.'],
   ['note_range',       'Pure constructor.'],

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -117,6 +117,7 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['dec',              'Pure: x - 1.'],
   ['define',           'Transpiler emits a JS function decl (TreeSitterTranspiler.transpileDefine). Runtime stub is a no-op.'],
   ['ndefine',          'Alias for define on the transpile path; same JS function decl. (#211 — non-persistence is identical to define until cross-eval persistence ships.)'],
+  ['defonce',          'Transpiler emits `name = defonce(...)` (TreeSitterTranspiler.transpileDefonce). Runtime registrar caches against engine.defonceCache. (#212 / #233)'],
   ['time_warp',        'Transpiler turns `time_warp 0.5 do … end` into `__b.at([0.5], null, …)` (transpileTimeWarp). Runtime stub forwards to topLevelAt for the regex fallback path.'],
   // Random — desktop Sonic Pi resolves these at build-time deterministically (seeded)
   ['rrand',            'Desktop SP convention: resolved at build-time against the live_loop seed.'],

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -64,6 +64,8 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['range',            'Pure constructor.'],
   ['line',             'Pure constructor.'],
   ['spread',           'Pure Euclidean-rhythm constructor.'],
+  ['doubles',          'Pure: ring of successive doubling.'],
+  ['halves',           'Pure: ring of successive halving.'],
   // Pure math
   ['note',             'Pure: note name → MIDI number.'],
   ['note_range',       'Pure constructor.'],

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -684,6 +684,24 @@ end`)
       expect(result.code).toMatch(/\.current_sched_ahead_time\(\)/)
     })
 
+    it('defonce :name do ... end emits bare-assignment + return on last expr (#233)', () => {
+      const result = treeSitterTranspile(`defonce :pad do
+  chord(:c, :major)
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toMatch(/pad = defonce\("pad", \{\}, \(__b\) => \{/)
+      expect(result.code).toMatch(/return __b\.chord\("c", "major"\)/)
+    })
+
+    it('defonce with override: true forwards opt to runtime (#233)', () => {
+      const result = treeSitterTranspile(`defonce :foo, override: true do
+  10
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toMatch(/foo = defonce\("foo", \{ override: true \}, \(__b\) => \{/)
+      expect(result.code).toMatch(/return 10/)
+    })
+
     it('tuplets [list], opts do |x| ... end transpiles to __b.tuplets(...) inside live_loop (#233)', () => {
       const result = treeSitterTranspile(`live_loop :t do
   tuplets [70, [72, 72], 70], swing: 0.2 do |n|

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -684,6 +684,22 @@ end`)
       expect(result.code).toMatch(/\.current_sched_ahead_time\(\)/)
     })
 
+    it('current_synth_defaults / current_debug etc. inside live_loop route via __b (#233)', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  use_synth_defaults amp: 0.5
+  puts current_synth_defaults
+  puts current_sample_defaults
+  puts current_arg_checks
+  puts current_debug
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toMatch(/\.current_synth_defaults\(\)/)
+      expect(result.code).toMatch(/\.current_sample_defaults\(\)/)
+      expect(result.code).toMatch(/\.current_arg_checks\(\)/)
+      expect(result.code).toMatch(/\.current_debug\(\)/)
+    })
+
     it('with_fx at top level (outside live_loop)', () => {
       const result = treeSitterTranspile(`with_fx :reverb, mix: 0.7 do
   live_loop :t do

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -684,6 +684,29 @@ end`)
       expect(result.code).toMatch(/\.current_sched_ahead_time\(\)/)
     })
 
+    it('tuplets [list], opts do |x| ... end transpiles to __b.tuplets(...) inside live_loop (#233)', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  tuplets [70, [72, 72], 70], swing: 0.2 do |n|
+    play n
+  end
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toMatch(/\.tuplets\(\[70, \[72, 72\], 70\], \{ swing: 0\.2 \}, \(__b, n\)/)
+      expect(result.code).toMatch(/__b\.play\(n,/)
+    })
+
+    it('tuplets without opts hash transpiles with empty options object (#233)', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  tuplets [60, 62, 64] do |n|
+    play n
+  end
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toMatch(/\.tuplets\(\[60, 62, 64\], \{\}, \(__b, n\)/)
+    })
+
     it('current_synth_defaults / current_debug etc. inside live_loop route via __b (#233)', () => {
       const result = treeSitterTranspile(`live_loop :t do
   use_synth_defaults amp: 0.5


### PR DESCRIPTION
Closes #233. Closes #212.

Eight user-facing DSL functions across four feature areas, all verified against upstream `sonic-pi-net/sonic-pi/dev`. Ships as four atomic commits (one per feature area) so any single area can be reverted without disturbing the others.

## Functions shipped

### Ring constructors (2) — pure, allow-listed
- `doubles(start, n=1)` — successive doubling, returns Ring; negative count delegates to `halves`
- `halves(start, n=1)` — successive halving; negative count delegates to `doubles`

### Defaults / setting introspection (4) — pure builder reads
- `current_synth_defaults` / `current_sample_defaults` — read per-loop builder state
- `current_debug` — read per-loop `_debug` flag
- `current_arg_checks` — returns constant `true` (matches Desktop SP default; we don't validate arg names yet — Tier C)

Routed via `BUILDER_METHODS` + `BARE_CALLABLE` so `puts current_debug` inside live_loops emits `__b.current_debug()` for per-task reads.

### Block-form scheduling (1) — deferred sub-program
- `tuplets(list, opts={}, &block)` — iterates leaves at build time, pushes one play+sleep step pair per leaf; sub-lists wrap in `with_density(N)` so N elements fit in `duration` beats; optional `swing` opt offsets every Nth beat via `at([swing/N], …)` density-scaled

Mirrors upstream `core.rb:486-512`. Same deferred-step category as `play_pattern_timed` (per SV20).

### Memoization (1) — already filed as #212
- `defonce(name, *opts, &block)` — `override:` opt only (no `force:` alias — confirmed)

Plumbing: `engine.defonceCache: Map<string, unknown>` survives re-evals (the whole point); spread into next eval's `persistedFns` alongside `definedFns` so removing the line doesn't break a still-running live_loop that reads `name` (same pattern as #215). Transpiler emits a bare assignment so the Sandbox proxy captures the value.

## Out of scope (corrections to original §10 plan)

Three corrections to `roadmap.md` §10 from upstream verification before coding (issue #233 comments document the audit):

- ~~`redistribute`~~ — private helper for `spread`, no `doc name:` in upstream `core.rb`
- ~~`power_of_two?`~~ — does not exist in upstream Sonic Pi
- ~~`factor?`~~ — already shipped (`ProgramBuilder.factor_q` + transpiler rename + 4 forum fixtures use it)
- ~~`buffer` family~~ — deferred to PR #3 (no fixture demand, design discussion needed for browser buffer storage)

## Verification

- `npx vitest run` — **866 tests pass** (835 → 866, +31)
- `npx tsc --noEmit` — **0 errors**
- `BASE_URL=http://localhost:5180 npx tsx tools/capture.ts --batch tests/book-examples/community` — **28/28 OK**
- `BASE_URL=http://localhost:5180 npx tsx tools/capture.ts --batch tests/book-examples/in-thread-forum` — **20/20 OK**
- 48/48 forum fixtures green

Note: first batch run had transient `net::ERR_INTERNET_DISCONNECTED` failures during a network blip; re-running cleanly hit 28/28 + 20/20. Not a code issue.

## Test plan

- [x] Unit tests for each ring helper (10 tests for doubles/halves)
- [x] Unit tests for each introspection method (5 tests)
- [x] Unit tests for tuplets (9 tests covering bare/sub-list/mixed/duration/swing/Ring/missing-block)
- [x] Engine integration tests for defonce (4 tests covering cache / override / re-eval persistence / dispose)
- [x] Transpiler integration tests for tuplets, defonce, and bare-callable introspection
- [x] DslBuilderContract.test.ts updated with allow-list justifications for each new pure entry
- [x] 48-fixture forum corpus regression — both batches green

## References

- Roadmap §10: `~/.anvideck/projects/sonicPiWeb/artifacts/roadmap.md`
- Gap inventory: `~/.anvideck/projects/sonicPiWeb/artifacts/gaps.md` §4.2 (corrections applied)
- Upstream verification: `sonic-pi-net/sonic-pi/dev` `app/server/ruby/lib/sonicpi/lang/{core,sound}.rb`
- Predecessor: #211 (Tier A umbrella) → #213, #225–#229 (Tier B PR #1) → #230