### PR TITLE
🐛 fix(engine): hot-swap nested live_loop inner body on Run (#199)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -686,6 +686,13 @@ export class SonicPiEngine {
           const existing = scheduler.getTask(name)
           if (existing && existing.running) {
             scheduler.hotSwap(name, asyncFn)
+            // Mirror the regular hot-swap path (#262): freeAllNodes ran during
+            // the outer's reEvaluate, so the inner's old loopBus is dead. Bind
+            // task.outBus to the freshly-allocated bus, and refresh bpm /
+            // currentSynth so a top-level use_bpm/use_synth change propagates.
+            existing.bpm = defaultBpm
+            existing.currentSynth = defaultSynth
+            existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
             scheduler.registerLoop(name, asyncFn, { bpm: defaultBpm, synth: defaultSynth })

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -676,7 +676,23 @@ export class SonicPiEngine {
           scheduler.fireCue(name, name)
         }
 
-        if (isReEvaluate) {
+        if (this.buildNestingDepth > 0 && isReEvaluate) {
+          // Nested hot-swap (issue #199): this call is firing from inside an
+          // outer live_loop's iteration, AFTER the top-level evaluate()'s
+          // pendingLoops reconciliation has already completed. Routing
+          // through pendingLoops would be futile — nobody picks up the entry.
+          // Hot-swap directly via the scheduler to refresh the inner closure
+          // (SV6: preserves virtualTime, bpm, density, random state).
+          const existing = scheduler.getTask(name)
+          if (existing && existing.running) {
+            scheduler.hotSwap(name, asyncFn)
+          } else {
+            // New inner declared during hot-swap (e.g. user added it on Run).
+            scheduler.registerLoop(name, asyncFn, { bpm: defaultBpm, synth: defaultSynth })
+            const task = scheduler.getTask(name)
+            if (task) task.outBus = loopBus
+          }
+        } else if (isReEvaluate) {
           pendingLoops.set(name, asyncFn)
           pendingDefaults.set(name, { bpm: defaultBpm, synth: defaultSynth })
         } else {

--- a/src/engine/__tests__/SonicPiEngine.test.ts
+++ b/src/engine/__tests__/SonicPiEngine.test.ts
@@ -312,6 +312,87 @@ live_loop("drums", (b) => {
     engine.dispose()
   })
 
+  // Issue #199 — nested live_loop inner body must hot-swap on Run.
+  // Pre-fix, the inner's asyncFn closure was never replaced because the
+  // synchronous inner registration fired inside the outer's iteration
+  // (after the top-level evaluate's pendingLoops had already been
+  // reconciled), so the new inner closure went into a dead map. Inner
+  // kept playing the OLD body forever. The fix routes nested+isReEvaluate
+  // through scheduler.hotSwap() directly, preserving virtualTime (SV6).
+  it('nested live_loop inner body refreshes on hot-swap (#199)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    // First evaluate — inner plays note 60.
+    await engine.evaluate(`
+      live_loop :outer do
+        live_loop :inner do
+          play 60
+          sleep 1
+        end
+        sleep 4
+      end
+    `)
+    engine.play()
+
+    type Sched = {
+      tick: (t: number) => void
+      getTask: (n: string) => { virtualTime: number } | undefined
+    }
+    const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+
+    // Tick enough for the outer to iterate at least twice (forces the
+    // first-occurrence-wins guard to be exercised) and for inner to play.
+    for (let i = 0; i < 3; i++) {
+      scheduler.tick(20)
+      await new Promise((r) => setTimeout(r, 5))
+    }
+    const innerVtBefore = scheduler.getTask('inner')!.virtualTime
+
+    const innerNotesBefore = events
+      .filter((e) => e.trackId === 'inner' && e.midiNote !== null)
+      .map((e) => e.midiNote)
+    expect(innerNotesBefore.length).toBeGreaterThan(0)
+    expect(innerNotesBefore.every((n) => n === 60)).toBe(true)
+
+    // Hot-swap: same outer, inner body now plays 72.
+    events.length = 0
+    await engine.evaluate(`
+      live_loop :outer do
+        live_loop :inner do
+          play 72
+          sleep 1
+        end
+        sleep 4
+      end
+    `)
+
+    // Outer iterates after the swap, re-declares the inner — that path is
+    // the one #199 fixed. Tick to let the new inner closure run.
+    for (let i = 0; i < 4; i++) {
+      scheduler.tick(20)
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    const innerNotesAfter = events
+      .filter((e) => e.trackId === 'inner' && e.midiNote !== null)
+      .map((e) => e.midiNote)
+    expect(innerNotesAfter.length).toBeGreaterThan(0)
+    // Pre-fix: every entry would still be 60. Fixed: post-swap entries are 72.
+    expect(innerNotesAfter.some((n) => n === 72)).toBe(true)
+    expect(innerNotesAfter.every((n) => n === 72)).toBe(true)
+
+    // SV6: hot-swap preserves virtualTime (inner's clock keeps moving forward,
+    // not reset to a fresh task's now).
+    const innerVtAfter = scheduler.getTask('inner')!.virtualTime
+    expect(innerVtAfter).toBeGreaterThanOrEqual(innerVtBefore)
+
+    engine.dispose()
+  })
+
   it('eventStream receives events during playback', async () => {
     const engine = new SonicPiEngine()
     await engine.init()


### PR DESCRIPTION
## Summary

- Phase D.5 made nested live_loop register on first occurrence only (correct for the bus-leak fix in #198), but this introduced a hot-swap regression: editing an inner live_loop body and hitting Run did not refresh the inner's closure — it kept playing the OLD body forever.
- Fix routes the nested+isReEvaluate path directly through `scheduler.hotSwap()` (existing inner → swap) or `scheduler.registerLoop()` (newly added inner), bypassing `pendingLoops` which is already reconciled by the time the synchronous inner registration fires from inside the outer's iteration.
- `scheduler.hotSwap()` preserves virtualTime, bpm, density, and random state — invariant SV6.

## Mechanism (the bug, in one paragraph)

`pendingLoops.set(name, asyncFn)` is reconciled once, at the end of the top-level `evaluate()` call. When the outer's NEW asyncFn (post-hot-swap) iterates LATER on an async tick and synchronously calls inner's `live_loop(...)`, the call lands in the OLD `pendingLoops` map whose owner has already finished. Nobody picks it up. Inner runs with the closure from the FIRST evaluate forever.

## Acceptance (mirrors #199's checklist)

- [x] Edit inner body, Run, assert inner's next iteration uses new closure
- [x] Outer hot-swap unaffected by the change (existing tests still pass)
- [x] New regression test in SonicPiEngine.test.ts asserting note transition 60 → 72 across hot-swap, plus virtualTime monotonicity (SV6)

## Test plan

- [x] `npx vitest run` — 929 / 929 passing (one new test added)
- [x] `npx tsc --noEmit` — zero errors
- [x] `#198` no-op-on-second-occurrence semantic still holds (initial Run path is unchanged — only the `isReEvaluate && nested` tail is new)

The new test uses the SoundEventStream (Level 2 / inference) to prove closure refresh — the appropriate level for a structural assertion about which asyncFn the scheduler holds. Level 3 audio capture would only confirm what Level 2 already proves for this bug class.

Closes #199