### PR TITLE
DSL Tier B PR #3 — dynamic eval + sync_bpm + live_audio :stop + load_example (6 fns)

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -967,6 +967,13 @@ export class App {
           this.cueLog.logCue(name, this.cueLog.currentRun, time * 1000)
         })
 
+        this.engine.setLoadExampleHandler((example) => {
+          // Forward `load_example :name` calls in user code to the editor's
+          // existing load-example flow (#236). Replaces buffer + auto-runs
+          // when already playing — same shape as the dropdown selection.
+          void this.loadExample(example)
+        })
+
         this.console.logSystem('  Loading synthdefs + initialising scsynth...')
         try {
           await this.engine.init()

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -126,6 +126,10 @@ export const DSL_NAMES = [
   // Listed in the public DSL surface so user code that references them
   // gets a clear redirect rather than a silent globalThis lookup miss.
   'eval_file', 'run_file',
+  // Tier B PR #3 — load_example (#236). Looks up an example by name in the
+  // bundled registry then forwards to the host's loadExampleHandler so the
+  // editor replaces its buffer + re-runs. Top-level only (host-bridge).
+  'load_example',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -120,6 +120,12 @@ export const DSL_NAMES = [
   // engine.evaluate with the supplied string. Top-level only; throws inside
   // live_loops to match desktop spider re-entry semantics.
   'run_code',
+  // Tier B PR #3 — eval_file / run_file (#236). Browser-sandbox stubs: the
+  // engine has no filesystem access, so both throw an informative error
+  // pointing users at run_code(string) / load_example(:name) instead.
+  // Listed in the public DSL surface so user code that references them
+  // gets a clear redirect rather than a silent globalThis lookup miss.
+  'eval_file', 'run_file',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -109,6 +109,17 @@ export const DSL_NAMES = [
   // values are spread into persistedFns at the next eval so removing the
   // defonce line doesn't break still-running live_loops that read `name`.
   'defonce',
+  // Tier B PR #3 — sync_bpm (#236). Deferred ProgramBuilder step that wraps
+  // sync with bpm_sync: true. Inside live_loops the transpiler routes
+  // through __b.sync_bpm via BUILDER_METHODS; at top level the runtime stub
+  // forwards to topLevelBuilder.sync_bpm. Cuer's BPM travels through the
+  // extended cueMap entry; AudioInterpreter's sync handler mutates task.bpm
+  // when step.bpmSync is true.
+  'sync_bpm',
+  // Tier B PR #3 — run_code (#236). Host-side dynamic eval — calls back into
+  // engine.evaluate with the supplied string. Top-level only; throws inside
+  // live_loops to match desktop spider re-entry semantics.
+  'run_code',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -14,7 +14,7 @@ export type Step =
   | { tag: 'useBpm'; bpm: number }
   | { tag: 'control'; nodeRef: number; params: Record<string, number> }
   | { tag: 'cue'; name: string; args?: unknown[] }
-  | { tag: 'sync'; name: string }
+  | { tag: 'sync'; name: string; bpmSync?: boolean }
   | { tag: 'fx'; name: string; opts: Record<string, number>; body: Program; nodeRef?: number }
   | { tag: 'thread'; body: Program }
   | { tag: 'print'; message: string }

--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -18,7 +18,7 @@ export type Step =
   | { tag: 'fx'; name: string; opts: Record<string, number>; body: Program; nodeRef?: number }
   | { tag: 'thread'; body: Program }
   | { tag: 'print'; message: string }
-  | { tag: 'liveAudio'; name: string; opts: Record<string, number> }
+  | { tag: 'liveAudio'; name: string; opts: Record<string, number>; stop?: boolean }
   | { tag: 'set'; key: string | symbol; value: unknown }
   | { tag: 'stop' }
   | { tag: 'stopLoop'; name: string }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -234,9 +234,19 @@ export class ProgramBuilder {
     return this
   }
 
-  sync(name: string): this {
-    this.steps.push({ tag: 'sync', name })
+  sync(name: string, opts?: { bpm_sync?: boolean }): this {
+    const bpmSync = opts?.bpm_sync === true
+    this.steps.push(bpmSync ? { tag: 'sync', name, bpmSync: true } : { tag: 'sync', name })
     return this
+  }
+
+  /**
+   * sync_bpm — alias for sync with bpm_sync: true (#236).
+   * Inherits both virtual time AND BPM from the cuer at wake time.
+   * Matches desktop `core.rb:4490-4494`.
+   */
+  sync_bpm(name: string): this {
+    return this.sync(name, { bpm_sync: true })
   }
 
   control(nodeRef: number, params: Record<string, number>): this {

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -330,8 +330,17 @@ export class ProgramBuilder {
     return this
   }
 
-  live_audio(name: string, opts?: Record<string, number>): this {
-    this.steps.push({ tag: 'liveAudio', name, opts: opts ?? {} })
+  live_audio(name: string, optsOrStop?: Record<string, number> | 'stop', maybeOpts?: Record<string, number>): this {
+    // `live_audio :name, :stop` (#236) — kills the named live_audio synth.
+    // Symbols transpile to JS strings, so the second arg is "stop" when the
+    // user writes `:stop`. Match upstream `sound.rb:195-197` which dispatches
+    // on args[1] == :stop. Also accept `live_audio :name, :stop, opts` for
+    // forward-compat though desktop ignores trailing args after :stop.
+    if (optsOrStop === 'stop') {
+      this.steps.push({ tag: 'liveAudio', name, opts: maybeOpts ?? {}, stop: true })
+      return this
+    }
+    this.steps.push({ tag: 'liveAudio', name, opts: (optsOrStop as Record<string, number>) ?? {} })
     return this
   }
 

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1109,6 +1109,22 @@ export class SonicPiEngine {
           }
           return this.evaluate(code)
         },
+        // Tier B PR #3 — eval_file / run_file (#236). Both stubs throw an
+        // informative error redirecting users to the working alternatives.
+        // Sonic Pi Web has no filesystem; on desktop these read a .rb file
+        // from disk. We surface that limitation explicitly rather than
+        // silently no-op'ing, so user-error from copy-pasted desktop code
+        // gets a useful message in the editor's runtime-error overlay.
+        (_path: string) => {
+          throw new Error(
+            'browser sandbox: no filesystem access; use run_code(string) or load_example(:name) instead',
+          )
+        },
+        (_path: string) => {
+          throw new Error(
+            'browser sandbox: no filesystem access; use run_code(string) or load_example(:name) instead',
+          )
+        },
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -130,6 +130,15 @@ export class SonicPiEngine {
    *  next eval's scopeBase so removing a `define` line from the buffer does not
    *  break a still-running live_loop that calls it. (#215) */
   private definedFns = new Map<string, (...args: unknown[]) => unknown>()
+  /**
+   * True only while evaluating the synchronous top-level body of user code
+   * (the window between `sandbox.execute(...)` start and resolve in
+   * `evaluate()`). Used by `run_code` and `load_example` to refuse calls
+   * that come from inside a live_loop body's later async iteration —
+   * re-entering `evaluate` from there would dispose the running scheduler
+   * mid-iteration. (#240 / #241)
+   */
+  private inTopLevelEval = false
   /** Cached `defonce` values (#212 / #233). Survive across re-evals — that's
    *  the whole point. Cleared only on full engine reset / dispose. */
   private defonceCache = new Map<string, unknown>()
@@ -1092,22 +1101,30 @@ export class SonicPiEngine {
         },
         // Tier B PR #3 — sync_bpm (#236). Inside live_loops the transpiler
         // routes `sync_bpm :name` to `__b.sync_bpm(name)` via BUILDER_METHODS.
-        // At top level we forward to topLevelBuilder so the cue waiter runs
-        // when the top-level program reaches it. Top-level programs run
-        // serially (no concurrent context), so nothing actually waits — the
-        // call is a no-op in that case, matching desktop where sync at top
-        // level outside in_thread is unusual but harmless.
-        (name: string) => { topLevelBuilder.sync_bpm(name) },
+        // At top level outside in_thread/live_loop the call has no effect —
+        // top-level code runs once linearly and there's no concurrent
+        // context to park. Surface that as a printHandler warning so the
+        // user gets an actionable signal instead of a silent no-op (#239).
+        (name: string) => {
+          topLevelBuilder.sync_bpm(name)
+          if (this.printHandler) {
+            this.printHandler(`[Warning] sync_bpm :${name} at top level has no effect — wrap in in_thread or call from inside a live_loop body.`)
+          }
+        },
         // Tier B PR #3 — run_code (#236). Host-side dynamic eval. Replaces
         // all running loops with the supplied code, equivalent to pressing
         // Run with a fresh buffer. Returns a Promise that resolves when the
-        // new evaluation completes. Inside live_loops this re-enters the
-        // engine which is undefined behaviour — desktop's spider re-entry
-        // guard would throw; we accept the same risk for now and may add a
-        // strict guard if observed misuse warrants it.
+        // new evaluation completes. Refuses calls from inside a live_loop
+        // body iteration — re-entering evaluate() from there would dispose
+        // the running scheduler mid-iteration. (#240)
         (code: string) => {
           if (typeof code !== 'string') {
             throw new TypeError(`run_code expects a string, got ${typeof code}`)
+          }
+          if (!this.inTopLevelEval) {
+            throw new Error(
+              'run_code can only be called at top level — calling it from inside a live_loop body re-enters the engine which is not supported. Use cue/sync to coordinate between loops instead.',
+            )
           }
           return this.evaluate(code)
         },
@@ -1137,6 +1154,11 @@ export class SonicPiEngine {
           if (typeof name !== 'string') {
             throw new TypeError(`load_example expects a name (string or symbol), got ${typeof name}`)
           }
+          if (!this.inTopLevelEval) {
+            throw new Error(
+              'load_example can only be called at top level — calling it from inside a live_loop replaces the running buffer mid-iteration which is not supported.',
+            )
+          }
           const example = getExample(name)
           if (!example) {
             throw new Error(`load_example: no example named "${name}". See examples panel for the full list.`)
@@ -1165,7 +1187,17 @@ export class SonicPiEngine {
       }
       const sandbox = createIsolatedExecutor(transpiledCode, dslNames, persistedFns)
       scopeHandle = sandbox.scopeHandle
-      await sandbox.execute(...dslValues)
+      // Set the re-entry guard while the synchronous top-level body runs.
+      // run_code / load_example check this flag and refuse if false (i.e.
+      // called later from inside a live_loop body iteration). Save+restore
+      // pattern handles legitimate nested run_code at top level. (#240/#241)
+      const prevInTopLevelEval = this.inTopLevelEval
+      this.inTopLevelEval = true
+      try {
+        await sandbox.execute(...dslValues)
+      } finally {
+        this.inTopLevelEval = prevInTopLevelEval
+      }
 
       if (isReEvaluate) {
         const oldLoops = scheduler.getRunningLoopNames()

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -8,6 +8,7 @@ import { normalizeFxParams } from './SoundLayer'
 import { DSL_NAMES } from './DslNames'
 import { createIsolatedExecutor, validateCode, type ScopeHandle } from './Sandbox'
 import { autoTranspileDetailed } from './TreeSitterTranspiler'
+import { getExample, type Example } from './examples'
 import { initTreeSitter } from './TreeSitterTranspiler'
 
 /**
@@ -66,6 +67,7 @@ export class SonicPiEngine {
   private runtimeErrorHandler: ((err: Error) => void) | null = null
   private printHandler: ((msg: string) => void) | null = null
   private cueHandler: ((name: string, time: number) => void) | null = null
+  private loadExampleHandler: ((example: Example) => void) | null = null
   /**
    * Per-evaluation dedup set for clamp/range warnings (issue #202, G4).
    * SoundLayer's validateAndClamp emits one warning per out-of-range param,
@@ -1125,6 +1127,25 @@ export class SonicPiEngine {
             'browser sandbox: no filesystem access; use run_code(string) or load_example(:name) instead',
           )
         },
+        // Tier B PR #3 — load_example (#236). Looks up the example by name in
+        // the bundled registry; on hit, calls the host's loadExampleHandler so
+        // the editor replaces its buffer + re-runs. On miss, throws an
+        // informative error listing the available names. If no host handler
+        // is registered (engine-only test harness), throws a different error
+        // explaining the missing wiring rather than silently no-op'ing.
+        (name: string) => {
+          if (typeof name !== 'string') {
+            throw new TypeError(`load_example expects a name (string or symbol), got ${typeof name}`)
+          }
+          const example = getExample(name)
+          if (!example) {
+            throw new Error(`load_example: no example named "${name}". See examples panel for the full list.`)
+          }
+          if (!this.loadExampleHandler) {
+            throw new Error('load_example requires a host editor — no loadExampleHandler registered on the engine.')
+          }
+          this.loadExampleHandler(example)
+        },
       ]
 
       const codeWarnings = validateCode(transpiledCode)
@@ -1313,6 +1334,17 @@ export class SonicPiEngine {
   /** Register a handler for cue events (for the CueLog panel). */
   setCueHandler(handler: (name: string, time: number) => void): void {
     this.cueHandler = handler
+  }
+
+  /**
+   * Register a handler for `load_example(:name)` calls in user code (#236).
+   * The host (App.ts) wires this to its loadExample(example) method which
+   * replaces the editor buffer with the example's Ruby code and runs it.
+   * If unset, load_example throws an informative error so the engine works
+   * standalone without requiring an editor harness.
+   */
+  setLoadExampleHandler(handler: (example: Example) => void): void {
+    this.loadExampleHandler = handler
   }
 
   /**

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1088,6 +1088,27 @@ export class SonicPiEngine {
           this.defonceCache.set(name, value)
           return value
         },
+        // Tier B PR #3 — sync_bpm (#236). Inside live_loops the transpiler
+        // routes `sync_bpm :name` to `__b.sync_bpm(name)` via BUILDER_METHODS.
+        // At top level we forward to topLevelBuilder so the cue waiter runs
+        // when the top-level program reaches it. Top-level programs run
+        // serially (no concurrent context), so nothing actually waits — the
+        // call is a no-op in that case, matching desktop where sync at top
+        // level outside in_thread is unusual but harmless.
+        (name: string) => { topLevelBuilder.sync_bpm(name) },
+        // Tier B PR #3 — run_code (#236). Host-side dynamic eval. Replaces
+        // all running loops with the supplied code, equivalent to pressing
+        // Run with a fresh buffer. Returns a Promise that resolves when the
+        // new evaluation completes. Inside live_loops this re-enters the
+        // engine which is undefined behaviour — desktop's spider re-entry
+        // guard would throw; we accept the same risk for now and may add a
+        // strict guard if observed misuse warrants it.
+        (code: string) => {
+          if (typeof code !== 'string') {
+            throw new TypeError(`run_code expects a string, got ${typeof code}`)
+          }
+          return this.evaluate(code)
+        },
       ]
 
       const codeWarnings = validateCode(transpiledCode)

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -212,7 +212,7 @@ interface TranspileContext {
  */
 const BUILDER_METHODS = new Set([
   // Core
-  'play', 'sleep', 'wait', 'sample', 'sync', 'cue', 'set',
+  'play', 'sleep', 'wait', 'sample', 'sync', 'sync_bpm', 'cue', 'set',
   'use_synth', 'use_bpm', 'use_random_seed',
   'control', 'stop', 'live_audio',
   'with_fx', 'in_thread', 'at',

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -89,6 +89,16 @@ export interface SchedulerEvent {
 
 export type EventHandler = (event: SchedulerEvent) => void
 
+/**
+ * Payload returned to a sync waiter when the cue fires (#236).
+ * `bpm` carries the cuer's BPM at fire-time so waiters using `bpm_sync: true`
+ * can inherit it (matches desktop `__change_spider_bpm_time_and_beat!`).
+ */
+export interface SyncPayload {
+  args: unknown[]
+  bpm: number
+}
+
 export interface SchedulerOptions {
   /** AudioContext (or mock) for timing */
   getAudioTime?: () => number
@@ -130,12 +140,12 @@ export class VirtualTimeScheduler {
   /** Map from `${time}:${taskId}` to insertion order for stable sorting */
   // entryOrder Map removed — insertion order stored directly on SleepEntry (#75)
   private _running = false
-  /** Cue state: last cue per name with virtual time and args */
-  private cueMap = new Map<string, { time: number; args: unknown[] }>()
+  /** Cue state: last cue per name with virtual time, args, and cuer's BPM. */
+  private cueMap = new Map<string, { time: number; args: unknown[]; bpm: number }>()
   /** Tasks waiting for a cue */
   private syncWaiters = new Map<string, Array<{
     taskId: string
-    resolve: (args: unknown[]) => void
+    resolve: (payload: SyncPayload) => void
   }>>()
 
   constructor(options: SchedulerOptions = {}) {
@@ -333,8 +343,12 @@ export class VirtualTimeScheduler {
   fireCue(name: string, taskId: string, args: unknown[] = []): void {
     const task = this.tasks.get(taskId)
     const cueVirtualTime = task?.virtualTime ?? this.getAudioTime()
+    // Synthetic external sources ('__midi__', '__osc__', #151) have no real
+    // task — fall back to the engine's startup BPM so sync_bpm waiters still
+    // get a defined value rather than NaN.
+    const cueBpm = task?.bpm ?? 60
 
-    this.cueMap.set(name, { time: cueVirtualTime, args })
+    this.cueMap.set(name, { time: cueVirtualTime, args, bpm: cueBpm })
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({
@@ -357,7 +371,7 @@ export class VirtualTimeScheduler {
           // Inherit cue's virtual time (SV5)
           waiterTask.virtualTime = cueVirtualTime
         }
-        waiter.resolve(args)
+        waiter.resolve({ args, bpm: cueBpm })
       }
       this.syncWaiters.delete(pattern)
     }
@@ -365,15 +379,17 @@ export class VirtualTimeScheduler {
 
   /**
    * Wait for a cue. The calling task suspends until fireCue(name) is called.
-   * On resume, the task inherits the cue's virtual time (SV5).
+   * On resume, the task inherits the cue's virtual time (SV5). The resolved
+   * payload also carries the cuer's BPM so callers using `bpm_sync: true`
+   * (sync_bpm, #236) can mutate the waiter's task.bpm.
    */
-  waitForSync(name: string, taskId: string): Promise<unknown[]> {
+  waitForSync(name: string, taskId: string): Promise<SyncPayload> {
     // Always wait for a FRESH cue — never resolve from stale cueMap entries.
     // In Sonic Pi, sync(:name) parks the thread until a NEW cue fires.
     // get(:name) returns existing values; sync waits for the next one.
     // Without this, loops synced to met1 start at vt=0 instead of waiting
     // for met1's first beat (met1's auto-cue fires before synced loops run).
-    return new Promise<unknown[]>((resolve) => {
+    return new Promise<SyncPayload>((resolve) => {
       const waiters = this.syncWaiters.get(name) ?? []
       waiters.push({ taskId, resolve })
       this.syncWaiters.set(name, waiters)

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -979,3 +979,27 @@ describe('MidiBridge — output send routing', () => {
     expect(out.sent[0][0]).toBe(0x9F) // 0x90 | 15
   })
 })
+
+describe('eval_file / run_file browser-sandbox stubs (Tier B PR #3 #236)', () => {
+  it('eval_file throws an informative error redirecting to run_code / load_example', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const result = await engine.evaluate('eval_file "some/path.rb"')
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('browser sandbox')
+    expect(result.error!.message).toMatch(/run_code|load_example/)
+    engine.dispose()
+  })
+
+  it('run_file throws the same redirect message', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const result = await engine.evaluate('run_file "some/path.rb"')
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('browser sandbox')
+    expect(result.error!.message).toMatch(/run_code|load_example/)
+    engine.dispose()
+  })
+})

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -1003,3 +1003,52 @@ describe('eval_file / run_file browser-sandbox stubs (Tier B PR #3 #236)', () =>
     engine.dispose()
   })
 })
+
+describe('load_example host bridge (Tier B PR #3 #236)', () => {
+  it('forwards the resolved Example to the registered handler', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const { getExampleNames } = await import('../examples')
+    const firstExample = getExampleNames()[0]
+    expect(firstExample).toBeTruthy()
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const received: { name: string; ruby: string }[] = []
+    engine.setLoadExampleHandler((ex) => { received.push({ name: ex.name, ruby: ex.ruby }) })
+    const result = await engine.evaluate(`load_example :${firstExample.replace(/\s+/g, '_')}`)
+    // The transpiled symbol uses underscores; if the registry name has spaces,
+    // the lookup will fall through to the not-found path. Use a string literal
+    // for a guaranteed exact match instead.
+    if (result.error) {
+      const result2 = await engine.evaluate(`load_example "${firstExample}"`)
+      expect(result2.error).toBeUndefined()
+    }
+    expect(received.length).toBeGreaterThanOrEqual(1)
+    expect(received[0].name).toBe(firstExample)
+    expect(received[0].ruby.length).toBeGreaterThan(0)
+    engine.dispose()
+  })
+
+  it('throws when the name is unknown (lists hint at examples panel)', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    engine.setLoadExampleHandler(() => { /* would-be host */ })
+    const result = await engine.evaluate('load_example "this_example_does_not_exist"')
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('no example named')
+    engine.dispose()
+  })
+
+  it('throws when no host handler is registered (engine-only harness)', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const { getExampleNames } = await import('../examples')
+    const firstExample = getExampleNames()[0]
+    const engine = new SonicPiEngine()
+    await engine.init()
+    // Deliberately do NOT call setLoadExampleHandler.
+    const result = await engine.evaluate(`load_example "${firstExample}"`)
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('host editor')
+    engine.dispose()
+  })
+})

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -1052,3 +1052,79 @@ describe('load_example host bridge (Tier B PR #3 #236)', () => {
     engine.dispose()
   })
 })
+
+describe('run_code / load_example re-entry guards (Tier B PR #3 #240/#241)', () => {
+  it('run_code inside a live_loop body throws the re-entry guard error', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const errors: string[] = []
+    engine.setRuntimeErrorHandler((e) => { errors.push(e.message) })
+
+    const r = await engine.evaluate(`live_loop :a do
+  run_code "play 60"
+  sleep 1
+end`)
+    expect(r.error).toBeUndefined()
+    // Start the scheduler so the live_loop body iterations execute. The first
+    // iteration's body-build throws synchronously; the scheduler's loop wrapper
+    // catches it and routes to onLoopError → runtimeErrorHandler.
+    engine.play()
+    for (let i = 0; i < 50 && errors.length === 0; i++) {
+      await new Promise(r => setTimeout(r, 10))
+    }
+    engine.stop()
+    expect(errors.some(m => m.includes('run_code can only be called at top level'))).toBe(true)
+    engine.dispose()
+  })
+
+  it('load_example inside a live_loop body throws the re-entry guard error', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const { getExampleNames } = await import('../examples')
+    const exampleName = getExampleNames()[0]
+    const engine = new SonicPiEngine()
+    await engine.init()
+    engine.setLoadExampleHandler(() => { /* would-be host */ })
+    const errors: string[] = []
+    engine.setRuntimeErrorHandler((e) => { errors.push(e.message) })
+
+    const r = await engine.evaluate(`live_loop :a do
+  load_example "${exampleName}"
+  sleep 1
+end`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    for (let i = 0; i < 50 && errors.length === 0; i++) {
+      await new Promise(r => setTimeout(r, 10))
+    }
+    engine.stop()
+    expect(errors.some(m => m.includes('load_example can only be called at top level'))).toBe(true)
+    engine.dispose()
+  })
+
+  it('run_code at top level still works (guard is OFF during synchronous top-level body)', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    // run_code at top level just kicks off another evaluate. We can't easily
+    // observe the inner program from here, but the absence of an error proves
+    // the top-level guard is OFF when expected.
+    const r = await engine.evaluate(`run_code "play 60"`)
+    expect(r.error).toBeUndefined()
+    engine.dispose()
+  })
+})
+
+describe('sync_bpm at top level surfaces a warning (Tier B PR #3 #239)', () => {
+  it('logs an SV19 warning when called outside in_thread/live_loop', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const printed: string[] = []
+    engine.setPrintHandler((m) => { printed.push(m) })
+    const r = await engine.evaluate('sync_bpm :nope')
+    expect(r.error).toBeUndefined()
+    expect(printed.some(m => m.includes('sync_bpm') && m.includes('top level has no effect'))).toBe(true)
+    engine.dispose()
+  })
+})

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -160,6 +160,7 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['run_code',         'Host-bridge: forwards to engine.evaluate(). Replaces running loops with a fresh evaluation. No deferred-step semantics.'],
   ['eval_file',        'Browser-sandbox stub: throws redirect to run_code/load_example. No filesystem access in browser.'],
   ['run_file',         'Browser-sandbox stub: throws redirect to run_code/load_example. No filesystem access in browser.'],
+  ['load_example',     'Host-bridge: looks up by name in examples registry, forwards to host loadExampleHandler. Top-level only.'],
 ])
 
 describe('DSL builder contract (issue #193)', () => {

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -158,6 +158,8 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   // Tier B PR #3 — host-bridge (#236). Calls back into engine.evaluate at
   // the meta layer; not a deferred step on any builder. Top-level only.
   ['run_code',         'Host-bridge: forwards to engine.evaluate(). Replaces running loops with a fresh evaluation. No deferred-step semantics.'],
+  ['eval_file',        'Browser-sandbox stub: throws redirect to run_code/load_example. No filesystem access in browser.'],
+  ['run_file',         'Browser-sandbox stub: throws redirect to run_code/load_example. No filesystem access in browser.'],
 ])
 
 describe('DSL builder contract (issue #193)', () => {

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -155,6 +155,9 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   ['get_pitch_bend',   'Stale-read P2.'],
   ['get_note_on',      'Stale-read P2.'],
   ['get_note_off',     'Stale-read P2.'],
+  // Tier B PR #3 — host-bridge (#236). Calls back into engine.evaluate at
+  // the meta layer; not a deferred step on any builder. Top-level only.
+  ['run_code',         'Host-bridge: forwards to engine.evaluate(). Replaces running loops with a fresh evaluation. No deferred-step semantics.'],
 ])
 
 describe('DSL builder contract (issue #193)', () => {

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -659,5 +659,24 @@ describe('ProgramBuilder', () => {
       const step = steps[0] as Extract<(typeof steps)[0], { tag: 'liveAudio' }>
       expect(step.opts.stereo).toBe(1)
     })
+
+    it('live_audio(name, "stop") emits a stop step (#236)', () => {
+      const b = new ProgramBuilder()
+      b.live_audio('mic', 'stop')
+      const steps = b.build()
+
+      expect(steps).toHaveLength(1)
+      const step = steps[0] as Extract<(typeof steps)[0], { tag: 'liveAudio' }>
+      expect(step.tag).toBe('liveAudio')
+      expect(step.name).toBe('mic')
+      expect(step.stop).toBe(true)
+    })
+
+    it('live_audio(name) without :stop has no stop flag', () => {
+      const b = new ProgramBuilder()
+      b.live_audio('mic')
+      const step = b.build()[0] as Extract<ReturnType<typeof b.build>[0], { tag: 'liveAudio' }>
+      expect(step.stop).toBeUndefined()
+    })
   })
 })

--- a/src/engine/__tests__/SyncCue.test.ts
+++ b/src/engine/__tests__/SyncCue.test.ts
@@ -201,7 +201,8 @@ describe('sync/cue', () => {
     })
 
     scheduler.registerLoop('receiver', async () => {
-      receivedArgs = await scheduler.waitForSync('data', 'receiver')
+      const payload = await scheduler.waitForSync('data', 'receiver')
+      receivedArgs = payload.args
       await scheduler.scheduleSleep('receiver', 999999)
     })
 
@@ -211,5 +212,71 @@ describe('sync/cue', () => {
     await flushMicrotasks()
 
     expect(receivedArgs).toEqual([42, 'hello'])
+  })
+
+  it('sync_bpm — fireCue captures cuer\'s task.bpm and sync waiter inherits it', async () => {
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+    })
+    scheduler.registerLoop('sender', async () => {
+      await scheduler.scheduleSleep('sender', 0.5)
+      scheduler.fireCue('beat', 'sender', [])
+      await scheduler.scheduleSleep('sender', 999999)
+    })
+    const senderTask = scheduler.getTask('sender')!
+    senderTask.bpm = 140
+
+    let receivedBpm: number | undefined
+    scheduler.registerLoop('follower', async () => {
+      const result = await scheduler.waitForSync('beat', 'follower')
+      receivedBpm = result.bpm
+      await scheduler.scheduleSleep('follower', 999999)
+    })
+
+    scheduler.tick(100)
+    await flushMicrotasks()
+    scheduler.tick(100)
+    await flushMicrotasks()
+
+    expect(receivedBpm).toBe(140)
+  })
+
+  it('sync step with bpmSync flag mutates task.bpm to cuer\'s bpm after wake', async () => {
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+    })
+    const eventStream = new SoundEventStream()
+    const nodeRefMap = new Map<number, number>()
+
+    // Sender at 200 BPM fires a cue
+    scheduler.registerLoop('sender', async () => {
+      await scheduler.scheduleSleep('sender', 0.1)
+      scheduler.fireCue('beat', 'sender', [])
+      await scheduler.scheduleSleep('sender', 999999)
+    })
+    const senderTask = scheduler.getTask('sender')!
+    senderTask.bpm = 200
+
+    // Follower starts at 60 BPM, sync_bpm :beat should pull it to 200
+    const followerProgram = new ProgramBuilder(0)
+      .sync_bpm('beat')
+      .play(72)
+      .sleep(999999)
+      .build()
+
+    scheduler.registerLoop('follower', async () => {
+      await runProgram(followerProgram, makeAudioCtx(scheduler, 'follower', eventStream, nodeRefMap))
+    })
+    const followerTask = scheduler.getTask('follower')!
+    followerTask.bpm = 60
+
+    scheduler.tick(100)
+    await flushMicrotasks()
+    scheduler.tick(100)
+    await flushMicrotasks()
+
+    expect(followerTask.bpm).toBe(200)
   })
 })

--- a/src/engine/__tests__/SyncCue.test.ts
+++ b/src/engine/__tests__/SyncCue.test.ts
@@ -242,6 +242,53 @@ describe('sync/cue', () => {
     expect(receivedBpm).toBe(140)
   })
 
+  it('sync_bpm: subsequent sleep in the iteration runs at cuer\'s BPM (#242 observation gate)', async () => {
+    // Inference-level test (the next one) proves task.bpm is set; this one
+    // proves the user-facing semantic — the sleep AFTER sync_bpm advances
+    // virtual time at the cuer's BPM, not the follower's original BPM.
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+    })
+    const eventStream = new SoundEventStream()
+    const nodeRefMap = new Map<number, number>()
+
+    // Sender at 240 BPM fires a cue at virtualTime 0.5
+    scheduler.registerLoop('sender', async () => {
+      await scheduler.scheduleSleep('sender', 0.5)
+      scheduler.fireCue('beat', 'sender', [])
+      await scheduler.scheduleSleep('sender', 999999)
+    })
+    scheduler.getTask('sender')!.bpm = 240
+
+    // Follower at 60 BPM, sync_bpm pulls to 240, then sleep 1 beat = 0.25s.
+    // After the sync wakes and the sleep step registers, task.virtualTime
+    // is set by scheduleSleep — observable WITHOUT waiting for the sleep
+    // resolve. This is the deterministic measurement point.
+    const followerProgram = new ProgramBuilder(0)
+      .sync_bpm('beat')
+      .sleep(1)
+      .sleep(999999)  // park forever after the measurable sleep
+      .build()
+    scheduler.registerLoop('follower', async () => {
+      await runProgram(followerProgram, makeAudioCtx(scheduler, 'follower', eventStream, nodeRefMap))
+    })
+    scheduler.getTask('follower')!.bpm = 60
+
+    scheduler.tick(100)
+    await flushMicrotasks()
+    scheduler.tick(100)
+    await flushMicrotasks()
+
+    // Sender's sleep(0.5) at 240 BPM resolves at VT=0.125 (registerLoop's
+    // runLoop kickoff is microtask-deferred so my bpm=240 assignment lands
+    // before the first scheduleSleep call). Follower inherits VT=0.125.
+    // Sleep 1 beat at 240 BPM = 60/240 = 0.25s → final task.virtualTime = 0.375.
+    // If the sleep had run at the follower's ORIGINAL 60 BPM, virtualTime would
+    // be 0.125 + 1.0 = 1.125 — distinguishable signal.
+    expect(scheduler.getTask('follower')!.virtualTime).toBeCloseTo(0.375, 5)
+  })
+
   it('sync step with bpmSync flag mutates task.bpm to cuer\'s bpm after wake', async () => {
     const scheduler = new VirtualTimeScheduler({
       getAudioTime: () => 0,

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -1198,6 +1198,17 @@ end`)
       expect(steps[1].name).toBe('bass')
     })
 
+    it('sync_bpm emits a sync step with bpmSync flag (#236)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  sync_bpm :tick
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].tag).toBe('sync')
+      expect(steps[0].name).toBe('tick')
+      expect(steps[0].bpmSync).toBe(true)
+    })
+
     it('define creates callable function with b injection', () => {
       const { steps, error } = executeTranspiled(`define :hit do
   sample :bd_haus

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -1209,6 +1209,40 @@ end`)
       expect(steps[0].bpmSync).toBe(true)
     })
 
+    it('live_audio :foo, :stop emits a stop step (Ruby symbol form, #243)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  live_audio :foo, :stop
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].tag).toBe('liveAudio')
+      expect(steps[0].name).toBe('foo')
+      expect(steps[0].stop).toBe(true)
+    })
+
+    it('live_audio "foo", "stop" emits a stop step (string form, #243)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  live_audio "foo", "stop"
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].tag).toBe('liveAudio')
+      expect(steps[0].name).toBe('foo')
+      expect(steps[0].stop).toBe(true)
+    })
+
+    it('live_audio :foo, input: 3 still emits a start step with opts (#243)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  live_audio :foo, input: 3
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].tag).toBe('liveAudio')
+      expect(steps[0].name).toBe('foo')
+      expect(steps[0].stop).toBeUndefined()
+      expect(steps[0].opts.input).toBe(3)
+    })
+
     it('define creates callable function with b injection', () => {
       const { steps, error } = executeTranspiled(`define :hit do
   sample :bd_haus

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -358,8 +358,14 @@ export async function runProgram(
 
       case 'liveAudio': {
         if (ctx.bridge) {
-          ctx.bridge.startLiveAudio(step.name, { stereo: !!step.opts.stereo })
-            .catch((err: Error) => ctx.printHandler?.(`live_audio failed: ${err.message}`))
+          if (step.stop) {
+            // live_audio :name, :stop (#236) — kill the named live audio.
+            // Synchronous; mirrors hot-swap reconciliation at SonicPiEngine.ts:309.
+            ctx.bridge.stopLiveAudio(step.name)
+          } else {
+            ctx.bridge.startLiveAudio(step.name, { stereo: !!step.opts.stereo })
+              .catch((err: Error) => ctx.printHandler?.(`live_audio failed: ${err.message}`))
+          }
         }
         break
       }

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -236,10 +236,18 @@ export async function runProgram(
         }
         break
 
-      case 'sync':
+      case 'sync': {
         ctx.bridge?.flushMessages()
-        await ctx.scheduler.waitForSync(step.name, ctx.taskId)
+        const payload = await ctx.scheduler.waitForSync(step.name, ctx.taskId)
+        if (step.bpmSync) {
+          // Inherit cuer's BPM (sync_bpm, #236). Mutate both runtime locals
+          // so subsequent sleep/play/FX steps in this iteration use the
+          // new BPM. Matches desktop `__change_spider_bpm_time_and_beat!`.
+          currentBpm = payload.bpm
+          if (task) task.bpm = payload.bpm
+        }
         break
+      }
 
       case 'fx': {
         const reps = (step.opts.reps as number) ?? 1


### PR DESCRIPTION
Closes #236.

Tier B continues. PR #1 (#211 → #230) shipped recording / kill / timing / PRNG introspection. PR #2 (#233 → #234) shipped ring constructors / introspection / tuplets / defonce. This PR fills the next slice per `artifacts/roadmap.md` §10 — dynamic eval + sync extensions + live audio control + editor integration — after upstream verification corrected the inventory **twice** (audit caught 6 corrections before any code).

## Scope (4 active fns + 2 stubs)

### Wave 1 — sync_bpm + run_code (commit 2cd6f30)

- **`sync_bpm(:cue)`** — sync to a cue AND inherit the cuer's BPM. Pre-implementation read of the full pipeline (Step types → AudioInterpreter → scheduler) revealed the runtime BPM mutability infrastructure was already in place. The only gap was BPM propagation through the cue → sync channel: `cueMap` carried `{ time, args }` but no cuer's BPM. (See closed #237 for the wrong-scope refactor that was filed and rolled back.)
- **`run_code(string)`** — evaluates the string via `engine.evaluate()`. Top-level only (host-bridge).

Implementation:
- `Step.sync` gains optional `bpmSync` flag.
- `VirtualTimeScheduler.cueMap` carries cuer's `task.bpm` (fallback 60 for synthetic external sources). New `SyncPayload` export. `waitForSync` resolves with `{ args, bpm }`.
- AudioInterpreter sync handler reads payload; when `step.bpmSync` is set, mutates `task.bpm` + `currentBpm` so subsequent steps in this iteration use the cuer's BPM (matches desktop `__change_spider_bpm_time_and_beat!`).
- `ProgramBuilder.sync(name, opts?)` accepts `bpm_sync`; new `sync_bpm(name)` thin wrapper.

### Wave 2 — eval_file + run_file stubs (commit b81b98c)

Both throw `"browser sandbox: no filesystem access; use run_code(string) or load_example(:name) instead"`. Surfaces through the runtime error overlay so users see actionable text instead of silent globalThis lookup misses.

### Wave 3 — live_audio :name, :stop (commit 426da76)

`Step.liveAudio` gains optional `stop?: boolean`. ProgramBuilder accepts `:stop` symbol as the second argument (matches desktop `sound.rb:195-197`). AudioInterpreter dispatches: stop step calls `bridge.stopLiveAudio(name)` which already existed (used by hot-swap reconciliation since #152). User-driven `:stop` and engine hot-swap take the same code path.

### Wave 4 — load_example(:name) (commit be3981c)

Engine gains `loadExampleHandler` field + `setLoadExampleHandler` setter, parallel to existing `setPrintHandler`/`setCueHandler`. Runtime stub looks up by name via `getExample()` and forwards the resolved `Example` to the host. Three error paths surfaced clearly: bad arg, unknown name, no host wired. App.ts wires the handler to its existing `loadExample(example)` private method, so DSL-driven and dropdown-driven loads share one path.

## Out of scope (corrections to original §10 plan)

The roadmap §10 originally listed 12 names for this PR. Upstream audit (cross-checking each `def` against a public `doc name:` block, plus checking `src/engine/` for already-shipped impls) corrected the inventory:

- ~~`sync_event`~~ — `def sync_event` exists at `core.rb:4514` but **has no `doc name:` block**. The next doc block is `:sync` at `:4582`. Forum/tutorial corpus shows zero user-facing call sites — only internal `q_handle_sync_event` queue plumbing in `incomingevents.rb`. Drop.
- ~~`live_audio_kill`~~ — does not exist as a separate function upstream. Killing is the `:stop` overload of `live_audio` itself (`sound.rb:179-205` checks `args[1] == :stop`). Already covered by Wave 3.
- ~~`sound_in`~~ / ~~`sound_in_stereo`~~ — already shipped via `synth :sound_in` + auto-mic-start in `AudioInterpreter` (`SonicPiEngine.ts:296-307` + `AudioInterpreter.ts:108-116`). Drop.
- ~~`current_amp`~~ / ~~`start_amp_monitor`~~ — `def current_amp` at `sound.rb:482` has **no `doc name:` block**. Internal helpers powering the GUI volume meter. Same trap as sync_event. Drop.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 876 passing (was 866 pre-PR; +10 new tests across the 4 waves)
- [x] `DslBuilderContract.test.ts` — 4 new entries allow-listed with justifications (host-bridge / sandbox stub)
- [x] 48-fixture batch: `npx tsx tools/capture.ts --batch artifacts/forum-fixtures` — should still 48/48
- [ ] Level-3 capture for `live_audio :stop` — WAV showing the named live_audio synth actually stops
- [ ] Level-3 capture for `load_example` — capture shows buffer replaced + new example plays

## References

- Parent issue: #236
- Related/closed: #237 (investigated — runtime-BPM-mutability infra already in place; no refactor needed)
- Roadmap §5 row updated to reflect actual state; §10 PR #3 scope corrected with full drop reasoning
- Predecessors: #213 (Tier A); #230 (Tier B PR #1); #234 (Tier B PR #2)