### PR TITLE
chore(polish): DEFAULT_TASK_BPM constant, Step.sync.bpmSync tightening, deterministic load_example test

### DIFF
--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -14,7 +14,10 @@ export type Step =
   | { tag: 'useBpm'; bpm: number }
   | { tag: 'control'; nodeRef: number; params: Record<string, number> }
   | { tag: 'cue'; name: string; args?: unknown[] }
-  | { tag: 'sync'; name: string; bpmSync?: boolean }
+  // bpmSync is `?: true` (not `?: boolean`): ProgramBuilder.sync_bpm pushes
+  // the flag only when set, so the field is either absent or `true` — the
+  // tighter type makes the discriminator unambiguous.
+  | { tag: 'sync'; name: string; bpmSync?: true }
   | { tag: 'fx'; name: string; opts: Record<string, number>; body: Program; nodeRef?: number }
   | { tag: 'thread'; body: Program }
   | { tag: 'print'; message: string }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -45,6 +45,13 @@ export const DEFAULT_SCHED_AHEAD_TIME = 0.3
 export const DEFAULT_TICK_INTERVAL_MS = 25
 
 /**
+ * Fallback BPM used by `fireCue` for synthetic external sources (`__midi__`,
+ * `__osc__`) whose tasks aren't tracked. Matches `SonicPiEngine`'s startup
+ * `defaultBpm = 60`. If you change one, change the other.
+ */
+export const DEFAULT_TASK_BPM = 60
+
+/**
  * Tiebreak weight applied to insertion order when two sleep entries share the same
  * virtual time. 1e-12 s is far below any audio scheduling precision (≥1 ms), so it
  * never shifts actual timing — it only produces a deterministic total order in the heap.
@@ -93,6 +100,11 @@ export type EventHandler = (event: SchedulerEvent) => void
  * Payload returned to a sync waiter when the cue fires (#236).
  * `bpm` carries the cuer's BPM at fire-time so waiters using `bpm_sync: true`
  * can inherit it (matches desktop `__change_spider_bpm_time_and_beat!`).
+ *
+ * Breaking change since v1.5.x: `waitForSync` previously returned
+ * `Promise<unknown[]>`. External embedders calling `scheduler.waitForSync`
+ * directly should migrate `args = await waitForSync(...)` to
+ * `{ args } = await waitForSync(...)`.
  */
 export interface SyncPayload {
   args: unknown[]
@@ -346,7 +358,7 @@ export class VirtualTimeScheduler {
     // Synthetic external sources ('__midi__', '__osc__', #151) have no real
     // task — fall back to the engine's startup BPM so sync_bpm waiters still
     // get a defined value rather than NaN.
-    const cueBpm = task?.bpm ?? 60
+    const cueBpm = task?.bpm ?? DEFAULT_TASK_BPM
 
     this.cueMap.set(name, { time: cueVirtualTime, args, bpm: cueBpm })
 

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -1005,26 +1005,46 @@ describe('eval_file / run_file browser-sandbox stubs (Tier B PR #3 #236)', () =>
 })
 
 describe('load_example host bridge (Tier B PR #3 #236)', () => {
-  it('forwards the resolved Example to the registered handler', async () => {
+  it('forwards the resolved Example to the registered handler (string form)', async () => {
     const { SonicPiEngine } = await import('../SonicPiEngine')
     const { getExampleNames } = await import('../examples')
+    // Use the string form unconditionally — exact match against the registry
+    // name regardless of spaces. Symbols only work for space-free names; the
+    // earlier hedged variant masked which path was actually exercised.
     const firstExample = getExampleNames()[0]
     expect(firstExample).toBeTruthy()
     const engine = new SonicPiEngine()
     await engine.init()
     const received: { name: string; ruby: string }[] = []
     engine.setLoadExampleHandler((ex) => { received.push({ name: ex.name, ruby: ex.ruby }) })
-    const result = await engine.evaluate(`load_example :${firstExample.replace(/\s+/g, '_')}`)
-    // The transpiled symbol uses underscores; if the registry name has spaces,
-    // the lookup will fall through to the not-found path. Use a string literal
-    // for a guaranteed exact match instead.
-    if (result.error) {
-      const result2 = await engine.evaluate(`load_example "${firstExample}"`)
-      expect(result2.error).toBeUndefined()
-    }
-    expect(received.length).toBeGreaterThanOrEqual(1)
+    const result = await engine.evaluate(`load_example "${firstExample}"`)
+    expect(result.error).toBeUndefined()
+    expect(received.length).toBe(1)
     expect(received[0].name).toBe(firstExample)
     expect(received[0].ruby.length).toBeGreaterThan(0)
+    engine.dispose()
+  })
+
+  it('forwards via the symbol form for space-free example names', async () => {
+    const { SonicPiEngine } = await import('../SonicPiEngine')
+    const { getExampleNames } = await import('../examples')
+    // Pick the first registry name that's a valid bare Ruby symbol so we're
+    // exercising the symbol-resolution path, not the string-literal path.
+    const spaceFree = getExampleNames().find(n => /^[A-Za-z_]\w*$/.test(n))
+    if (!spaceFree) {
+      // No space-free names in the bundled registry — symbol path can't be
+      // tested with current fixtures. The string-form test above still covers
+      // the handler-forwarding contract.
+      return
+    }
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const received: { name: string; ruby: string }[] = []
+    engine.setLoadExampleHandler((ex) => { received.push({ name: ex.name, ruby: ex.ruby }) })
+    const result = await engine.evaluate(`load_example :${spaceFree}`)
+    expect(result.error).toBeUndefined()
+    expect(received.length).toBe(1)
+    expect(received[0].name).toBe(spaceFree)
     engine.dispose()
   })
 


### PR DESCRIPTION
## Summary

Polish bundle from the PR #238 critical self-review. Three small items, no behavior change.

## Changes

- **#244 — Deterministic load_example test:** the prior test tried the symbol form then fell back to the string form on error, masking which path was actually exercised. Split into two tests: a string-form test that runs unconditionally, and a symbol-form test that filters for a space-free registry name (skips if none exists).
- **#245 G4 — Named constant for fireCue fallback BPM:** \`task?.bpm ?? 60\` becomes \`task?.bpm ?? DEFAULT_TASK_BPM\` with a top-level export and doc comment noting the coupling to \`SonicPiEngine.defaultBpm\`.
- **#245 G5 — Tighten \`Step.sync.bpmSync\` type:** \`?: boolean\` → \`?: true\` (ProgramBuilder.sync_bpm only ever pushes \`true\`; absent means false).
- **#245 G11 — SyncPayload migration comment:** added a doc comment to \`SyncPayload\` pointing external embedders at the shape change since v1.5.x (\`Promise<unknown[]>\` → \`Promise<SyncPayload>\`).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 885/885 pass (was 884; new symbol-form test adds 1)

Closes #244, #245