### PR TITLE
🐛 fix(comparator): unify desktop ↔ web on DSL-driven recording + document audio fidelity gaps

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -30,6 +30,35 @@ Current known limitations and browser-specific behaviors for Sonic Pi Web.
 - **Variable name `b`**: Avoid assigning to a variable named `b` at top level — the transpiler uses `__b` for the internal ProgramBuilder reference, but any variable shadowing in bare code scopes can conflict with DSL infrastructure. Use longer names like `bass`, `beat`, etc.
 - **Ruby Array methods not supported**: `.zip(other)` and `.each_with_index` are not implemented. Use manual iteration with `.length.times do |i|` and index access `arr[i]` as a workaround. See #154.
 
+## Audio Fidelity vs Desktop Sonic Pi
+
+The same composition will sound recognizably similar but not bit-identical to desktop Sonic Pi. Most differences come from running scsynth in WebAssembly (no native audio drivers, fixed AudioWorklet block size, 32-bit FP) and choices made to keep the browser engine stable.
+
+### Envelope shape — linear instead of exponential
+
+- Sonic Pi defaults envelope-driven synths to `env_curve: 2` (exponential). We use `env_curve: 1` (linear) because exponential triggers a WASM scsynth bug at small attack values (silence on isolated synths, 1-sample δ-spike on overlapping ones).
+- **Audible difference:** sustained notes hold their level longer through the release phase. Most noticeable on pads, drones, ambient music, and long-release leads. Drum/percussion and short staccato lines are essentially unaffected.
+- **Workaround for users:** if you want a softer release on a specific synth, pass `attack: 0.01` or higher and re-enable the curve via `env_curve: 2` explicitly per-note (this works once attack ≥ 10ms).
+
+### Per-synth loudness divergence
+
+- Synth output levels diverge from desktop Sonic Pi by anywhere from 0.30× to 4.20× depending on the synth. Examples (measured 2026-05-04 against Sonic Pi.app on the same composition):
+  - `:prophet` runs ~1.78× louder
+  - `:pluck` runs ~0.51× quieter
+  - Drum samples (`:bd_haus`, `:drum_cymbal_closed`) within ~2% of desktop
+- Mixer levels (`pre_amp`, `amp`) are calibrated for browser playback (no native driver attenuation), following the Sonic Tau reference rather than raw desktop Sonic Pi values.
+- **Workaround for users:** adjust master volume when porting compositions from desktop, and use `amp:` per-synth to fine-tune.
+- Tracking: a per-synth amp calibration phase is planned but deferred. Issue: [#268](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/268).
+
+### FX coverage
+
+- 42 FX are wired end-to-end. Only 2/42 are WAV-verified against desktop output (`:decimator`/bitcrusher and one other). The rest instantiate cleanly and route signal correctly, but their output level/shape vs desktop is not yet measured.
+- **Layer-isolation testing has confirmed `:reverb` and `:echo` route signal cleanly** (web/desktop ratio matches the dry-signal ratio for the same synth, indicating no FX-specific divergence).
+
+### Specific synths/samples with known issues
+
+- A small number of upstream synthdef binaries are missing from `supersonic-scsynth-synthdefs` and not loadable on web (`dark_sea_horn`, `singer`, `winwood_lead`). Tracking upstream at [samaaron/supersonic#7](https://github.com/samaaron/supersonic/issues/7).
+
 ## Performance
 
 - **Infinite loop detection**: Loops without `sleep` are stopped after 100,000 iterations to prevent browser tab freeze

--- a/tools/capture-desktop.ts
+++ b/tools/capture-desktop.ts
@@ -193,22 +193,24 @@ async function runDesktopCapture(
   const ports = discoverPorts()
   const notes: string[] = []
 
-  // Wrap the user's code with a recording-controller in_thread so it survives
-  // alongside whatever live_loops the user declared. The thread sleeps the
-  // capture window in REAL time (not bpm-scaled) via `rt(N)`-equivalent: we
-  // just send a literal sleep at default 60 BPM, where 1 beat == 1 second.
-  // After recording_stop we save to the absolute path. The user's loops keep
-  // running; /stop-all-jobs below tears them down.
+  // Wrap the user's code with bare top-level recording control. Sequence:
+  // user code (which may declare live_loops that fire async), then sleep
+  // duration_sec at default 60 BPM (1 beat = 1 second), then stop+save.
+  // The user's live_loops keep firing during the sleep and get captured;
+  // /stop-all-jobs below tears them down after recording is saved.
+  // Symmetric with tools/capture.ts wrap-recording mode (issue #266) so
+  // both sides use the same DSL pattern.
+  // with_bpm 60 around the sleep so the user's `use_bpm N` doesn't change
+  // the recording window length. At 60 BPM, sleep N == N real seconds.
   const durationSec = duration / 1000.0
   const wrapped =
     `recording_start\n` +
-    `in_thread do\n` +
+    `${code}\n` +
+    `with_bpm 60 do\n` +
     `  sleep ${durationSec}\n` +
-    `  recording_stop\n` +
-    `  recording_save "${audioPath}"\n` +
     `end\n` +
-    `\n` +
-    code
+    `recording_stop\n` +
+    `recording_save "${audioPath}"\n`
 
   // /run-code wire format: [token as int, code as string].
   const runPacket = oscMessage('/run-code', 'is', [ports.token, wrapped])

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -66,13 +66,37 @@ interface CaptureResult {
 async function captureRun(
   browser: Browser,
   code: string,
-  opts: { duration?: number; name?: string } = {}
+  opts: { duration?: number; name?: string; wrapRecordingSec?: number } = {}
 ): Promise<CaptureResult> {
   const duration = opts.duration ?? DEFAULT_DURATION
   const name = opts.name ?? 'capture'
   const safeName = name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60)
   const ts = new Date().toISOString().replace(/[:.]/g, '-')
   const prefix = `${ts}_${safeName}`
+
+  if (opts.wrapRecordingSec !== undefined && opts.wrapRecordingSec > 0) {
+    // Wrap user code so recording is DSL-driven on this side too — matches
+    // tools/capture-desktop.ts:202-211 so both sides record from the same
+    // virtual t=0 to t=duration. PR #228 pattern: recording_start, user code,
+    // sleep, recording_stop, recording_save — all bare top-level so the
+    // transpiler wraps them into a single __run_once whose main thread
+    // controls the recording window. The user's own live_loops keep firing
+    // in parallel and get captured. (Earlier attempt with in_thread broke:
+    // recording_stop/save inside an in_thread doesn't see the recorder
+    // state set by a bare top-level recording_start — issue #266.)
+    const dur = opts.wrapRecordingSec
+    // with_bpm 60 around the sleep so a user's `use_bpm 120` (or any other
+    // tempo set inside <code>) doesn't shrink/expand the recording window.
+    // At 60 BPM, sleep N == N real seconds.
+    code =
+      `recording_start\n` +
+      `${code}\n` +
+      `with_bpm 60 do\n` +
+      `  sleep ${dur}\n` +
+      `end\n` +
+      `recording_stop\n` +
+      `recording_save "spw_capture_${ts}.wav"\n`
+  }
 
   const context = await browser.newContext({
     acceptDownloads: true,
@@ -207,7 +231,7 @@ async function captureRun(
     const codeDrivesRecording = /\brecording_(start|save)\b/.test(code)
     if (hasRec > 0 && !codeDrivesRecording) {
       await recBtn.click()
-      await page.waitForTimeout(duration - 1000)
+      await page.waitForTimeout(duration)
       // Stop recording — button now says "Save"
       const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
       const hasSave = await saveBtn.count()
@@ -216,12 +240,12 @@ async function captureRun(
       } else {
         await recBtn.click()
       }
-      await page.waitForTimeout(2000) // wait for blob to be captured
+      await page.waitForTimeout(1500) // blob flush margin (matches desktop capture-desktop.ts +2500 minus blob-extract overhead)
     } else {
-      await page.waitForTimeout(duration - 1000)
-      // Give DSL-driven recording a beat to flush the MediaRecorder + WAV
-      // encode before we extract.
-      if (codeDrivesRecording) await page.waitForTimeout(2000)
+      // DSL-driven recording: the user code's recording_stop fires at user-code
+      // t=duration. Wait that long plus a blob flush margin for MediaRecorder
+      // + WAV encode to land in __capturedWavBlob before extraction.
+      await page.waitForTimeout(duration + 1500)
     }
 
     // Extract the captured WAV blob — populated by the click interceptor
@@ -528,6 +552,7 @@ async function main() {
   let duration = DEFAULT_DURATION
   let runAllExamples = false
   let batchPath: string | null = null
+  let wrapRecordingSec: number | undefined
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--file') {
@@ -543,6 +568,8 @@ async function main() {
     } else if (args[i] === '--example') {
       name = args[++i]
       // Will be loaded from the app's example selector
+    } else if (args[i] === '--wrap-recording') {
+      wrapRecordingSec = parseFloat(args[++i])
     } else if (!args[i].startsWith('--')) {
       code = args[i]
       name = 'inline'
@@ -604,7 +631,7 @@ end`
       const tag = `[${i + 1}/${fixtures.length}]`
       process.stdout.write(`  ${tag} ${fx.relPath}... `)
       try {
-        const result = await captureRun(browser, fx.code, { duration, name: fx.name })
+        const result = await captureRun(browser, fx.code, { duration, name: fx.name, wrapRecordingSec })
         const reportPath = resolve(CAPTURES_DIR, `batch_${fx.name}.md`)
         writeCaptureReport(result, reportPath)
         const errs = result.errorSummary.length
@@ -648,7 +675,7 @@ end`
 
     for (const ex of examples) {
       console.log(`  Running: ${ex.name}...`)
-      const result = await captureRun(browser, ex.code, { duration, name: ex.name })
+      const result = await captureRun(browser, ex.code, { duration, name: ex.name, wrapRecordingSec })
       const reportPath = resolve(CAPTURES_DIR, `${ex.name.replace(/\s+/g, '_')}.md`)
       writeCaptureReport(result, reportPath)
 
@@ -666,7 +693,7 @@ end`
     console.log(`\nSummary: ${summaryPath}`)
   } else {
     console.log(`  Running: ${name} (${duration}ms)...`)
-    const result = await captureRun(browser, code, { duration, name })
+    const result = await captureRun(browser, code, { duration, name, wrapRecordingSec })
     const reportPath = resolve(CAPTURES_DIR, `${name}.md`)
     writeCaptureReport(result, reportPath)
 

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -358,8 +358,15 @@ async function main(): Promise<void> {
   // name from --file basename or defaults to "inline" for raw code. So we
   // pass --name only to the desktop side and locate the web report via the
   // "Capture saved: <path>" line printed by capture.ts.
+  //
+  // Recording-mechanism parity (issue #266): desktop wraps user code with
+  // recording_start/stop internally (capture-desktop.ts:202). To match its
+  // DSL clock semantics on web, pass --wrap-recording to capture.ts so it
+  // takes the codeDrivesRecording branch instead of the UI Rec button path.
+  // Both sides now record from user-code t=0 to user-code t=duration.
+  const durationSec = args.duration / 1000.0
   const desktopArgs = [args.code, '--duration', String(args.duration), '--name', args.name]
-  const webArgs     = [args.code, '--duration', String(args.duration)]
+  const webArgs     = [args.code, '--duration', String(args.duration), '--wrap-recording', String(durationSec)]
 
   const [desktop, web] = await Promise.all([
     runChild('npx', ['tsx', 'tools/capture-desktop.ts', ...desktopArgs]),

--- a/tools/spectrogram-compare.py
+++ b/tools/spectrogram-compare.py
@@ -260,8 +260,20 @@ def main() -> int:
         print(f"Web WAV not found: {web_path}", file=sys.stderr)
         return 1
 
-    audio_d, sr_d = load_mono(desktop_path)
-    audio_w, sr_w = load_mono(web_path)
+    audio_d, sr_d_raw = load_mono(desktop_path)
+    audio_w, sr_w_raw = load_mono(web_path)
+
+    # Sample-rate normalization (issue #266): if the two WAVs are at different
+    # sample rates (44.1k vs 48k machines), every downstream metric — mel,
+    # MFCC, peak-freq, l2 — would compare frames that don't align in time or
+    # frequency, producing false divergence. Resample the lower-SR side up to
+    # the higher SR so all metrics see a single consistent grid.
+    sr = max(sr_d_raw, sr_w_raw)
+    if sr_d_raw != sr:
+        audio_d = librosa.resample(audio_d.astype(np.float32), orig_sr=sr_d_raw, target_sr=sr)
+    if sr_w_raw != sr:
+        audio_w = librosa.resample(audio_w.astype(np.float32), orig_sr=sr_w_raw, target_sr=sr)
+    sr_d = sr_w = sr
 
     mel_d = mel_db(audio_d, sr_d)
     mel_w = mel_db(audio_w, sr_w)
@@ -298,13 +310,15 @@ def main() -> int:
     metrics = {
         "desktop": {
             "path": desktop_path,
-            "sample_rate": int(sr_d),
+            "sample_rate": int(sr_d_raw),
+            "sample_rate_normalized": int(sr_d),
             "duration_s": float(audio_d.shape[0] / sr_d),
             "peak_freq_hz": peak_frequency(audio_d, sr_d),
         },
         "web": {
             "path": web_path,
-            "sample_rate": int(sr_w),
+            "sample_rate": int(sr_w_raw),
+            "sample_rate_normalized": int(sr_w),
             "duration_s": float(audio_w.shape[0] / sr_w),
             "peak_freq_hz": peak_frequency(audio_w, sr_w),
         },


### PR DESCRIPTION
## Summary

Two commits closing #266 (A/B comparator edge effects) plus a public docs update covering the audio-fidelity gaps the comparator surfaced.

### Commit 1 — \`7db6589\` comparator unified on DSL-driven recording

The A/B comparator (\`tools/compare-desktop-vs-web.ts\`, shipped in #264) produced reports with non-real edge effects polluting every whole-WAV metric. On a 5s drum loop @ 120 BPM: desktop silent on beats 0–1 (~2 beats front silence), web silent on beat 9 (~1 beat tail crop), MFCC distance 232 despite per-beat steady-state RMS matching to ~2%.

Root cause: the two child capture tools used different recording mechanisms with different time-zero semantics. Desktop wrapped user code with \`recording_start\` in the same OSC packet (locked to user-code t=0). Web fell through to the UI Rec button path (engine-ready + 500ms, recorded \`duration - 1000\` ms). Comparator passed raw user code without wrapping, so the \`codeDrivesRecording\` regex on \`capture.ts:207\` never matched.

**Fix:**
- \`capture.ts\` gains \`--wrap-recording <dur_sec>\` flag. Internally wraps user code with \`recording_start; <code>; with_bpm 60 do sleep N end; recording_stop; recording_save \"...\"\` so the existing DSL-driven path (PR #228) is taken instead of the UI Rec button. Drop the hardcoded \`-1000\` constant.
- \`capture-desktop.ts\` switches from \`in_thread\` wrapping to the same bare top-level pattern. The previous \`in_thread\` variant fails on web's engine (\`recording_save: no completed recording\` warning, filed as #267).
- \`with_bpm 60\` wraps the sleep so user code's \`use_bpm 120\` doesn't change the recording window length. At 60 BPM, sleep N == N real seconds.
- \`compare-desktop-vs-web.ts\` passes \`--wrap-recording\` to the web child. Single source of truth for timing semantics.
- \`spectrogram-compare.py\` resamples the lower-SR WAV up to the higher SR before mel/MFCC/peak-freq so 44.1k vs 48k machines don't get false divergence reports.

### Commit 2 — \`de9697a\` document audio fidelity divergences

Added \"Audio Fidelity vs Desktop Sonic Pi\" section to \`KNOWN_LIMITATIONS.md\` covering:
- Envelope shape (linear vs exponential, env_curve workaround)
- Per-synth loudness divergence (0.30×–4.20× range, calibration plan)
- FX coverage status (2/42 WAV-verified; reverb + echo proven layer-clean)
- Specific known-broken upstream synthdef binaries

## Test plan

- [x] \`npx tsc --noEmit\` — zero type errors
- [x] \`npx vitest run\` — 929/929 tests pass
- [x] Smoke test: 5s drum loop @ use_bpm 120, 10 beats — beat 0 audio non-zero on BOTH sides (was: desktop silent only); tail beats audio non-zero on BOTH sides (was: web cropped); no \`recording_save: no completed recording\` warnings
- [x] Verified UI Rec button legacy path still works (\`tools/capture.ts\` without \`--wrap-recording\`)
- [x] Full A/B sweep across 10 e2e fixtures: mean consistency 65/100, median 72 (sweep tool: \`/tmp/ab_sweep.ts\`, results: \`/tmp/ab_sweep_results.json\`)

## Out of scope (filed separately)

- #267 P3: \`recording_save\` inside \`in_thread\` engine bug — workaround applied here, fix deferred
- #268 P2: \`:prophet\` 1.78× louder than desktop — env_curve root-caused, mitigation options documented and deferred
- 42-FX WAV-verify sweep — unblocked by this PR, planned as follow-up phase
- MFCC threshold recalibration — depends on this landing first

## Refs

- Closes #266
- Builds on #264 (A/B comparator infrastructure)
- Mitigations for the divergences this PR documents are tracked in #268, samaaron/supersonic#7