### PR TITLE
fix(host): load_example replay unconditional on first run

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -1105,13 +1105,24 @@ export class App {
     this.saveBuffers()
     this.sessionLog.logLoadExample(example.name, example.ruby)
     this.console.logSystem(`  Loaded: ${example.name} — ${example.description}`)
-    if (this.playing) {
-      this.engine!.stop()
-      // Wait for pre-scheduled audio in the lookahead buffer to drain before
-      // starting the new example — otherwise scsynth plays the tail of the old one.
-      await new Promise(r => setTimeout(r, this.engine!.schedAhead * 1000 + 50))
-      await this.handlePlay()
+    // Always replay so the DSL `load_example "..."` works on first run.
+    // The previous `if (this.playing)` guard raced with handlePlay setting
+    // playing=true AFTER `await evaluate` returned — meaning the DSL handler
+    // (fire-and-forget from inside evaluate) saw playing=false and skipped.
+    //
+    // The setTimeout yield is mandatory: when triggered from the DSL, we are
+    // synchronously inside the outer evaluate. engine.evaluate is not
+    // reentrant — we must let the outer call finish before recursing into
+    // handlePlay. The drain delay also lets pre-scheduled audio in the
+    // lookahead buffer flush so scsynth doesn't play the tail of the old run.
+    if (this.engine && this.playing) {
+      const drainMs = this.engine.schedAhead * 1000 + 50
+      this.engine.stop()
+      await new Promise(r => setTimeout(r, drainMs))
+    } else {
+      await new Promise(r => setTimeout(r, 0))
     }
+    await this.handlePlay()
   }
 
   private async handleSave(): Promise<void> {

--- a/tools/capture-level3-pr238.ts
+++ b/tools/capture-level3-pr238.ts
@@ -194,10 +194,9 @@ async function testLiveAudioStop() {
 
 async function testLoadExample() {
   console.log('\n=== TEST 2: load_example(:name) — buffer replaced + new example plays ===')
-  console.log('  Note: tests the "already playing" path. The first-run path has a')
-  console.log('  pre-existing host race in App.handlePlay (this.playing set AFTER')
-  console.log('  evaluate completes, so loadExample\'s `if (this.playing)` check')
-  console.log('  fails on first run — tracked separately).')
+  console.log('  Tests the "already playing" path: a buzz live_loop runs first,')
+  console.log('  then load_example "Basic Beat" replaces the buffer + auto-replays.')
+  console.log('  TEST 3 covers the first-run path (#246 fix).')
   const browser = await chromium.launch({
     headless: false,
     args: ['--autoplay-policy=no-user-gesture-required'],
@@ -255,18 +254,73 @@ async function testLoadExample() {
   return pass
 }
 
+async function testLoadExampleFirstRun() {
+  console.log('\n=== TEST 3: load_example(:name) on FIRST RUN (#246 fix) ===')
+  console.log('  Engine has never played. Buffer = `load_example "Basic Beat"`.')
+  console.log('  Without the fix, loadExample\'s `if (this.playing)` guard saw')
+  console.log('  playing=false (set AFTER await evaluate) and silently skipped')
+  console.log('  the replay. With the fix, the buffer replays unconditionally.')
+  const browser = await chromium.launch({
+    headless: false,
+    args: ['--autoplay-policy=no-user-gesture-required'],
+  })
+  const page = await setupPage(browser, 'load_example_first_run')
+
+  // Step 1 — fresh app, engine never played. Run `load_example "Basic Beat"`.
+  await setEditorAndRun(page, `load_example "Basic Beat"`)
+
+  // Poll for buffer replacement to "Basic Beat" content. Longer window than
+  // Test 2 because the fresh-engine init (~2-4s) happens inline.
+  let editorContent = ''
+  for (let i = 0; i < 80; i++) {
+    editorContent = await readEditor(page)
+    if (editorContent.includes('live_loop :drums') && editorContent.includes('bd_haus')) break
+    await page.waitForTimeout(150)
+  }
+  const bufferReplaced = editorContent.includes('live_loop :drums') &&
+                          editorContent.includes('bd_haus') &&
+                          editorContent.includes('sn_dub')
+  console.log(`  Buffer replaced to Basic Beat: ${bufferReplaced ? '✓' : '✗'}`)
+
+  // Wait for the recursive handlePlay's evaluate + drums to start playing.
+  await page.waitForTimeout(2500)
+
+  const wav = await recordFor(page, 4000)
+  await browser.close()
+
+  if (!wav) {
+    console.log('  ✗ FAIL — no WAV captured')
+    return false
+  }
+  const wavPath = resolve(OUT_DIR, 'load_example_first_run.wav')
+  writeFileSync(wavPath, wav)
+
+  const stats = analyzeWav(wav)
+  console.log(`  WAV: ${wavPath}`)
+  console.log(`  duration=${stats.duration.toFixed(2)}s  peak=${stats.peak.toFixed(4)}  rms=${stats.rms.toFixed(4)}`)
+
+  // Acceptance: peak > 0.01 (drum hits audible), buffer replaced.
+  const audible = stats.peak > 0.01
+  const pass = bufferReplaced && audible
+  console.log(`  Verdict: ${pass ? '✓ PASS' : '✗ FAIL'} — buffer replaced (${bufferReplaced}), example audible (${audible})`)
+  return pass
+}
+
 async function main() {
   const results = {
     live_audio_stop: false,
     load_example: false,
+    load_example_first_run: false,
   }
   results.live_audio_stop = await testLiveAudioStop()
   results.load_example = await testLoadExample()
+  results.load_example_first_run = await testLoadExampleFirstRun()
 
   console.log('\n=== SUMMARY ===')
-  console.log(`  live_audio :stop: ${results.live_audio_stop ? '✓ PASS' : '✗ FAIL'}`)
-  console.log(`  load_example:     ${results.load_example ? '✓ PASS' : '✗ FAIL'}`)
-  process.exit((results.live_audio_stop && results.load_example) ? 0 : 1)
+  console.log(`  live_audio :stop:           ${results.live_audio_stop ? '✓ PASS' : '✗ FAIL'}`)
+  console.log(`  load_example (replay):      ${results.load_example ? '✓ PASS' : '✗ FAIL'}`)
+  console.log(`  load_example (first run):   ${results.load_example_first_run ? '✓ PASS' : '✗ FAIL'}`)
+  process.exit((results.live_audio_stop && results.load_example && results.load_example_first_run) ? 0 : 1)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Fixes the silent first-run path for the `load_example "..."` DSL: pressing Run on a fresh buffer whose only content is `load_example "Basic Beat"` replaced the editor text but produced no audio.

## Root cause

`App.handlePlay` sets `this.playing = true` *after* `await engine.evaluate(code)` resolves. The DSL's `load_example` handler fires fire-and-forget *inside* evaluate, so `App.loadExample`'s `if (this.playing)` guard always evaluated to `false` on first run and silently skipped the stop+replay branch.

## Fix

Drop the `if (this.playing)` guard in `App.loadExample`. Always yield via `setTimeout` (mandatory — `engine.evaluate` is not reentrant; the outer call must finish before we recurse into `handlePlay`) and always call `handlePlay` against the freshly replaced buffer. The stop+drain delay stays conditional on `this.playing` so menu picks while stopped don't churn the scheduler.

Side effect: picking an example from the View > Examples menu while stopped will now autoplay it. Acceptable per the issue (Option B was the recommended fix).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 884/884 pass
- [x] `tools/capture-level3-pr238.ts` — all three tests pass (Level-3 WAV observation)
  - TEST 1 (live_audio :stop): first half audible, second silent ✓
  - TEST 2 (load_example replay path): peak 1.0, RMS 0.0858 ✓
  - **TEST 3 (load_example first-run path, NEW): peak 0.2363, RMS 0.0416 ✓**

Closes #246