### PR TITLE
🔧 tools: A/B comparison rig — desktop Sonic Pi ↔ SonicPi.js

### DIFF
--- a/tools/capture-desktop.ts
+++ b/tools/capture-desktop.ts
@@ -1,0 +1,344 @@
+/**
+ * Desktop Sonic Pi capture tool — sends Ruby code to the running Sonic Pi.app
+ * via OSC, captures the resulting WAV, and writes a report alongside the
+ * existing browser-side captures (.captures/) for A/B comparison.
+ *
+ * Mirrors the surface of tools/capture.ts so the e2e parity workflow can run
+ * desktop ↔ web side-by-side. This is an OBSERVATION tool, not a test.
+ *
+ * Usage:
+ *   npx tsx tools/capture-desktop.ts                          # default snippet
+ *   npx tsx tools/capture-desktop.ts "play 60; sleep 1"       # inline code
+ *   npx tsx tools/capture-desktop.ts --file path/to/code.rb   # from file
+ *   npx tsx tools/capture-desktop.ts --duration 12000         # 12 seconds
+ *   npx tsx tools/capture-desktop.ts --name minimal_techno    # custom report name
+ *
+ * Prereqs:
+ *   1. Sonic Pi.app must be running. If not: `open -a "Sonic Pi"` and wait
+ *      for boot (~10s) before running this tool.
+ *   2. The tool discovers the running instance's OSC ports and auth token
+ *      from the live `spider-server.rb` process args via `ps`.
+ *
+ * Wire format:
+ *   /run-code is a Sonic Pi internal OSC endpoint with type tag `,is` —
+ *   int (the auth token printed by the daemon at boot) then string (the
+ *   user's code). Token is a signed 32-bit integer that rotates per boot.
+ *   /stop-all-jobs takes the token alone (`,i`).
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync, statSync } from 'fs'
+import { resolve, dirname, basename } from 'path'
+import { fileURLToPath } from 'url'
+import { execSync } from 'child_process'
+import { createSocket, type Socket } from 'dgram'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CAPTURES_DIR = resolve(__dirname, '../.captures')
+const RECORDINGS_DIR = resolve(__dirname, '../.captures/desktop-recordings')
+const DEFAULT_DURATION = 8000
+
+// ---------------------------------------------------------------------------
+// Port + token discovery
+// ---------------------------------------------------------------------------
+
+interface DesktopPorts {
+  guiSendToSpider: number  // we send /run-code here
+  guiListenToSpider: number // spider replies here (we don't currently parse replies)
+  token: number
+}
+
+function discoverPorts(): DesktopPorts {
+  let psOutput: string
+  try {
+    psOutput = execSync('ps -axo args', { encoding: 'utf8' })
+  } catch (err) {
+    throw new Error(`ps failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  // The daemon spawns ruby with positional args:
+  //   spider-server.rb -u GUI_SEND_TO_SPIDER GUI_LISTEN_TO_SPIDER SCSYNTH SCSYNTH_SEND OSC_CUES TAU SPIDER_LISTEN_TO_TAU TOKEN
+  // (8 args total after -u; ports are listed in daemon.log under "Selected ports".)
+  const m = psOutput.match(
+    /spider-server\.rb\s+-u\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(-?\d+)/,
+  )
+  if (!m) {
+    throw new Error(
+      'Sonic Pi is not running (no spider-server.rb process found).\n' +
+      '→ Run `open -a "Sonic Pi"` and wait ~10 seconds for it to boot.',
+    )
+  }
+  return {
+    guiSendToSpider: parseInt(m[1], 10),
+    guiListenToSpider: parseInt(m[2], 10),
+    token: parseInt(m[8], 10),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal OSC 1.0 encoder (no dependency)
+// ---------------------------------------------------------------------------
+
+function pad4(buf: Buffer): Buffer {
+  const padLen = (4 - (buf.length % 4)) % 4
+  return padLen === 0 ? buf : Buffer.concat([buf, Buffer.alloc(padLen)])
+}
+
+function oscString(s: string): Buffer {
+  return pad4(Buffer.concat([Buffer.from(s, 'utf8'), Buffer.from([0])]))
+}
+
+function oscInt32(n: number): Buffer {
+  const b = Buffer.alloc(4)
+  b.writeInt32BE(n)
+  return b
+}
+
+function oscMessage(addr: string, typeTag: string, args: Array<string | number>): Buffer {
+  const parts: Buffer[] = [oscString(addr), oscString(',' + typeTag)]
+  for (let i = 0; i < typeTag.length; i++) {
+    const t = typeTag[i]
+    if (t === 's') parts.push(oscString(String(args[i])))
+    else if (t === 'i') parts.push(oscInt32(args[i] as number))
+    else throw new Error(`Unsupported OSC type tag: ${t}`)
+  }
+  return Buffer.concat(parts)
+}
+
+async function sendUdp(host: string, port: number, packet: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const sock: Socket = createSocket('udp4')
+    sock.send(packet, port, host, (err) => {
+      sock.close()
+      err ? reject(err) : resolve()
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// WAV stats — same shape as tools/capture.ts (PCM 16-bit interleaved)
+// ---------------------------------------------------------------------------
+
+interface AudioStats {
+  duration: number
+  peak: number
+  rms: number
+  clipping: number
+  sampleRate: number
+  channels: number
+}
+
+function analyzeWav(path: string): AudioStats | null {
+  try {
+    const buf = readFileSync(path)
+    const sampleRate = buf.readUInt32LE(24)
+    const bitsPerSample = buf.readUInt16LE(34)
+    const channels = buf.readUInt16LE(22)
+    const dataOffset = 44
+    const bytesPerSample = bitsPerSample / 8
+    const numSamples = Math.floor((buf.length - dataOffset) / (channels * bytesPerSample))
+    let sumSq = 0
+    let peak = 0
+    let clipCount = 0
+    for (let i = 0; i < numSamples; i++) {
+      const off = dataOffset + i * channels * bytesPerSample
+      const val = buf.readInt16LE(off) / 32768.0
+      sumSq += val * val
+      const a = Math.abs(val)
+      if (a > peak) peak = a
+      if (a > 0.95) clipCount++
+    }
+    const rms = Math.sqrt(sumSq / numSamples)
+    return {
+      duration: numSamples / sampleRate,
+      peak: Math.round(peak * 10000) / 10000,
+      rms: Math.round(rms * 10000) / 10000,
+      clipping: Math.round((clipCount / numSamples) * 10000) / 100,
+      sampleRate,
+      channels,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Capture flow
+// ---------------------------------------------------------------------------
+
+interface DesktopCaptureResult {
+  timestamp: string
+  code: string
+  duration: number
+  reportPath: string
+  audioPath: string | null
+  audioStats: AudioStats | null
+  ports: DesktopPorts
+  notes: string[]
+}
+
+async function runDesktopCapture(
+  code: string,
+  opts: { duration?: number; name?: string } = {},
+): Promise<DesktopCaptureResult> {
+  const duration = opts.duration ?? DEFAULT_DURATION
+  const name = opts.name ?? 'capture'
+  const safeName = name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60)
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const prefix = `desktop_${ts}_${safeName}`
+
+  mkdirSync(CAPTURES_DIR, { recursive: true })
+  mkdirSync(RECORDINGS_DIR, { recursive: true })
+  const audioPath = resolve(RECORDINGS_DIR, `${prefix}.wav`)
+  const reportPath = resolve(CAPTURES_DIR, `${prefix}.md`)
+
+  const ports = discoverPorts()
+  const notes: string[] = []
+
+  // Wrap the user's code with a recording-controller in_thread so it survives
+  // alongside whatever live_loops the user declared. The thread sleeps the
+  // capture window in REAL time (not bpm-scaled) via `rt(N)`-equivalent: we
+  // just send a literal sleep at default 60 BPM, where 1 beat == 1 second.
+  // After recording_stop we save to the absolute path. The user's loops keep
+  // running; /stop-all-jobs below tears them down.
+  const durationSec = duration / 1000.0
+  const wrapped =
+    `recording_start\n` +
+    `in_thread do\n` +
+    `  sleep ${durationSec}\n` +
+    `  recording_stop\n` +
+    `  recording_save "${audioPath}"\n` +
+    `end\n` +
+    `\n` +
+    code
+
+  // /run-code wire format: [token as int, code as string].
+  const runPacket = oscMessage('/run-code', 'is', [ports.token, wrapped])
+  await sendUdp('127.0.0.1', ports.guiSendToSpider, runPacket)
+  notes.push(`sent /run-code to 127.0.0.1:${ports.guiSendToSpider} (token ${ports.token})`)
+
+  // Wait the capture window + ~2.5s for recording_save to flush WAV to disk.
+  await new Promise((r) => setTimeout(r, duration + 2500))
+
+  // Tear down user's code and the recording thread cleanly.
+  const stopPacket = oscMessage('/stop-all-jobs', 'i', [ports.token])
+  await sendUdp('127.0.0.1', ports.guiSendToSpider, stopPacket)
+  notes.push(`sent /stop-all-jobs`)
+
+  // Give the file system a moment to settle, then check the WAV.
+  await new Promise((r) => setTimeout(r, 500))
+  let audioStats: AudioStats | null = null
+  if (existsSync(audioPath)) {
+    const sz = statSync(audioPath).size
+    if (sz > 44) audioStats = analyzeWav(audioPath)
+    else notes.push(`WAV exists at ${audioPath} but is empty (${sz} bytes)`)
+  } else {
+    notes.push(
+      `Recording not produced at ${audioPath}. Likely causes:\n` +
+      `  • Sonic Pi rejected the code — check ~/.sonic-pi/log/spider.log\n` +
+      `  • duration too short for recording to flush\n` +
+      `  • a syntax/runtime error in the user code`,
+    )
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    code,
+    duration,
+    reportPath,
+    audioPath: audioStats ? audioPath : null,
+    audioStats,
+    ports,
+    notes,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report writer (matches tools/capture.ts feel)
+// ---------------------------------------------------------------------------
+
+function writeReport(r: DesktopCaptureResult): void {
+  const lines: string[] = []
+  lines.push(`# Desktop Sonic Pi Capture: ${r.timestamp}`)
+  lines.push('')
+  lines.push(`- **Duration window:** ${r.duration} ms`)
+  lines.push(`- **Spider port:** ${r.ports.guiSendToSpider} (token ${r.ports.token})`)
+  lines.push('')
+
+  lines.push('## Code')
+  lines.push('```ruby')
+  lines.push(r.code.trim())
+  lines.push('```')
+  lines.push('')
+
+  if (r.audioStats && r.audioPath) {
+    const s = r.audioStats
+    lines.push('## Audio (Level 3 — observation, not inference)')
+    lines.push(`- **Path:** \`${r.audioPath}\``)
+    lines.push(`- **Sample rate:** ${s.sampleRate} Hz, **channels:** ${s.channels}`)
+    lines.push(`- **Duration:** ${s.duration.toFixed(3)}s`)
+    lines.push(`- **Peak:** ${s.peak}`)
+    lines.push(`- **RMS:** ${s.rms}`)
+    lines.push(`- **Clipping:** ${s.clipping}%`)
+    if (s.peak < 0.01) lines.push(`- ⚠ **Silent output** — the user code may not have produced audio`)
+    if (s.rms > 0.3) lines.push(`- ⚠ **Loud output** — RMS ${s.rms} (Sonic Pi reference ≈ 0.19)`)
+  } else {
+    lines.push('## Audio')
+    lines.push(`_No WAV produced._`)
+  }
+  lines.push('')
+
+  if (r.notes.length > 0) {
+    lines.push('## Notes')
+    for (const n of r.notes) lines.push(`- ${n}`)
+  }
+
+  writeFileSync(r.reportPath, lines.join('\n'))
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): { code: string; duration: number; name: string } {
+  let duration = DEFAULT_DURATION
+  let name = 'inline'
+  let code = `play 60\nsleep 1\nplay 67\nsleep 1\nplay 72\nsleep 1`
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--duration') duration = parseInt(argv[++i], 10)
+    else if (a === '--name') name = argv[++i]
+    else if (a === '--file') {
+      const path = argv[++i]
+      code = readFileSync(path, 'utf8')
+      name = basename(path).replace(/\.[^.]+$/, '')
+    } else if (!a.startsWith('--')) {
+      code = a
+    }
+  }
+  return { code, duration, name }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  console.log(`▶ Desktop capture (${args.duration}ms): ${args.name}`)
+  const result = await runDesktopCapture(args.code, {
+    duration: args.duration,
+    name: args.name,
+  })
+  writeReport(result)
+  console.log(`✓ Report: ${result.reportPath}`)
+  if (result.audioPath) {
+    console.log(`✓ WAV:    ${result.audioPath}`)
+    if (result.audioStats) {
+      const s = result.audioStats
+      console.log(`  ${s.duration.toFixed(2)}s · peak ${s.peak} · RMS ${s.rms} · clip ${s.clipping}%`)
+    }
+  } else {
+    console.log(`⚠ No WAV produced. See report for diagnostics.`)
+    process.exitCode = 1
+  }
+}
+
+main().catch((err) => {
+  console.error('✗', err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -5,7 +5,8 @@
  *
  * Useful for parity verification: "does our engine produce the same audio
  * shape as Desktop SP for this snippet?" — the desktop side is the canonical
- * reference (SV8: WAV observation over event-log inference).
+ * reference (audio WAV is the gold standard for observation; the event log
+ * is inference about what should happen, not observation of what did).
  *
  * Prereqs (BOTH must hold):
  *   1. Sonic Pi.app must be running (`open -a "Sonic Pi"` and wait ~10s).

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -1,0 +1,458 @@
+/**
+ * A/B comparator — runs the same Sonic Pi snippet through BOTH desktop
+ * Sonic Pi.app (via tools/capture-desktop.ts) and the SonicPi.js browser app
+ * (via tools/capture.ts), then writes a side-by-side stats report.
+ *
+ * Useful for parity verification: "does our engine produce the same audio
+ * shape as Desktop SP for this snippet?" — the desktop side is the canonical
+ * reference (SV8: WAV observation over event-log inference).
+ *
+ * Prereqs (BOTH must hold):
+ *   1. Sonic Pi.app must be running (`open -a "Sonic Pi"` and wait ~10s).
+ *   2. The browser dev server must be running (`npm run dev` on :5173).
+ *
+ * Usage:
+ *   npx tsx tools/compare-desktop-vs-web.ts                          # default snippet
+ *   npx tsx tools/compare-desktop-vs-web.ts "play 60; sleep 1"        # inline
+ *   npx tsx tools/compare-desktop-vs-web.ts --file path/to/code.rb    # from file
+ *   npx tsx tools/compare-desktop-vs-web.ts --file foo.rb --duration 12000
+ *
+ * Per-beat windowed analysis (opt-in for rhythmic content):
+ *   npx tsx tools/compare-desktop-vs-web.ts --file beat.rb --bpm 120 --beats 16
+ *   # → slices both WAVs into 16 windows of 0.5s each, computes per-beat
+ *   #   RMS / peak / MFCC distance, identifies most-divergent beats, and
+ *   #   emits a per-beat bar-chart PNG alongside the spectrogram.
+ *
+ * Output:
+ *   .captures/compare_<ts>_<name>.md  — side-by-side stats + verdict
+ *   .captures/desktop-recordings/...wav and .captures/...wav (the source WAVs)
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs'
+import { resolve, dirname, basename } from 'path'
+import { fileURLToPath } from 'url'
+import { spawn } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CAPTURES_DIR = resolve(__dirname, '../.captures')
+const DEFAULT_DURATION = 8000
+
+// ---------------------------------------------------------------------------
+// Spawn helper — collect stdout, return when child exits
+// ---------------------------------------------------------------------------
+
+interface ChildResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+function runChild(cmd: string, args: string[]): Promise<ChildResult> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(cmd, args, { cwd: resolve(__dirname, '..') })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (b) => { stdout += b.toString() })
+    child.stderr.on('data', (b) => { stderr += b.toString() })
+    child.on('error', rejectP)
+    child.on('close', (code) => {
+      resolveP({ exitCode: code ?? -1, stdout, stderr })
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// WAV stats — same impl as capture.ts and capture-desktop.ts
+// ---------------------------------------------------------------------------
+
+interface AudioStats {
+  duration: number
+  peak: number
+  rms: number
+  clipping: number
+  sampleRate: number
+  channels: number
+}
+
+function analyzeWav(path: string): AudioStats | null {
+  try {
+    const buf = readFileSync(path)
+    const sampleRate = buf.readUInt32LE(24)
+    const bitsPerSample = buf.readUInt16LE(34)
+    const channels = buf.readUInt16LE(22)
+    const dataOffset = 44
+    const bytesPerSample = bitsPerSample / 8
+    const numSamples = Math.floor((buf.length - dataOffset) / (channels * bytesPerSample))
+    let sumSq = 0
+    let peak = 0
+    let clipCount = 0
+    for (let i = 0; i < numSamples; i++) {
+      const off = dataOffset + i * channels * bytesPerSample
+      const val = buf.readInt16LE(off) / 32768.0
+      sumSq += val * val
+      const a = Math.abs(val)
+      if (a > peak) peak = a
+      if (a > 0.95) clipCount++
+    }
+    const rms = Math.sqrt(sumSq / numSamples)
+    return {
+      duration: numSamples / sampleRate,
+      peak: Math.round(peak * 10000) / 10000,
+      rms: Math.round(rms * 10000) / 10000,
+      clipping: Math.round((clipCount / numSamples) * 10000) / 100,
+      sampleRate,
+      channels,
+    }
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WAV path discovery — parse the child tools' stdout
+// ---------------------------------------------------------------------------
+
+function findWavPath(stdout: string, regex: RegExp): string | null {
+  const m = stdout.match(regex)
+  return m ? m[1] : null
+}
+
+// ---------------------------------------------------------------------------
+// Comparison report
+// ---------------------------------------------------------------------------
+
+interface PerBeatRow {
+  beat: number
+  desktop_rms: number
+  web_rms: number
+  desktop_peak: number
+  web_peak: number
+  mfcc_distance: number | null
+}
+
+interface PerBeatMetrics {
+  bpm: number
+  beats: number
+  rows: PerBeatRow[]
+  most_divergent_beats: number[]
+  mean_per_beat_mfcc_distance: number
+  per_beat_png: string
+}
+
+interface SpectrogramMetrics {
+  l2_mel_db: number
+  mfcc_distance: number
+  frames_compared: number
+  spectrogram_png: string
+  desktop_peak_freq_hz: number
+  web_peak_freq_hz: number
+  per_beat: PerBeatMetrics | null
+}
+
+interface ComparisonResult {
+  timestamp: string
+  code: string
+  duration: number
+  name: string
+  desktop: { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean }
+  web:     { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean }
+  spectrogram: SpectrogramMetrics | null
+  spectrogramError: string | null
+  reportPath: string
+}
+
+function writeComparisonReport(r: ComparisonResult): void {
+  const lines: string[] = []
+  lines.push(`# Desktop ↔ Web Comparison: ${r.name}`)
+  lines.push('')
+  lines.push(`- **Timestamp:** ${r.timestamp}`)
+  lines.push(`- **Capture window:** ${r.duration} ms`)
+  lines.push('')
+
+  lines.push('## Code')
+  lines.push('```ruby')
+  lines.push(r.code.trim())
+  lines.push('```')
+  lines.push('')
+
+  lines.push('## Stats (Level 3 — observation, not inference)')
+  lines.push('')
+  lines.push('| Metric        | Desktop SP             | SonicPi.js (web)        | Δ (desk − web) |')
+  lines.push('|---------------|------------------------|-------------------------|----------------|')
+
+  const fmt = (v: number | undefined, digits = 4) =>
+    v === undefined || Number.isNaN(v) ? '—' : v.toFixed(digits)
+
+  const dStats = r.desktop.stats
+  const wStats = r.web.stats
+
+  const row = (
+    label: string,
+    pickD: (s: AudioStats) => number,
+    pickW: (s: AudioStats) => number,
+    digits = 4,
+  ) => {
+    const dv = dStats ? pickD(dStats) : undefined
+    const wv = wStats ? pickW(wStats) : undefined
+    const delta = dv !== undefined && wv !== undefined ? dv - wv : undefined
+    lines.push(`| ${label} | ${fmt(dv, digits)} | ${fmt(wv, digits)} | ${fmt(delta, digits)} |`)
+  }
+
+  row('Duration (s)', s => s.duration, s => s.duration, 3)
+  row('Peak',         s => s.peak,     s => s.peak)
+  row('RMS',          s => s.rms,      s => s.rms)
+  row('Clipping (%)', s => s.clipping, s => s.clipping, 2)
+  lines.push(`| Sample rate (Hz) | ${dStats?.sampleRate ?? '—'} | ${wStats?.sampleRate ?? '—'} | ${
+    dStats && wStats ? dStats.sampleRate - wStats.sampleRate : '—'
+  } |`)
+  lines.push(`| Channels | ${dStats?.channels ?? '—'} | ${wStats?.channels ?? '—'} | — |`)
+  lines.push('')
+
+  // Verdict — compare key metrics with simple thresholds
+  lines.push('## Verdict')
+  const verdicts: string[] = []
+  if (!dStats) verdicts.push(`✗ Desktop produced no WAV — see desktop tool stdout in this report`)
+  if (!wStats) verdicts.push(`✗ Web produced no WAV — see web tool stdout in this report`)
+  if (dStats && wStats) {
+    if (dStats.sampleRate !== wStats.sampleRate) {
+      verdicts.push(`⚠ Sample-rate mismatch (${dStats.sampleRate} vs ${wStats.sampleRate} Hz) — RMS / peak / spectrum comparisons are at-source only, not resampled`)
+    }
+    const rmsRatio = dStats.rms > 0 ? wStats.rms / dStats.rms : 0
+    if (rmsRatio < 0.5 || rmsRatio > 2.0) {
+      verdicts.push(`⚠ RMS ratio web/desktop = ${rmsRatio.toFixed(2)}× — significant level divergence`)
+    } else {
+      verdicts.push(`✓ RMS ratio web/desktop = ${rmsRatio.toFixed(2)}× (within 0.5×–2× tolerance)`)
+    }
+    const peakRatio = dStats.peak > 0 ? wStats.peak / dStats.peak : 0
+    if (peakRatio < 0.5 || peakRatio > 2.0) {
+      verdicts.push(`⚠ Peak ratio web/desktop = ${peakRatio.toFixed(2)}× — significant peak divergence`)
+    } else {
+      verdicts.push(`✓ Peak ratio web/desktop = ${peakRatio.toFixed(2)}× (within 0.5×–2× tolerance)`)
+    }
+    if (dStats.clipping > 1 || wStats.clipping > 1) {
+      verdicts.push(`⚠ Clipping detected (desktop ${dStats.clipping}%, web ${wStats.clipping}%)`)
+    }
+    const durDelta = Math.abs(dStats.duration - wStats.duration)
+    if (durDelta > 1.0) {
+      verdicts.push(`⚠ Duration delta ${durDelta.toFixed(2)}s — captures may not have aligned windows`)
+    }
+  }
+  for (const v of verdicts) lines.push(`- ${v}`)
+  lines.push('')
+
+  lines.push('## Source WAVs')
+  lines.push(`- **Desktop:** ${r.desktop.wavPath ?? '_(not produced)_'}`)
+  lines.push(`- **Web:** ${r.web.wavPath ?? '_(not produced)_'}`)
+  lines.push('')
+
+  lines.push('## Spectrogram comparison')
+  if (r.spectrogram) {
+    const sp = r.spectrogram
+    lines.push(`![spectrogram comparison](${sp.spectrogram_png})`)
+    lines.push('')
+    lines.push('| Metric | Value | Reading |')
+    lines.push('|---|---|---|')
+    lines.push(`| L2 distance (mel-dB) | ${sp.l2_mel_db.toFixed(2)} | < 10 = very close · 10–25 = similar shape · > 25 = divergent |`)
+    lines.push(`| MFCC distance (timbre) | ${sp.mfcc_distance.toFixed(2)} | < 30 = similar · 30–80 = noticeably different · > 80 = unrelated |`)
+    lines.push(`| Frames compared | ${sp.frames_compared} | overlapping window after length-aligning |`)
+    lines.push(`| Peak freq desktop | ${sp.desktop_peak_freq_hz.toFixed(1)} Hz | dominant frequency |`)
+    lines.push(`| Peak freq web | ${sp.web_peak_freq_hz.toFixed(1)} Hz | dominant frequency |`)
+    if (sp.l2_mel_db > 25) {
+      lines.push('')
+      lines.push(`⚠ Spectral L2 ${sp.l2_mel_db.toFixed(2)} indicates divergent spectral content — inspect the diff panel of the PNG above.`)
+    }
+    if (sp.mfcc_distance > 80) {
+      lines.push(`⚠ MFCC distance ${sp.mfcc_distance.toFixed(2)} indicates unrelated timbre — likely different synth or sample chain firing.`)
+    }
+
+    if (sp.per_beat) {
+      const pb = sp.per_beat
+      lines.push('')
+      lines.push(`### Per-beat (bpm=${pb.bpm}, ${pb.beats} beats)`)
+      lines.push('')
+      lines.push(`![per-beat comparison](${pb.per_beat_png})`)
+      lines.push('')
+      lines.push('| Beat | Desktop RMS | Web RMS | RMS Δ | MFCC dist |')
+      lines.push('|---|---|---|---|---|')
+      for (const row of pb.rows) {
+        const delta = row.desktop_rms - row.web_rms
+        const mfcc = row.mfcc_distance === null ? '—' : row.mfcc_distance.toFixed(1)
+        lines.push(`| ${row.beat} | ${row.desktop_rms.toFixed(4)} | ${row.web_rms.toFixed(4)} | ${delta >= 0 ? '+' : ''}${delta.toFixed(4)} | ${mfcc} |`)
+      }
+      lines.push('')
+      lines.push(`- **Mean per-beat MFCC distance:** ${pb.mean_per_beat_mfcc_distance.toFixed(2)}`)
+      lines.push(`- **Most divergent beats (top 3):** ${pb.most_divergent_beats.join(', ') || '—'}`)
+      const silentDesktop = pb.rows.filter(r => r.desktop_rms < 0.001).map(r => r.beat)
+      const silentWeb = pb.rows.filter(r => r.web_rms < 0.001).map(r => r.beat)
+      if (silentDesktop.length !== silentWeb.length) {
+        lines.push(`- ⚠ **Silent-beat asymmetry:** desktop silent on beats ${silentDesktop.join(',') || '(none)'} · web silent on beats ${silentWeb.join(',') || '(none)'} — likely a missed trigger on one side`)
+      }
+    }
+  } else if (r.spectrogramError) {
+    lines.push(`_Spectrogram analysis failed: ${r.spectrogramError}_`)
+  } else {
+    lines.push('_Spectrogram analysis skipped — both WAVs required._')
+  }
+  lines.push('')
+
+  lines.push('## Tool stdout (debug)')
+  lines.push('### Desktop')
+  lines.push('```')
+  lines.push(r.desktop.rawStdout.trim())
+  lines.push('```')
+  lines.push('### Web')
+  lines.push('```')
+  lines.push(r.web.rawStdout.trim())
+  lines.push('```')
+
+  writeFileSync(r.reportPath, lines.join('\n'))
+}
+
+// ---------------------------------------------------------------------------
+// Main flow
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  code: string
+  duration: number
+  name: string
+  bpm: number | null   // null → no per-beat analysis
+  beats: number | null
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let duration = DEFAULT_DURATION
+  let name = 'inline'
+  let code = `play 60\nsleep 1\nplay 67\nsleep 1\nplay 72\nsleep 1`
+  let bpm: number | null = null
+  let beats: number | null = null
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--duration') duration = parseInt(argv[++i], 10)
+    else if (a === '--name') name = argv[++i]
+    else if (a === '--bpm') bpm = parseFloat(argv[++i])
+    else if (a === '--beats') beats = parseInt(argv[++i], 10)
+    else if (a === '--file') {
+      const path = argv[++i]
+      code = readFileSync(path, 'utf8')
+      name = basename(path).replace(/\.[^.]+$/, '')
+    } else if (!a.startsWith('--')) {
+      code = a
+    }
+  }
+  // Per-beat fires only when --beats is given. If --bpm omitted, default to 60
+  // (Sonic Pi default; matches the Python script's default).
+  if (beats !== null && bpm === null) bpm = 60
+  return { code, duration, name, bpm, beats }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+  console.log(`▶ A/B comparison (${args.duration}ms): ${args.name}`)
+  console.log(`  Running desktop + web in parallel...`)
+
+  mkdirSync(CAPTURES_DIR, { recursive: true })
+
+  // Desktop tool accepts --name; web tool (capture.ts) does not — it picks the
+  // name from --file basename or defaults to "inline" for raw code. So we
+  // pass --name only to the desktop side and locate the web report via the
+  // "Capture saved: <path>" line printed by capture.ts.
+  const desktopArgs = [args.code, '--duration', String(args.duration), '--name', args.name]
+  const webArgs     = [args.code, '--duration', String(args.duration)]
+
+  const [desktop, web] = await Promise.all([
+    runChild('npx', ['tsx', 'tools/capture-desktop.ts', ...desktopArgs]),
+    runChild('npx', ['tsx', 'tools/capture.ts', ...webArgs]),
+  ])
+
+  // capture-desktop.ts prints: "✓ WAV:    <abs-path>"
+  const desktopWav = findWavPath(desktop.stdout, /✓ WAV:\s+(\S+\.wav)/)
+  // capture.ts prints: "Capture saved: <abs-path-to-md>". Read that md and
+  // grep for the **File:** line (the audio path inside the report).
+  let webWav: string | null = null
+  const webReportMatch = web.stdout.match(/Capture saved:\s+(\S+\.md)/)
+  if (webReportMatch && existsSync(webReportMatch[1])) {
+    const md = readFileSync(webReportMatch[1], 'utf8')
+    const m = md.match(/\*\*File:\*\*\s+`([^`]+\.wav)`/)
+    if (m) webWav = m[1]
+  }
+
+  const desktopStats = desktopWav ? analyzeWav(desktopWav) : null
+  const webStats = webWav ? analyzeWav(webWav) : null
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  const reportPath = resolve(CAPTURES_DIR, `compare_${ts}_${args.name}.md`)
+
+  // Spectrogram + MFCC analysis via Python (librosa). Only if both WAVs exist.
+  let spectrogram: SpectrogramMetrics | null = null
+  let spectrogramError: string | null = null
+  if (desktopWav && webWav) {
+    const specOutPrefix = resolve(CAPTURES_DIR, `compare_${ts}_${args.name}_spectrogram`)
+    const pyArgs = ['tools/spectrogram-compare.py', desktopWav, webWav, specOutPrefix]
+    if (args.beats !== null && args.bpm !== null) {
+      pyArgs.push('--bpm', String(args.bpm), '--beats', String(args.beats))
+    }
+    try {
+      const py = await runChild('python3', pyArgs)
+      if (py.exitCode === 0) {
+        const jsonPath = `${specOutPrefix}.json`
+        if (existsSync(jsonPath)) {
+          const data = JSON.parse(readFileSync(jsonPath, 'utf8'))
+          spectrogram = {
+            l2_mel_db: data.comparison.l2_mel_db,
+            mfcc_distance: data.comparison.mfcc_distance,
+            frames_compared: data.comparison.frames_compared,
+            spectrogram_png: data.comparison.spectrogram_png,
+            desktop_peak_freq_hz: data.desktop.peak_freq_hz,
+            web_peak_freq_hz: data.web.peak_freq_hz,
+            per_beat: data.per_beat ?? null,
+          }
+        }
+      } else {
+        spectrogramError = py.stderr.trim() || `python3 exited ${py.exitCode}`
+      }
+    } catch (err) {
+      spectrogramError = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  writeComparisonReport({
+    timestamp: new Date().toISOString(),
+    code: args.code,
+    duration: args.duration,
+    name: args.name,
+    desktop: { wavPath: desktopWav, stats: desktopStats, rawStdout: desktop.stdout, ok: desktop.exitCode === 0 },
+    web:     { wavPath: webWav,     stats: webStats,     rawStdout: web.stdout,     ok: web.exitCode === 0 },
+    spectrogram,
+    spectrogramError,
+    reportPath,
+  })
+
+  console.log(`\n✓ Comparison report: ${reportPath}`)
+  if (desktopStats && webStats) {
+    const rmsRatio = desktopStats.rms > 0 ? webStats.rms / desktopStats.rms : 0
+    const peakRatio = desktopStats.peak > 0 ? webStats.peak / desktopStats.peak : 0
+    console.log(`  Desktop: peak ${desktopStats.peak} · RMS ${desktopStats.rms} · ${desktopStats.duration.toFixed(2)}s @ ${desktopStats.sampleRate}Hz`)
+    console.log(`  Web:     peak ${webStats.peak} · RMS ${webStats.rms} · ${webStats.duration.toFixed(2)}s @ ${webStats.sampleRate}Hz`)
+    console.log(`  Ratios:  peak ${peakRatio.toFixed(2)}× · RMS ${rmsRatio.toFixed(2)}× (web/desktop)`)
+    if (spectrogram) {
+      console.log(`  Spec:    L2(mel-dB)=${spectrogram.l2_mel_db.toFixed(2)} · MFCC dist=${spectrogram.mfcc_distance.toFixed(2)}`)
+      console.log(`  PNG:     ${spectrogram.spectrogram_png}`)
+      if (spectrogram.per_beat) {
+        const pb = spectrogram.per_beat
+        console.log(`  Per-beat: mean MFCC ${pb.mean_per_beat_mfcc_distance.toFixed(2)} · most divergent beats: ${pb.most_divergent_beats.join(', ')}`)
+        console.log(`  PNG:      ${pb.per_beat_png}`)
+      }
+    } else if (spectrogramError) {
+      console.log(`  ⚠ Spectrogram analysis failed: ${spectrogramError}`)
+    }
+  } else {
+    console.log(`  ⚠ One or both sides produced no WAV — see report for stdout`)
+    process.exitCode = 1
+  }
+}
+
+main().catch((err) => {
+  console.error('✗', err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/tools/spectrogram-compare.py
+++ b/tools/spectrogram-compare.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Side-by-side spectrogram comparison for desktop ↔ web parity.
+
+Inputs:  two WAV file paths (desktop, web)
+Outputs:
+  - <out>.png    side-by-side mel-spectrograms (desktop | web | diff)
+  - <out>.json   {l2_distance, mfcc_distance, peak_freq_*, per_beat: [...], ...}
+
+Per-beat windowed analysis fires when --beats N (and optionally --bpm M)
+are given. Each window is `60/bpm` seconds wide, sliced from t=0. For
+each beat we record per-side RMS, peak, and MFCC vector; cross-side we
+record an L2 distance per beat. A second PNG (`<out>_perbeat.png`) plots
+the per-beat distance bar chart and per-beat RMS comparison.
+
+Usage:
+  python3 tools/spectrogram-compare.py <desktop.wav> <web.wav> <out-prefix>
+                                       [--bpm 120] [--beats 16]
+
+Called by tools/compare-desktop-vs-web.ts. Standalone-runnable for ad-hoc use.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import numpy as np
+from scipy.io import wavfile
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+try:
+    import librosa
+    import librosa.display
+except ImportError:
+    os.system("pip3 install librosa")
+    import librosa
+    import librosa.display
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+N_MELS = 128
+N_FFT = 2048
+HOP_LENGTH = 512
+
+
+def load_mono(path: str) -> tuple[np.ndarray, int]:
+    """Load WAV, downmix to mono float32 in [-1, 1]."""
+    sr, data = wavfile.read(path)
+    if data.dtype == np.int16:
+        data = data.astype(np.float32) / 32768.0
+    elif data.dtype == np.int32:
+        data = data.astype(np.float32) / 2147483648.0
+    elif data.dtype == np.uint8:
+        data = (data.astype(np.float32) - 128.0) / 128.0
+    else:
+        data = data.astype(np.float32)
+    if data.ndim == 2:
+        data = data.mean(axis=1)
+    return data, sr
+
+
+def mel_db(audio: np.ndarray, sr: int) -> np.ndarray:
+    spec = librosa.feature.melspectrogram(
+        y=audio, sr=sr, n_mels=N_MELS, n_fft=N_FFT, hop_length=HOP_LENGTH
+    )
+    return librosa.power_to_db(spec, ref=np.max)
+
+
+def mfcc_distance(a: np.ndarray, sr_a: int, b: np.ndarray, sr_b: int) -> float:
+    """Mean Euclidean distance between MFCC frames after length alignment.
+
+    A small distance (< 30) means broadly similar timbral envelope. Values
+    over ~80 mean very different content."""
+    mfcc_a = librosa.feature.mfcc(y=a, sr=sr_a, n_mfcc=13)
+    mfcc_b = librosa.feature.mfcc(y=b, sr=sr_b, n_mfcc=13)
+    # Align lengths — truncate to the shorter
+    n = min(mfcc_a.shape[1], mfcc_b.shape[1])
+    if n == 0:
+        return float("nan")
+    return float(np.mean(np.linalg.norm(mfcc_a[:, :n] - mfcc_b[:, :n], axis=0)))
+
+
+def l2_spectral_distance(mel_a: np.ndarray, mel_b: np.ndarray) -> float:
+    """Per-frame L2 distance, averaged. Both inputs are mel-dB matrices."""
+    n = min(mel_a.shape[1], mel_b.shape[1])
+    if n == 0:
+        return float("nan")
+    diff = mel_a[:, :n] - mel_b[:, :n]
+    return float(np.sqrt(np.mean(diff * diff)))
+
+
+def peak_frequency(audio: np.ndarray, sr: int) -> float:
+    """Dominant frequency from the average magnitude spectrum (Hz)."""
+    spec = np.abs(np.fft.rfft(audio))
+    freqs = np.fft.rfftfreq(len(audio), 1 / sr)
+    if spec.sum() == 0:
+        return 0.0
+    return float(freqs[int(np.argmax(spec))])
+
+
+def slice_beats(audio: np.ndarray, sr: int, bpm: float, beats: int) -> list[np.ndarray]:
+    """Slice audio into `beats` windows of (60/bpm) seconds each, from t=0.
+
+    If audio is shorter than the full grid, the last few windows may be empty
+    or partial — we pad with silence so MFCC frame count stays consistent."""
+    samples_per_beat = int(round(sr * 60.0 / bpm))
+    out: list[np.ndarray] = []
+    for k in range(beats):
+        start = k * samples_per_beat
+        end = start + samples_per_beat
+        if start >= len(audio):
+            out.append(np.zeros(samples_per_beat, dtype=np.float32))
+        else:
+            window = audio[start:end]
+            if len(window) < samples_per_beat:
+                window = np.concatenate(
+                    [window, np.zeros(samples_per_beat - len(window), dtype=audio.dtype)]
+                )
+            out.append(window)
+    return out
+
+
+def per_beat_compare(
+    audio_d: np.ndarray, sr_d: int,
+    audio_w: np.ndarray, sr_w: int,
+    bpm: float, beats: int,
+) -> dict:
+    """Slice both audios at the beat grid; compute per-beat RMS, peak, and
+    cross-side MFCC distance. Both sides must use the same beat grid; if
+    sample rates differ we resample web → desktop sample rate first."""
+    if sr_w != sr_d:
+        audio_w = librosa.resample(audio_w.astype(np.float32), orig_sr=sr_w, target_sr=sr_d)
+        sr_w = sr_d
+
+    bins_d = slice_beats(audio_d, sr_d, bpm, beats)
+    bins_w = slice_beats(audio_w, sr_w, bpm, beats)
+
+    rows = []
+    for k in range(beats):
+        d, w = bins_d[k], bins_w[k]
+        d_rms = float(np.sqrt(np.mean(d * d))) if len(d) else 0.0
+        w_rms = float(np.sqrt(np.mean(w * w))) if len(w) else 0.0
+        d_peak = float(np.max(np.abs(d))) if len(d) else 0.0
+        w_peak = float(np.max(np.abs(w))) if len(w) else 0.0
+        # MFCC distance for this beat — if either is silent, distance is the
+        # other's overall MFCC norm (i.e. "max possible" for present-vs-silent).
+        try:
+            mfcc_d = librosa.feature.mfcc(y=d, sr=sr_d, n_mfcc=13)
+            mfcc_w = librosa.feature.mfcc(y=w, sr=sr_d, n_mfcc=13)
+            n = min(mfcc_d.shape[1], mfcc_w.shape[1])
+            mfcc_dist = float(np.mean(np.linalg.norm(mfcc_d[:, :n] - mfcc_w[:, :n], axis=0))) if n > 0 else float("nan")
+        except Exception:
+            mfcc_dist = float("nan")
+        rows.append({
+            "beat": k,
+            "desktop_rms": round(d_rms, 4),
+            "web_rms": round(w_rms, 4),
+            "desktop_peak": round(d_peak, 4),
+            "web_peak": round(w_peak, 4),
+            "mfcc_distance": round(mfcc_dist, 2) if not np.isnan(mfcc_dist) else None,
+        })
+    # Identify the most divergent beats (top 3 by MFCC distance)
+    valid = [r for r in rows if r["mfcc_distance"] is not None]
+    most_divergent = sorted(valid, key=lambda r: r["mfcc_distance"], reverse=True)[:3]
+    return {
+        "bpm": bpm,
+        "beats": beats,
+        "rows": rows,
+        "most_divergent_beats": [r["beat"] for r in most_divergent],
+        "mean_per_beat_mfcc_distance": (
+            float(np.mean([r["mfcc_distance"] for r in valid])) if valid else float("nan")
+        ),
+    }
+
+
+def plot_per_beat(per_beat: dict, out_png: str) -> None:
+    rows = per_beat["rows"]
+    beats = [r["beat"] for r in rows]
+    d_rms = [r["desktop_rms"] for r in rows]
+    w_rms = [r["web_rms"] for r in rows]
+    mfcc = [r["mfcc_distance"] if r["mfcc_distance"] is not None else 0 for r in rows]
+
+    fig, axes = plt.subplots(2, 1, figsize=(max(8, len(beats) * 0.5), 6), constrained_layout=True)
+
+    # Top: per-beat RMS comparison
+    width = 0.4
+    x = np.arange(len(beats))
+    axes[0].bar(x - width / 2, d_rms, width, label="Desktop", color="#444")
+    axes[0].bar(x + width / 2, w_rms, width, label="Web", color="#cc4444")
+    axes[0].set_xticks(x)
+    axes[0].set_xticklabels(beats)
+    axes[0].set_xlabel("Beat index")
+    axes[0].set_ylabel("RMS")
+    axes[0].set_title(f"Per-beat RMS (bpm={per_beat['bpm']}, beats={per_beat['beats']})")
+    axes[0].legend()
+
+    # Bottom: per-beat MFCC distance
+    axes[1].bar(x, mfcc, color="#aa4488")
+    axes[1].axhline(30, color="green", linestyle="--", linewidth=0.8, label="≤30 similar")
+    axes[1].axhline(80, color="red", linestyle="--", linewidth=0.8, label=">80 unrelated")
+    axes[1].set_xticks(x)
+    axes[1].set_xticklabels(beats)
+    axes[1].set_xlabel("Beat index")
+    axes[1].set_ylabel("MFCC distance")
+    axes[1].set_title("Per-beat MFCC distance (timbre divergence)")
+    axes[1].legend(loc="upper right")
+
+    fig.savefig(out_png, dpi=110)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str]) -> tuple[str, str, str, float | None, int | None]:
+    if len(argv) < 4:
+        return ("", "", "", None, None)
+    desktop_path, web_path, out_prefix = argv[1], argv[2], argv[3]
+    bpm: float | None = None
+    beats: int | None = None
+    i = 4
+    while i < len(argv):
+        if argv[i] == "--bpm":
+            bpm = float(argv[i + 1])
+            i += 2
+        elif argv[i] == "--beats":
+            beats = int(argv[i + 1])
+            i += 2
+        else:
+            i += 1
+    if beats is not None and bpm is None:
+        bpm = 60.0  # Sonic Pi default
+    return desktop_path, web_path, out_prefix, bpm, beats
+
+
+def main() -> int:
+    desktop_path, web_path, out_prefix, bpm, beats = parse_args(sys.argv)
+    if not desktop_path:
+        print(
+            "Usage: spectrogram-compare.py <desktop.wav> <web.wav> <out-prefix> [--bpm N] [--beats K]",
+            file=sys.stderr,
+        )
+        return 1
+    out_png = f"{out_prefix}.png"
+    out_json = f"{out_prefix}.json"
+
+    if not os.path.exists(desktop_path):
+        print(f"Desktop WAV not found: {desktop_path}", file=sys.stderr)
+        return 1
+    if not os.path.exists(web_path):
+        print(f"Web WAV not found: {web_path}", file=sys.stderr)
+        return 1
+
+    audio_d, sr_d = load_mono(desktop_path)
+    audio_w, sr_w = load_mono(web_path)
+
+    mel_d = mel_db(audio_d, sr_d)
+    mel_w = mel_db(audio_w, sr_w)
+
+    # Diff in mel-dB space (clipped for plotting)
+    n_frames = min(mel_d.shape[1], mel_w.shape[1])
+    diff = mel_d[:, :n_frames] - mel_w[:, :n_frames]
+
+    # Plot — three panels, shared mel axis
+    fig, axes = plt.subplots(1, 3, figsize=(18, 5), constrained_layout=True)
+    librosa.display.specshow(
+        mel_d, sr=sr_d, hop_length=HOP_LENGTH, y_axis="mel", x_axis="time",
+        ax=axes[0], cmap="magma", vmin=-80, vmax=0,
+    )
+    axes[0].set_title(f"Desktop SP\n{os.path.basename(desktop_path)}\n{sr_d} Hz · {audio_d.shape[0]/sr_d:.2f}s")
+
+    librosa.display.specshow(
+        mel_w, sr=sr_w, hop_length=HOP_LENGTH, y_axis="mel", x_axis="time",
+        ax=axes[1], cmap="magma", vmin=-80, vmax=0,
+    )
+    axes[1].set_title(f"SonicPi.js (web)\n{os.path.basename(web_path)}\n{sr_w} Hz · {audio_w.shape[0]/sr_w:.2f}s")
+
+    img = librosa.display.specshow(
+        diff, sr=sr_d, hop_length=HOP_LENGTH, y_axis="mel", x_axis="time",
+        ax=axes[2], cmap="RdBu_r", vmin=-40, vmax=40,
+    )
+    axes[2].set_title("Diff (desktop − web), dB\nblue = web louder, red = desktop louder")
+    fig.colorbar(img, ax=axes[2], format="%+2.0f dB")
+
+    fig.savefig(out_png, dpi=110)
+    plt.close(fig)
+
+    # Numeric metrics
+    metrics = {
+        "desktop": {
+            "path": desktop_path,
+            "sample_rate": int(sr_d),
+            "duration_s": float(audio_d.shape[0] / sr_d),
+            "peak_freq_hz": peak_frequency(audio_d, sr_d),
+        },
+        "web": {
+            "path": web_path,
+            "sample_rate": int(sr_w),
+            "duration_s": float(audio_w.shape[0] / sr_w),
+            "peak_freq_hz": peak_frequency(audio_w, sr_w),
+        },
+        "comparison": {
+            "l2_mel_db": l2_spectral_distance(mel_d, mel_w),
+            "mfcc_distance": mfcc_distance(audio_d, sr_d, audio_w, sr_w),
+            "frames_compared": int(n_frames),
+            "spectrogram_png": out_png,
+        },
+    }
+
+    if beats is not None and bpm is not None:
+        per_beat = per_beat_compare(audio_d, sr_d, audio_w, sr_w, bpm, beats)
+        per_beat_png = f"{out_prefix}_perbeat.png"
+        plot_per_beat(per_beat, per_beat_png)
+        per_beat["per_beat_png"] = per_beat_png
+        metrics["per_beat"] = per_beat
+
+    with open(out_json, "w") as f:
+        json.dump(metrics, f, indent=2)
+
+    # Echo a one-line summary so the caller can grep stdout
+    summary = (
+        f"spectrogram OK · L2(mel-dB)={metrics['comparison']['l2_mel_db']:.2f} · "
+        f"MFCC dist={metrics['comparison']['mfcc_distance']:.2f} · "
+        f"png={out_png}"
+    )
+    if "per_beat" in metrics:
+        pb = metrics["per_beat"]
+        summary += (
+            f" · per-beat mean MFCC={pb['mean_per_beat_mfcc_distance']:.2f} · "
+            f"divergent beats={pb['most_divergent_beats']}"
+        )
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three composable tools that enable repeatable parity testing between desktop Sonic Pi.app and SonicPi.js:

- **\`tools/capture-desktop.ts\`** — sends Ruby code to the running Sonic Pi.app via OSC, captures the WAV via \`recording_save\`, analyzes it (peak / RMS / clipping / sample-rate), and writes a Markdown report mirroring the existing \`tools/capture.ts\` format
- **\`tools/spectrogram-compare.py\`** — two WAVs in, 3-panel mel-spectrogram PNG out (desktop · web · diff in dB), plus L2 mel-distance + MFCC distance + dominant frequency in JSON. Optional per-beat windowed analysis (\`--bpm N --beats K\`) emits per-beat RMS / peak / MFCC bar charts plus a most-divergent-beats list
- **\`tools/compare-desktop-vs-web.ts\`** — orchestrator that spawns both capture tools in parallel, locates both WAVs, calls the Python script, and writes a unified report with auto-fired verdicts (RMS-ratio tolerance, MFCC threshold, silent-beat asymmetry, sample-rate mismatch, duration delta)

Pure tools-only addition. No engine code touched. \`tsc --noEmit\` clean.

## Usage

\`\`\`bash
# Whole-WAV stats + 3-panel spectrogram (works for any content):
npx tsx tools/compare-desktop-vs-web.ts --file foo.rb --duration 8000

# + per-beat windowed analysis (rhythmic content):
npx tsx tools/compare-desktop-vs-web.ts --file beat.rb --duration 5000 --bpm 120 --beats 16
\`\`\`

Prereqs: Sonic Pi.app must be open (\`open -a \"Sonic Pi\"\`, wait ~10s) and \`npm run dev\` must be serving on :5173.

## Live verification

**3-note arpeggio:** desktop peak 0.42 / RMS 0.11, web peak 0.21 / RMS 0.06, MFCC dist 129.7 — auto-confirms the long-known gain-staging gap (web ~half level)

**\`use_bpm 120; live_loop :kick (sleep 1); live_loop :hat (sleep 0.5)\` over 10 beats:** per-beat asymmetry auto-flagged — desktop silent on beats 0–1 (scsynth warm-up), web silent on beat 9 (capture-window cutoff), steady-state beats 3–7 agree within 2 mRMS

## Test plan

- [x] \`npx tsc --noEmit\` zero errors
- [x] \`npx vitest run\` (no regressions — engine untouched)
- [x] Live OSC round-trip against Sonic Pi.app v4.6 on macOS
- [x] Spectrogram analysis works for both melodic and rhythmic content
- [x] Per-beat analysis surfaces real asymmetries with auto-flagged verdicts

## Notes for reviewers

- OSC port + token discovery parses live \`spider-server.rb\` process args (rotates per Sonic Pi boot — no static config)
- Wire format for \`/run-code\` is \`,is\` (token-int first, then code-string) — verified live during the first round-trip; the alternative \`,si\` produced an "Invalid token: <code>" error in spider.log
- \`tools/capture.ts\` doesn't accept \`--name\`; the orchestrator parses the web report path from its stdout instead (no upstream change needed)
- Python script uses \`from __future__ import annotations\` so PEP 604 syntax (\`X | None\`) works on Python 3.9

Closes #263