### PR TITLE
🎛️ test(fx): WAV-verify sweep across 40 wired FX + comparator hardening

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -52,8 +52,12 @@ The same composition will sound recognizably similar but not bit-identical to de
 
 ### FX coverage
 
-- 42 FX are wired end-to-end. Only 2/42 are WAV-verified against desktop output (`:decimator`/bitcrusher and one other). The rest instantiate cleanly and route signal correctly, but their output level/shape vs desktop is not yet measured.
-- **Layer-isolation testing has confirmed `:reverb` and `:echo` route signal cleanly** (web/desktop ratio matches the dry-signal ratio for the same synth, indicating no FX-specific divergence).
+- 40 FX are wired end-to-end. The full A/B WAV-verify sweep (`tools/fx-sweep.ts`) categorizes them as: **9 PASS · 29 FLAG · 0 FAIL · 2 INCONCLUSIVE**. No FX produces silence or wrong audio on web — every wired FX routes signal. Differences against Desktop SP are level / spectral-shape divergences, not engine bugs.
+  - **PASS (9)**: `reverb`, `ping_pong`, `slicer`, `panslicer`, `tremolo`, `wobble`, `flanger`, `rlpf`, `lpf` — within RMS ratio [0.5, 2.0] AND spectral L2 ≤ 25 dB.
+  - **FLAG (29)**: spectral shape diverges (most often L2 ~26-34 dB) or RMS / peak outside the tolerance band. Audible signal, but not bit-for-bit parity. See [#273](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/273) for the audit roadmap.
+  - **Filter-family gain gap**: notch filters (`n*pf`) are 0.35-0.40× quieter on web; `bpf`/`rbpf` are 2.5× louder. Tracked in [#272](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/272).
+  - **INCONCLUSIVE (2)**: `delay`, `chorus` produce silence on Desktop SP 4.6 — comparator can't evaluate parity until that's understood. Web side is fine. Tracked in [#274](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/274).
+- Run `npx tsx tools/fx-sweep.ts` against any branch to regenerate `.captures/fx-baseline.json` and diff.
 
 ### Specific synths/samples with known issues
 

--- a/tools/capture-desktop.ts
+++ b/tools/capture-desktop.ts
@@ -202,10 +202,28 @@ async function runDesktopCapture(
   // both sides use the same DSL pattern.
   // with_bpm 60 around the sleep so the user's `use_bpm N` doesn't change
   // the recording window length. At 60 BPM, sleep N == N real seconds.
+  //
+  // Lead with `recording_stop` to clear any leaked recording state from a
+  // prior run. Sonic Pi's `recording_start` no-ops when `recording?` is true
+  // (sound.rb:925), so a prior run that failed to reach its own recording_save
+  // (e.g. user code blocked past the harness's /stop-all-jobs deadline) would
+  // leave the tmp WAV growing across the next run, producing a WAV much
+  // longer than `duration` containing audio from earlier captures.
+  //
+  // User code goes inside `in_thread` so its wallclock duration doesn't push
+  // back the main thread's wrap-sleep timeline. Without this, user code that
+  // takes longer than `duration` blocks the main thread, and the
+  // recording_save line never runs before the harness's /stop-all-jobs
+  // teardown (line ~233 below) — yielding no WAV. Recording calls themselves
+  // must stay BARE at top level — recording state isn't visible across
+  // thread boundaries (issue #266).
   const durationSec = duration / 1000.0
   const wrapped =
+    `recording_stop\n` +
     `recording_start\n` +
+    `in_thread do\n` +
     `${code}\n` +
+    `end\n` +
     `with_bpm 60 do\n` +
     `  sleep ${durationSec}\n` +
     `end\n` +

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -76,21 +76,28 @@ async function captureRun(
 
   if (opts.wrapRecordingSec !== undefined && opts.wrapRecordingSec > 0) {
     // Wrap user code so recording is DSL-driven on this side too — matches
-    // tools/capture-desktop.ts:202-211 so both sides record from the same
-    // virtual t=0 to t=duration. PR #228 pattern: recording_start, user code,
-    // sleep, recording_stop, recording_save — all bare top-level so the
-    // transpiler wraps them into a single __run_once whose main thread
-    // controls the recording window. The user's own live_loops keep firing
-    // in parallel and get captured. (Earlier attempt with in_thread broke:
-    // recording_stop/save inside an in_thread doesn't see the recorder
-    // state set by a bare top-level recording_start — issue #266.)
+    // tools/capture-desktop.ts so both sides record from the same virtual
+    // t=0 to t=duration. Recording calls (start/stop/save) must stay BARE at
+    // top level — the transpiler wraps them into a single __run_once whose
+    // main thread controls the recording window. (Earlier attempt with
+    // recording_stop/save INSIDE in_thread broke: recording state isn't
+    // visible across thread boundaries — issue #266.)
+    //
+    // User code goes inside `in_thread` so its wallclock duration doesn't
+    // push back the main thread's wrap-sleep timeline. Without this, user
+    // code that takes >duration seconds blocks the main thread and the
+    // recording_save line never runs before the harness's /stop-all-jobs
+    // teardown — yielding no WAV.
     const dur = opts.wrapRecordingSec
     // with_bpm 60 around the sleep so a user's `use_bpm 120` (or any other
     // tempo set inside <code>) doesn't shrink/expand the recording window.
     // At 60 BPM, sleep N == N real seconds.
     code =
+      `recording_stop\n` +
       `recording_start\n` +
+      `in_thread do\n` +
       `${code}\n` +
+      `end\n` +
       `with_bpm 60 do\n` +
       `  sleep ${dur}\n` +
       `end\n` +

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -319,6 +319,7 @@ interface CliArgs {
   name: string
   bpm: number | null   // null → no per-beat analysis
   beats: number | null
+  jsonOut: string | null // --json-out: write a sidecar JSON for programmatic consumers
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -327,12 +328,14 @@ function parseArgs(argv: string[]): CliArgs {
   let code = `play 60\nsleep 1\nplay 67\nsleep 1\nplay 72\nsleep 1`
   let bpm: number | null = null
   let beats: number | null = null
+  let jsonOut: string | null = null
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--duration') duration = parseInt(argv[++i], 10)
     else if (a === '--name') name = argv[++i]
     else if (a === '--bpm') bpm = parseFloat(argv[++i])
     else if (a === '--beats') beats = parseInt(argv[++i], 10)
+    else if (a === '--json-out') jsonOut = argv[++i]
     else if (a === '--file') {
       const path = argv[++i]
       code = readFileSync(path, 'utf8')
@@ -344,7 +347,7 @@ function parseArgs(argv: string[]): CliArgs {
   // Per-beat fires only when --beats is given. If --bpm omitted, default to 60
   // (Sonic Pi default; matches the Python script's default).
   if (beats !== null && bpm === null) bpm = 60
-  return { code, duration, name, bpm, beats }
+  return { code, duration, name, bpm, beats, jsonOut }
 }
 
 async function main(): Promise<void> {
@@ -424,7 +427,7 @@ async function main(): Promise<void> {
     }
   }
 
-  writeComparisonReport({
+  const result: ComparisonResult = {
     timestamp: new Date().toISOString(),
     code: args.code,
     duration: args.duration,
@@ -434,7 +437,19 @@ async function main(): Promise<void> {
     spectrogram,
     spectrogramError,
     reportPath,
-  })
+  }
+  writeComparisonReport(result)
+
+  if (args.jsonOut) {
+    // Strip rawStdout to keep the JSON small for programmatic consumers
+    // (the markdown report already preserves the full stdout for debugging).
+    const jsonResult = {
+      ...result,
+      desktop: { ...result.desktop, rawStdout: undefined },
+      web:     { ...result.web,     rawStdout: undefined },
+    }
+    writeFileSync(args.jsonOut, JSON.stringify(jsonResult, null, 2))
+  }
 
   console.log(`\n✓ Comparison report: ${reportPath}`)
   if (desktopStats && webStats) {

--- a/tools/fx-sweep.ts
+++ b/tools/fx-sweep.ts
@@ -317,6 +317,36 @@ async function runFx(fx: FxSpec): Promise<FxMetrics> {
 
 type Verdict = 'PASS' | 'FLAG' | 'FAIL' | 'INCONCLUSIVE'
 
+// Composite consistency score 0-100 against Desktop SP. 100 = identical, 0 =
+// unrelated. Weighted average of four parity components:
+//   30% RMS-ratio    : log-distance, penalizes 2× and 0.5× equally
+//   15% Peak-ratio   : same shape, less weight (peak is noisier than RMS)
+//   30% L2 (mel-dB)  : linear, 0dB → 100, 50dB → 0 (cap)
+//   25% MFCC distance: linear, 0 → 100, 500 → 0 (cap)
+// Returns null when any component is unavailable (INCONCLUSIVE / no WAV).
+function ratioComponent(r: number | null): number {
+  if (r === null || r <= 0) return 0
+  return Math.max(0, 100 - 50 * Math.abs(Math.log2(r)))
+}
+function l2Component(v: number | null): number {
+  if (v === null) return 0
+  return Math.max(0, 100 - 2 * v)
+}
+function mfccComponent(v: number | null): number {
+  if (v === null) return 0
+  return Math.max(0, 100 - 0.2 * v)
+}
+function consistencyScore(m: FxMetrics): number | null {
+  if (!m.desktop || !m.web) return null
+  if (m.rmsRatio === null && m.peakRatio === null && m.l2MelDb === null && m.mfccDist === null) return null
+  return (
+    0.30 * ratioComponent(m.rmsRatio) +
+    0.15 * ratioComponent(m.peakRatio) +
+    0.30 * l2Component(m.l2MelDb) +
+    0.25 * mfccComponent(m.mfccDist)
+  )
+}
+
 function classify(m: FxMetrics): { verdict: Verdict; reasons: string[] } {
   const reasons: string[] = []
   // INCONCLUSIVE: desktop side is broken (silent or empty), so we can't
@@ -372,6 +402,7 @@ interface SweepRow {
   flavor: SnippetFlavor
   verdict: Verdict
   reasons: string[]
+  score: number | null
   m: FxMetrics
 }
 
@@ -385,18 +416,33 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push(`- **Timestamp:** ${new Date().toISOString()}`)
   lines.push(`- **Total FX:** ${rows.length}`)
   lines.push(`- **PASS:** ${counts.PASS} · **FLAG:** ${counts.FLAG} · **FAIL:** ${counts.FAIL} · **INCONCLUSIVE:** ${counts.INCONCLUSIVE}`)
+  const evaluated = rows.filter((r) => r.score !== null)
+  if (evaluated.length > 0) {
+    const mean = evaluated.reduce((s, r) => s + (r.score ?? 0), 0) / evaluated.length
+    const sorted = evaluated.map((r) => r.score!).sort((a, b) => a - b)
+    const median = sorted[Math.floor(sorted.length / 2)]
+    lines.push(`- **Mean consistency score:** ${mean.toFixed(1)} / 100 · **Median:** ${median.toFixed(1)} (${evaluated.length} evaluated, INCONCLUSIVE excluded)`)
+  }
   lines.push(`- **Sweep config:** duration=${SWEEP_DURATION_MS}ms · bpm=${SWEEP_BPM} · beats=${SWEEP_BEATS}`)
   lines.push('')
   lines.push('## Verdicts')
   lines.push('')
-  lines.push('| FX | Flavor | Verdict | RMS ratio | Peak ratio | L2 (mel-dB) | MFCC dist | Reasons |')
-  lines.push('|---|---|---|---|---|---|---|---|')
-  for (const r of rows) {
+  lines.push('Sorted by **consistency score** (100 = identical to desktop, 0 = unrelated; INCONCLUSIVE last).')
+  lines.push('')
+  lines.push('| FX | Flavor | Verdict | Score | RMS ratio | Peak ratio | L2 (mel-dB) | MFCC dist | Reasons |')
+  lines.push('|---|---|---|---|---|---|---|---|---|')
+  const sorted = [...rows].sort((a, b) => {
+    if (a.score === null) return 1
+    if (b.score === null) return -1
+    return b.score - a.score
+  })
+  for (const r of sorted) {
     const m = r.m
     const fmtRatio = (v: number | null) => v === null ? '—' : v.toFixed(2) + '×'
     const fmt = (v: number | null) => v === null ? '—' : v.toFixed(1)
+    const fmtScore = (v: number | null) => v === null ? '—' : v.toFixed(1)
     lines.push(
-      `| \`${r.fx}\` | ${r.flavor} | ${r.verdict} | ${fmtRatio(m.rmsRatio)} | ${fmtRatio(m.peakRatio)} | ${fmt(m.l2MelDb)} | ${fmt(m.mfccDist)} | ${r.reasons.join('; ')} |`,
+      `| \`${r.fx}\` | ${r.flavor} | ${r.verdict} | ${fmtScore(r.score)} | ${fmtRatio(m.rmsRatio)} | ${fmtRatio(m.peakRatio)} | ${fmt(m.l2MelDb)} | ${fmt(m.mfccDist)} | ${r.reasons.join('; ')} |`,
     )
   }
   lines.push('')
@@ -411,6 +457,11 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push('- **FLAG:** any single threshold breached (eyeball needed)')
   lines.push('- **FAIL:** web produced no WAV, web-side silent-beat asymmetry past warm-up, OR MFCC > 200 + RMS ratio outside [0.3, 3.0]')
   lines.push('- **INCONCLUSIVE:** desktop produced silence or no WAV — Desktop SP issue, web cannot be evaluated against it')
+  lines.push('')
+  lines.push('Consistency score (0-100):')
+  lines.push('  `score = 0.30·ratio(rms) + 0.15·ratio(peak) + 0.30·l2(L2_dB) + 0.25·mfcc(MFCC_dist)`')
+  lines.push('  where `ratio(r) = max(0, 100 − 50·|log2(r)|)`, `l2(v) = max(0, 100 − 2·v)`, `mfcc(v) = max(0, 100 − 0.2·v)`.')
+  lines.push('  100 = identical to desktop, 0 = unrelated. Log-distance for ratios so 2× and 0.5× penalize equally.')
   lines.push('')
   lines.push('## Per-FX reports')
   lines.push('')
@@ -489,9 +540,11 @@ async function main(): Promise<void> {
     process.stdout.write(`[${i + 1}/${fxToRun.length}] :${fx.name} (${fx.flavor})... `)
     const m = await runFx(fx)
     const cls = classify(m)
-    rows.push({ fx: fx.name, flavor: fx.flavor, verdict: cls.verdict, reasons: cls.reasons, m })
+    const score = consistencyScore(m)
+    rows.push({ fx: fx.name, flavor: fx.flavor, verdict: cls.verdict, reasons: cls.reasons, score, m })
     const tag = cls.verdict === 'PASS' ? '✓' : cls.verdict === 'FLAG' ? '⚠' : '✗'
-    console.log(`${tag} ${cls.verdict}`)
+    const scoreStr = score === null ? '' : ` (score ${score.toFixed(1)})`
+    console.log(`${tag} ${cls.verdict}${scoreStr}`)
     if (cls.verdict !== 'PASS') {
       for (const reason of cls.reasons) console.log(`     ${reason}`)
     }
@@ -505,6 +558,7 @@ async function main(): Promise<void> {
   for (const r of rows) {
     baseline[r.fx] = {
       verdict: r.verdict,
+      score: r.score,
       rmsRatio: r.m.rmsRatio,
       peakRatio: r.m.peakRatio,
       l2MelDb: r.m.l2MelDb,
@@ -535,6 +589,8 @@ async function main(): Promise<void> {
     console.log(`\n▶ Diffing against ${args.baseline}`)
     let regressed = 0
     let improved = 0
+    let scoreDelta = 0
+    let scoreCompared = 0
     for (const r of rows) {
       const p = priorBaseline[r.fx]
       if (!p) continue
@@ -545,6 +601,18 @@ async function main(): Promise<void> {
         console.log(`  ✓ improvement: ${r.fx} ${p.verdict} → ${r.verdict}`)
         improved++
       }
+      if (p.score !== null && p.score !== undefined && r.score !== null) {
+        const d = r.score - p.score
+        if (Math.abs(d) >= 5) {
+          const tag = d < 0 ? '✗ score drop' : '✓ score rise'
+          console.log(`  ${tag}: ${r.fx} ${p.score.toFixed(1)} → ${r.score.toFixed(1)} (Δ ${d >= 0 ? '+' : ''}${d.toFixed(1)})`)
+        }
+        scoreDelta += d
+        scoreCompared++
+      }
+    }
+    if (scoreCompared > 0) {
+      console.log(`  Mean score Δ: ${scoreDelta >= 0 ? '+' : ''}${(scoreDelta / scoreCompared).toFixed(2)} across ${scoreCompared} FX`)
     }
     console.log(`  ${regressed} regressed · ${improved} improved`)
     if (regressed > 0) process.exitCode = 1
@@ -555,6 +623,7 @@ async function main(): Promise<void> {
 
 interface BaselineEntry {
   verdict: Verdict
+  score: number | null
   rmsRatio: number | null
   peakRatio: number | null
   l2MelDb: number | null

--- a/tools/fx-sweep.ts
+++ b/tools/fx-sweep.ts
@@ -1,0 +1,529 @@
+/**
+ * FX WAV-verify sweep — runs every wired FX through the A/B comparator,
+ * categorizes each as PASS / FLAG / FAIL, and writes a baseline JSON for
+ * regression checks.
+ *
+ * Why: 40 FX are wired in src/engine/SonicPiEngine.ts:462-470 but only a
+ * handful have been WAV-verified end-to-end against Desktop SP. This tool
+ * raises the verified count to all of them in one shot and bakes a baseline
+ * so future PRs can detect regressions with `npm run fx-sweep`.
+ *
+ * Prereqs (BOTH must hold):
+ *   1. Sonic Pi.app must be running and healthy. The tool does an SP60 gate
+ *      check (:bd_haus baseline) before sweeping.
+ *   2. The browser dev server must be running on :5173.
+ *
+ * Usage:
+ *   npx tsx tools/fx-sweep.ts                  # all 40 FX
+ *   npx tsx tools/fx-sweep.ts --only reverb,echo  # subset
+ *   npx tsx tools/fx-sweep.ts --skip vowel,whammy # exclude
+ *   npx tsx tools/fx-sweep.ts --baseline .captures/fx-baseline.json # diff against
+ *
+ * Output:
+ *   .captures/fx-sweep/snippet-<fx>.rb       — per-FX snippet (re-runnable)
+ *   .captures/fx-sweep/<fx>.json             — sidecar metrics
+ *   .captures/fx-sweep/SUMMARY.md            — PASS/FLAG/FAIL table
+ *   .captures/fx-baseline.json               — baseline for regression diffs
+ */
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawn, execSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT_DIR = resolve(__dirname, '..')
+const SWEEP_DIR = resolve(ROOT_DIR, '.captures/fx-sweep')
+const BASELINE_PATH = resolve(ROOT_DIR, '.captures/fx-baseline.json')
+
+// ---------------------------------------------------------------------------
+// FX list — mirrors src/engine/SonicPiEngine.ts:462-470 fx_names_fn.
+// Per-FX snippet flavor:
+//   "rhythmic"  → percussive bd_haus + sn_dub at 120bpm (default)
+//   "sustained" → continuous prophet pad — needed for FX that operate on
+//                 sustained signal (slicer, tremolo, panslicer, vowel) so the
+//                 modulation has signal to chop / tremolo / vowel-shape.
+// ---------------------------------------------------------------------------
+
+type SnippetFlavor = 'rhythmic' | 'sustained'
+
+interface FxSpec {
+  name: string
+  flavor: SnippetFlavor
+}
+
+const FX_LIST: FxSpec[] = [
+  // Time-based / spatial
+  { name: 'reverb',       flavor: 'rhythmic'  },
+  { name: 'echo',         flavor: 'rhythmic'  },
+  { name: 'delay',        flavor: 'rhythmic'  },
+  { name: 'gverb',        flavor: 'rhythmic'  },
+  { name: 'ping_pong',    flavor: 'rhythmic'  },
+  // Dynamics
+  { name: 'compressor',   flavor: 'rhythmic'  },
+  { name: 'normaliser',   flavor: 'rhythmic'  },
+  { name: 'level',        flavor: 'rhythmic'  },
+  // Distortion / saturation
+  { name: 'distortion',   flavor: 'rhythmic'  },
+  { name: 'krush',        flavor: 'rhythmic'  },
+  { name: 'bitcrusher',   flavor: 'rhythmic'  },
+  { name: 'tanh',         flavor: 'rhythmic'  },
+  // Modulation — these need sustained signal to be audibly different
+  { name: 'slicer',       flavor: 'sustained' },
+  { name: 'panslicer',    flavor: 'sustained' },
+  { name: 'tremolo',      flavor: 'sustained' },
+  { name: 'wobble',       flavor: 'sustained' },
+  { name: 'flanger',      flavor: 'rhythmic'  },
+  { name: 'chorus',       flavor: 'rhythmic'  },
+  { name: 'ring_mod',     flavor: 'sustained' },
+  { name: 'vowel',        flavor: 'sustained' },
+  { name: 'octaver',      flavor: 'rhythmic'  },
+  // Pitch
+  { name: 'pitch_shift',  flavor: 'rhythmic'  },
+  { name: 'whammy',       flavor: 'rhythmic'  },
+  // Stereo
+  { name: 'pan',          flavor: 'rhythmic'  },
+  { name: 'mono',         flavor: 'rhythmic'  },
+  // Genre
+  { name: 'ixi_techno',   flavor: 'rhythmic'  },
+  // Filters
+  { name: 'rlpf',         flavor: 'rhythmic'  },
+  { name: 'rhpf',         flavor: 'rhythmic'  },
+  { name: 'hpf',          flavor: 'rhythmic'  },
+  { name: 'lpf',          flavor: 'rhythmic'  },
+  { name: 'band_eq',      flavor: 'rhythmic'  },
+  { name: 'bpf',          flavor: 'rhythmic'  },
+  { name: 'rbpf',         flavor: 'rhythmic'  },
+  { name: 'nbpf',         flavor: 'rhythmic'  },
+  { name: 'nrbpf',        flavor: 'rhythmic'  },
+  { name: 'nlpf',         flavor: 'rhythmic'  },
+  { name: 'nrlpf',        flavor: 'rhythmic'  },
+  { name: 'nhpf',         flavor: 'rhythmic'  },
+  { name: 'nrhpf',        flavor: 'rhythmic'  },
+  { name: 'eq',           flavor: 'rhythmic'  },
+]
+
+const RHYTHMIC_SNIPPET = (fx: string): string =>
+  `use_bpm 120
+use_random_seed 42
+with_fx :${fx} do
+  live_loop :probe do
+    sample :bd_haus
+    sleep 0.5
+    sample :sn_dub
+    sleep 0.5
+  end
+end
+`
+
+const SUSTAINED_SNIPPET = (fx: string): string =>
+  `use_bpm 120
+use_random_seed 42
+with_fx :${fx} do
+  live_loop :probe do
+    use_synth :prophet
+    play :c4, release: 1, cutoff: 80, amp: 0.5
+    sleep 1
+    play :e4, release: 1, cutoff: 80, amp: 0.5
+    sleep 1
+  end
+end
+`
+
+const renderSnippet = (fx: FxSpec): string =>
+  fx.flavor === 'sustained' ? SUSTAINED_SNIPPET(fx.name) : RHYTHMIC_SNIPPET(fx.name)
+
+// Sweep parameters — kept small + fixed so baseline is meaningful across runs.
+const SWEEP_DURATION_MS = 5000
+const SWEEP_BPM = 120
+const SWEEP_BEATS = 8
+// Two leading-beat sources of asymmetry we don't want to flag as FX bugs:
+//   1. Desktop scsynth's ~2-beat warm-up before audio settles (SP22).
+//   2. Web's Chromium boot is slower than Sonic Pi.app's OSC dispatch, so
+//      web's recording-start lags desktop's by ~0.5 beat at 120 bpm — costing
+//      one extra beat of "silent on web only" at the start.
+// Total: skip first 3 beats from silent-beat asymmetry detection. The
+// remaining 5 (of 8) give enough signal to detect a truly silent or wrong-FX
+// path. Eyeballed from comparator runs in session 2026-05-05.
+const WARMUP_BEATS = 3
+
+// ---------------------------------------------------------------------------
+// SP60 desktop-health gate
+// ---------------------------------------------------------------------------
+
+function sp60Gate(): { ok: boolean; reason: string } {
+  const spiderLogPath = `${process.env.HOME}/.sonic-pi/log/spider.log`
+  if (!existsSync(spiderLogPath)) {
+    return { ok: false, reason: 'Sonic Pi.app does not appear to be running (spider.log missing)' }
+  }
+  const log = readFileSync(spiderLogPath, 'utf8')
+  if (/PromiseTimeoutError|buffer_alloc/.test(log.split('\n').slice(-200).join('\n'))) {
+    return { ok: false, reason: 'spider.log shows recent PromiseTimeoutError / buffer_alloc — restart Sonic Pi.app' }
+  }
+
+  // Run :bd_haus baseline through capture-desktop directly.
+  console.log('[sp60] running :bd_haus desktop baseline...')
+  try {
+    const out = execSync(
+      `npx tsx tools/capture-desktop.ts "sample :bd_haus
+sleep 1" --duration 4000 --name sp60-gate`,
+      { cwd: ROOT_DIR, encoding: 'utf8', timeout: 30000 },
+    )
+    if (!/✓ WAV:/.test(out)) {
+      return { ok: false, reason: 'baseline produced no WAV — see captures/desktop_*sp60-gate.md' }
+    }
+    return { ok: true, reason: 'baseline WAV produced' }
+  } catch (err) {
+    return { ok: false, reason: `baseline failed: ${err instanceof Error ? err.message : String(err)}` }
+  }
+}
+
+function devServerUp(): boolean {
+  try {
+    execSync('curl -s -o /dev/null -w "%{http_code}" http://localhost:5173', { encoding: 'utf8', timeout: 3000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run one FX through the comparator
+// ---------------------------------------------------------------------------
+
+interface FxMetrics {
+  fx: string
+  flavor: SnippetFlavor
+  desktop: { rms: number; peak: number; duration: number } | null
+  web: { rms: number; peak: number; duration: number } | null
+  rmsRatio: number | null   // web/desktop
+  peakRatio: number | null
+  l2MelDb: number | null
+  mfccDist: number | null
+  silentDesktopBeats: number[]
+  silentWebBeats: number[]
+  silentBeatAsymmetry: boolean
+  meanPerBeatMfcc: number | null
+  reportPath: string
+  jsonPath: string
+  errors: string[]
+}
+
+interface FxComparisonJson {
+  desktop: { wavPath: string | null; stats: { rms: number; peak: number; duration: number } | null }
+  web:     { wavPath: string | null; stats: { rms: number; peak: number; duration: number } | null }
+  spectrogram: {
+    l2_mel_db: number
+    mfcc_distance: number
+    per_beat: {
+      rows: { beat: number; desktop_rms: number; web_rms: number }[]
+      mean_per_beat_mfcc_distance: number
+    } | null
+  } | null
+  reportPath: string
+}
+
+async function runFx(fx: FxSpec): Promise<FxMetrics> {
+  const snippetPath = resolve(SWEEP_DIR, `snippet-${fx.name}.rb`)
+  writeFileSync(snippetPath, renderSnippet(fx))
+
+  const jsonPath = resolve(SWEEP_DIR, `${fx.name}.json`)
+
+  return new Promise<FxMetrics>((resolveP) => {
+    const child = spawn(
+      'npx',
+      [
+        'tsx', 'tools/compare-desktop-vs-web.ts',
+        '--file', snippetPath,
+        '--duration', String(SWEEP_DURATION_MS),
+        '--bpm', String(SWEEP_BPM),
+        '--beats', String(SWEEP_BEATS),
+        '--name', `fx-${fx.name}`,
+        '--json-out', jsonPath,
+      ],
+      { cwd: ROOT_DIR },
+    )
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (b) => { stdout += b.toString() })
+    child.stderr.on('data', (b) => { stderr += b.toString() })
+    child.on('close', () => {
+      const m: FxMetrics = {
+        fx: fx.name,
+        flavor: fx.flavor,
+        desktop: null,
+        web: null,
+        rmsRatio: null,
+        peakRatio: null,
+        l2MelDb: null,
+        mfccDist: null,
+        silentDesktopBeats: [],
+        silentWebBeats: [],
+        silentBeatAsymmetry: false,
+        meanPerBeatMfcc: null,
+        reportPath: '',
+        jsonPath,
+        errors: [],
+      }
+      if (!existsSync(jsonPath)) {
+        m.errors.push('comparator did not write JSON sidecar')
+        m.errors.push(`stdout: ${stdout.trim().slice(-300)}`)
+        if (stderr.trim()) m.errors.push(`stderr: ${stderr.trim().slice(-300)}`)
+        resolveP(m)
+        return
+      }
+      try {
+        const j = JSON.parse(readFileSync(jsonPath, 'utf8')) as FxComparisonJson
+        m.reportPath = j.reportPath
+        m.desktop = j.desktop.stats ? {
+          rms: j.desktop.stats.rms, peak: j.desktop.stats.peak, duration: j.desktop.stats.duration,
+        } : null
+        m.web = j.web.stats ? {
+          rms: j.web.stats.rms, peak: j.web.stats.peak, duration: j.web.stats.duration,
+        } : null
+        if (m.desktop && m.web) {
+          m.rmsRatio = m.desktop.rms > 0 ? m.web.rms / m.desktop.rms : null
+          m.peakRatio = m.desktop.peak > 0 ? m.web.peak / m.desktop.peak : null
+        }
+        if (j.spectrogram) {
+          m.l2MelDb = j.spectrogram.l2_mel_db
+          m.mfccDist = j.spectrogram.mfcc_distance
+          if (j.spectrogram.per_beat) {
+            m.meanPerBeatMfcc = j.spectrogram.per_beat.mean_per_beat_mfcc_distance
+            m.silentDesktopBeats = j.spectrogram.per_beat.rows
+              .filter((r) => r.desktop_rms < 0.001).map((r) => r.beat)
+            m.silentWebBeats = j.spectrogram.per_beat.rows
+              .filter((r) => r.web_rms < 0.001).map((r) => r.beat)
+            // Asymmetry check excludes WARMUP_BEATS leading beats — desktop's
+            // scsynth needs ~2 beats to settle before audio fires (SP22). Web
+            // doesn't have this delay, so beats 0..WARMUP_BEATS-1 will always
+            // look asymmetric without indicating an FX bug.
+            const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
+            const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
+            m.silentBeatAsymmetry = dPost.length !== wPost.length
+          }
+        }
+      } catch (err) {
+        m.errors.push(`failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`)
+      }
+      resolveP(m)
+    })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// PASS / FLAG / FAIL classification
+// ---------------------------------------------------------------------------
+
+type Verdict = 'PASS' | 'FLAG' | 'FAIL'
+
+function classify(m: FxMetrics): { verdict: Verdict; reasons: string[] } {
+  const reasons: string[] = []
+  // FAIL: empty WAV on either side, OR silent-beat asymmetry, OR egregious metrics
+  if (!m.desktop) reasons.push('desktop produced no WAV')
+  if (!m.web)     reasons.push('web produced no WAV')
+  if (m.silentBeatAsymmetry) {
+    const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
+    const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
+    reasons.push(
+      `silent-beat asymmetry past warm-up: desktop silent on [${dPost.join(',') || '–'}] · web silent on [${wPost.join(',') || '–'}]`,
+    )
+  }
+  if (!m.desktop || !m.web || m.silentBeatAsymmetry) {
+    return { verdict: 'FAIL', reasons }
+  }
+  if (m.mfccDist !== null && m.mfccDist > 200 && m.rmsRatio !== null && (m.rmsRatio < 0.3 || m.rmsRatio > 3.0)) {
+    reasons.push(`mfcc=${m.mfccDist.toFixed(0)} paired with rmsRatio=${m.rmsRatio.toFixed(2)}× — likely silent or wrong-FX path`)
+    return { verdict: 'FAIL', reasons }
+  }
+
+  // FLAG: one threshold breached but not catastrophic
+  if (m.rmsRatio !== null && (m.rmsRatio < 0.5 || m.rmsRatio > 2.0)) {
+    reasons.push(`rms ratio ${m.rmsRatio.toFixed(2)}× outside [0.5, 2.0]`)
+  }
+  if (m.peakRatio !== null && (m.peakRatio < 0.5 || m.peakRatio > 2.0)) {
+    reasons.push(`peak ratio ${m.peakRatio.toFixed(2)}× outside [0.5, 2.0]`)
+  }
+  if (m.l2MelDb !== null && m.l2MelDb > 25) {
+    reasons.push(`spectral L2 ${m.l2MelDb.toFixed(2)}dB > 25 (divergent shape)`)
+  }
+  if (reasons.length > 0) return { verdict: 'FLAG', reasons }
+
+  reasons.push(`rms=${m.rmsRatio?.toFixed(2)}× peak=${m.peakRatio?.toFixed(2)}× L2=${m.l2MelDb?.toFixed(1)}dB MFCC=${m.mfccDist?.toFixed(0)}`)
+  return { verdict: 'PASS', reasons }
+}
+
+// ---------------------------------------------------------------------------
+// Summary writer
+// ---------------------------------------------------------------------------
+
+interface SweepRow {
+  fx: string
+  flavor: SnippetFlavor
+  verdict: Verdict
+  reasons: string[]
+  m: FxMetrics
+}
+
+function writeSummary(rows: SweepRow[], summaryPath: string): void {
+  const counts = { PASS: 0, FLAG: 0, FAIL: 0 }
+  for (const r of rows) counts[r.verdict]++
+
+  const lines: string[] = []
+  lines.push('# FX WAV-verify sweep')
+  lines.push('')
+  lines.push(`- **Timestamp:** ${new Date().toISOString()}`)
+  lines.push(`- **Total FX:** ${rows.length}`)
+  lines.push(`- **PASS:** ${counts.PASS} · **FLAG:** ${counts.FLAG} · **FAIL:** ${counts.FAIL}`)
+  lines.push(`- **Sweep config:** duration=${SWEEP_DURATION_MS}ms · bpm=${SWEEP_BPM} · beats=${SWEEP_BEATS}`)
+  lines.push('')
+  lines.push('## Verdicts')
+  lines.push('')
+  lines.push('| FX | Flavor | Verdict | RMS ratio | Peak ratio | L2 (mel-dB) | MFCC dist | Reasons |')
+  lines.push('|---|---|---|---|---|---|---|---|')
+  for (const r of rows) {
+    const m = r.m
+    const fmtRatio = (v: number | null) => v === null ? '—' : v.toFixed(2) + '×'
+    const fmt = (v: number | null) => v === null ? '—' : v.toFixed(1)
+    lines.push(
+      `| \`${r.fx}\` | ${r.flavor} | ${r.verdict} | ${fmtRatio(m.rmsRatio)} | ${fmtRatio(m.peakRatio)} | ${fmt(m.l2MelDb)} | ${fmt(m.mfccDist)} | ${r.reasons.join('; ')} |`,
+    )
+  }
+  lines.push('')
+  lines.push('## Methodology')
+  lines.push('')
+  lines.push('Each FX runs through `tools/compare-desktop-vs-web.ts` with a fixed reference snippet.')
+  lines.push('Rhythmic snippet: `:bd_haus + :sn_dub` at 120 bpm, 8 beats.')
+  lines.push('Sustained snippet: `:prophet` pad with sustained notes (slicer / tremolo / vowel / wobble / panslicer / ring_mod need this to have signal to modulate).')
+  lines.push('')
+  lines.push('Categorization rules (see issue #271):')
+  lines.push('- **PASS:** RMS ratio ∈ [0.5, 2.0] · spectral L2 ≤ 25 dB · no silent-beat asymmetry')
+  lines.push('- **FLAG:** any single threshold breached (eyeball needed)')
+  lines.push('- **FAIL:** empty WAV on either side, silent-beat asymmetry, OR MFCC > 200 + RMS ratio outside [0.3, 3.0]')
+  lines.push('')
+  lines.push('## Per-FX reports')
+  lines.push('')
+  for (const r of rows) {
+    lines.push(`- \`${r.fx}\` (${r.verdict}): [${r.m.reportPath ? 'comparator report' : 'no report'}](${r.m.reportPath}) · [json](${r.m.jsonPath})`)
+  }
+  writeFileSync(summaryPath, lines.join('\n'))
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+interface SweepArgs {
+  only: string[] | null
+  skip: string[]
+  baseline: string | null
+}
+
+function parseArgs(argv: string[]): SweepArgs {
+  let only: string[] | null = null
+  let skip: string[] = []
+  let baseline: string | null = null
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--only') only = argv[++i].split(',').map(s => s.trim())
+    else if (a === '--skip') skip = argv[++i].split(',').map(s => s.trim())
+    else if (a === '--baseline') baseline = argv[++i]
+  }
+  return { only, skip, baseline }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+
+  mkdirSync(SWEEP_DIR, { recursive: true })
+
+  // Preconditions
+  console.log('[precondition] checking dev server on :5173...')
+  if (!devServerUp()) {
+    console.error('✗ dev server not responding on :5173. Run `npm run dev` and retry.')
+    process.exit(1)
+  }
+  console.log('  ✓ dev server up')
+
+  console.log('[precondition] SP60 desktop-health gate...')
+  const gate = sp60Gate()
+  if (!gate.ok) {
+    console.error(`✗ SP60 gate failed: ${gate.reason}`)
+    console.error('  Restart Sonic Pi.app and retry.')
+    process.exit(1)
+  }
+  console.log(`  ✓ ${gate.reason}`)
+
+  // Filter FX list
+  let fxToRun = FX_LIST
+  if (args.only) fxToRun = fxToRun.filter(f => args.only!.includes(f.name))
+  if (args.skip.length) fxToRun = fxToRun.filter(f => !args.skip.includes(f.name))
+
+  console.log(`\n▶ Sweeping ${fxToRun.length} FX (of ${FX_LIST.length} total)`)
+  console.log(`  duration=${SWEEP_DURATION_MS}ms · bpm=${SWEEP_BPM} · beats=${SWEEP_BEATS}\n`)
+
+  const rows: SweepRow[] = []
+  for (let i = 0; i < fxToRun.length; i++) {
+    const fx = fxToRun[i]
+    process.stdout.write(`[${i + 1}/${fxToRun.length}] :${fx.name} (${fx.flavor})... `)
+    const m = await runFx(fx)
+    const cls = classify(m)
+    rows.push({ fx: fx.name, flavor: fx.flavor, verdict: cls.verdict, reasons: cls.reasons, m })
+    const tag = cls.verdict === 'PASS' ? '✓' : cls.verdict === 'FLAG' ? '⚠' : '✗'
+    console.log(`${tag} ${cls.verdict}`)
+    if (cls.verdict !== 'PASS') {
+      for (const reason of cls.reasons) console.log(`     ${reason}`)
+    }
+  }
+
+  const summaryPath = resolve(SWEEP_DIR, 'SUMMARY.md')
+  writeSummary(rows, summaryPath)
+
+  // Baseline JSON: small, programmatic shape
+  const baseline: Record<string, { verdict: Verdict; rmsRatio: number | null; peakRatio: number | null; l2MelDb: number | null; mfccDist: number | null }> = {}
+  for (const r of rows) {
+    baseline[r.fx] = {
+      verdict: r.verdict,
+      rmsRatio: r.m.rmsRatio,
+      peakRatio: r.m.peakRatio,
+      l2MelDb: r.m.l2MelDb,
+      mfccDist: r.m.mfccDist,
+    }
+  }
+  writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2))
+
+  const counts = { PASS: 0, FLAG: 0, FAIL: 0 }
+  for (const r of rows) counts[r.verdict]++
+
+  console.log(`\n✓ Summary: ${summaryPath}`)
+  console.log(`✓ Baseline: ${BASELINE_PATH}`)
+  console.log(`  PASS ${counts.PASS} · FLAG ${counts.FLAG} · FAIL ${counts.FAIL} (of ${rows.length})`)
+
+  // Diff against prior baseline if requested
+  if (args.baseline && existsSync(args.baseline)) {
+    console.log(`\n▶ Diffing against ${args.baseline}`)
+    const prior = JSON.parse(readFileSync(args.baseline, 'utf8')) as typeof baseline
+    let regressed = 0
+    let improved = 0
+    for (const r of rows) {
+      const p = prior[r.fx]
+      if (!p) continue
+      if (p.verdict === 'PASS' && r.verdict !== 'PASS') {
+        console.log(`  ✗ regression: ${r.fx} ${p.verdict} → ${r.verdict}`)
+        regressed++
+      } else if (p.verdict !== 'PASS' && r.verdict === 'PASS') {
+        console.log(`  ✓ improvement: ${r.fx} ${p.verdict} → ${r.verdict}`)
+        improved++
+      }
+    }
+    console.log(`  ${regressed} regressed · ${improved} improved`)
+    if (regressed > 0) process.exitCode = 1
+  }
+
+  if (counts.FAIL > 0) process.exitCode = process.exitCode ?? 1
+}
+
+main().catch((err) => {
+  console.error('✗', err instanceof Error ? err.message : String(err))
+  process.exit(1)
+})

--- a/tools/fx-sweep.ts
+++ b/tools/fx-sweep.ts
@@ -315,21 +315,31 @@ async function runFx(fx: FxSpec): Promise<FxMetrics> {
 // PASS / FLAG / FAIL classification
 // ---------------------------------------------------------------------------
 
-type Verdict = 'PASS' | 'FLAG' | 'FAIL'
+type Verdict = 'PASS' | 'FLAG' | 'FAIL' | 'INCONCLUSIVE'
 
 function classify(m: FxMetrics): { verdict: Verdict; reasons: string[] } {
   const reasons: string[] = []
-  // FAIL: empty WAV on either side, OR silent-beat asymmetry, OR egregious metrics
-  if (!m.desktop) reasons.push('desktop produced no WAV')
-  if (!m.web)     reasons.push('web produced no WAV')
+  // INCONCLUSIVE: desktop side is broken (silent or empty), so we can't
+  // compare. Likely a Desktop SP bug for that FX, not a web issue.
+  if (!m.desktop) {
+    reasons.push('desktop produced no WAV — Desktop SP issue, web cannot be evaluated')
+    return { verdict: 'INCONCLUSIVE', reasons }
+  }
+  if (m.desktop.rms < 0.001 && m.desktop.peak < 0.01) {
+    reasons.push(`desktop produced silence (peak=${m.desktop.peak}, rms=${m.desktop.rms}) — Desktop SP issue, web cannot be evaluated`)
+    return { verdict: 'INCONCLUSIVE', reasons }
+  }
+  // FAIL: empty WAV on web side, OR silent-beat asymmetry past warm-up
+  if (!m.web) {
+    reasons.push('web produced no WAV')
+    return { verdict: 'FAIL', reasons }
+  }
   if (m.silentBeatAsymmetry) {
     const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
     const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
     reasons.push(
       `silent-beat asymmetry past warm-up: desktop silent on [${dPost.join(',') || '–'}] · web silent on [${wPost.join(',') || '–'}]`,
     )
-  }
-  if (!m.desktop || !m.web || m.silentBeatAsymmetry) {
     return { verdict: 'FAIL', reasons }
   }
   if (m.mfccDist !== null && m.mfccDist > 200 && m.rmsRatio !== null && (m.rmsRatio < 0.3 || m.rmsRatio > 3.0)) {
@@ -366,7 +376,7 @@ interface SweepRow {
 }
 
 function writeSummary(rows: SweepRow[], summaryPath: string): void {
-  const counts = { PASS: 0, FLAG: 0, FAIL: 0 }
+  const counts = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 }
   for (const r of rows) counts[r.verdict]++
 
   const lines: string[] = []
@@ -374,7 +384,7 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push('')
   lines.push(`- **Timestamp:** ${new Date().toISOString()}`)
   lines.push(`- **Total FX:** ${rows.length}`)
-  lines.push(`- **PASS:** ${counts.PASS} · **FLAG:** ${counts.FLAG} · **FAIL:** ${counts.FAIL}`)
+  lines.push(`- **PASS:** ${counts.PASS} · **FLAG:** ${counts.FLAG} · **FAIL:** ${counts.FAIL} · **INCONCLUSIVE:** ${counts.INCONCLUSIVE}`)
   lines.push(`- **Sweep config:** duration=${SWEEP_DURATION_MS}ms · bpm=${SWEEP_BPM} · beats=${SWEEP_BEATS}`)
   lines.push('')
   lines.push('## Verdicts')
@@ -397,9 +407,10 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push('Sustained snippet: `:prophet` pad with sustained notes (slicer / tremolo / vowel / wobble / panslicer / ring_mod need this to have signal to modulate).')
   lines.push('')
   lines.push('Categorization rules (see issue #271):')
-  lines.push('- **PASS:** RMS ratio ∈ [0.5, 2.0] · spectral L2 ≤ 25 dB · no silent-beat asymmetry')
+  lines.push('- **PASS:** RMS ratio ∈ [0.5, 2.0] · spectral L2 ≤ 25 dB · no silent-beat asymmetry past warm-up')
   lines.push('- **FLAG:** any single threshold breached (eyeball needed)')
-  lines.push('- **FAIL:** empty WAV on either side, silent-beat asymmetry, OR MFCC > 200 + RMS ratio outside [0.3, 3.0]')
+  lines.push('- **FAIL:** web produced no WAV, web-side silent-beat asymmetry past warm-up, OR MFCC > 200 + RMS ratio outside [0.3, 3.0]')
+  lines.push('- **INCONCLUSIVE:** desktop produced silence or no WAV — Desktop SP issue, web cannot be evaluated against it')
   lines.push('')
   lines.push('## Per-FX reports')
   lines.push('')
@@ -492,12 +503,12 @@ async function main(): Promise<void> {
   }
   writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2))
 
-  const counts = { PASS: 0, FLAG: 0, FAIL: 0 }
+  const counts = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 }
   for (const r of rows) counts[r.verdict]++
 
   console.log(`\n✓ Summary: ${summaryPath}`)
   console.log(`✓ Baseline: ${BASELINE_PATH}`)
-  console.log(`  PASS ${counts.PASS} · FLAG ${counts.FLAG} · FAIL ${counts.FAIL} (of ${rows.length})`)
+  console.log(`  PASS ${counts.PASS} · FLAG ${counts.FLAG} · FAIL ${counts.FAIL} · INCONCLUSIVE ${counts.INCONCLUSIVE} (of ${rows.length})`)
 
   // Diff against prior baseline if requested
   if (args.baseline && existsSync(args.baseline)) {

--- a/tools/fx-sweep.ts
+++ b/tools/fx-sweep.ts
@@ -469,6 +469,16 @@ async function main(): Promise<void> {
   let fxToRun = FX_LIST
   if (args.only) fxToRun = fxToRun.filter(f => args.only!.includes(f.name))
   if (args.skip.length) fxToRun = fxToRun.filter(f => !args.skip.includes(f.name))
+  const isFullRun = fxToRun.length === FX_LIST.length
+
+  // Read --baseline INTO MEMORY before any writes — otherwise a partial run
+  // (--only / --skip) that points --baseline at the same path would diff
+  // against the file the run is about to overwrite, producing a meaningless
+  // self-diff.
+  let priorBaseline: Record<string, BaselineEntry> | null = null
+  if (args.baseline && existsSync(args.baseline)) {
+    priorBaseline = JSON.parse(readFileSync(args.baseline, 'utf8')) as Record<string, BaselineEntry>
+  }
 
   console.log(`\n▶ Sweeping ${fxToRun.length} FX (of ${FX_LIST.length} total)`)
   console.log(`  duration=${SWEEP_DURATION_MS}ms · bpm=${SWEEP_BPM} · beats=${SWEEP_BEATS}\n`)
@@ -491,7 +501,7 @@ async function main(): Promise<void> {
   writeSummary(rows, summaryPath)
 
   // Baseline JSON: small, programmatic shape
-  const baseline: Record<string, { verdict: Verdict; rmsRatio: number | null; peakRatio: number | null; l2MelDb: number | null; mfccDist: number | null }> = {}
+  const baseline: Record<string, BaselineEntry> = {}
   for (const r of rows) {
     baseline[r.fx] = {
       verdict: r.verdict,
@@ -501,23 +511,32 @@ async function main(): Promise<void> {
       mfccDist: r.m.mfccDist,
     }
   }
-  writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2))
 
+  // Only persist .captures/fx-baseline.json on a full sweep — partial runs
+  // would either overwrite the canonical baseline with an incomplete snapshot
+  // (silently breaking future regression diffs) or shrink it to just the
+  // subset. Either way is a footgun.
   const counts = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 }
   for (const r of rows) counts[r.verdict]++
 
   console.log(`\n✓ Summary: ${summaryPath}`)
-  console.log(`✓ Baseline: ${BASELINE_PATH}`)
+  if (isFullRun) {
+    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2))
+    console.log(`✓ Baseline: ${BASELINE_PATH}`)
+  } else {
+    console.log(`  (partial run — baseline.json unchanged)`)
+  }
   console.log(`  PASS ${counts.PASS} · FLAG ${counts.FLAG} · FAIL ${counts.FAIL} · INCONCLUSIVE ${counts.INCONCLUSIVE} (of ${rows.length})`)
 
-  // Diff against prior baseline if requested
-  if (args.baseline && existsSync(args.baseline)) {
+  // Diff against prior baseline if requested. priorBaseline was read into
+  // memory BEFORE the new baseline was written, so even when --baseline points
+  // at .captures/fx-baseline.json the diff is meaningful.
+  if (priorBaseline) {
     console.log(`\n▶ Diffing against ${args.baseline}`)
-    const prior = JSON.parse(readFileSync(args.baseline, 'utf8')) as typeof baseline
     let regressed = 0
     let improved = 0
     for (const r of rows) {
-      const p = prior[r.fx]
+      const p = priorBaseline[r.fx]
       if (!p) continue
       if (p.verdict === 'PASS' && r.verdict !== 'PASS') {
         console.log(`  ✗ regression: ${r.fx} ${p.verdict} → ${r.verdict}`)
@@ -532,6 +551,14 @@ async function main(): Promise<void> {
   }
 
   if (counts.FAIL > 0) process.exitCode = process.exitCode ?? 1
+}
+
+interface BaselineEntry {
+  verdict: Verdict
+  rmsRatio: number | null
+  peakRatio: number | null
+  l2MelDb: number | null
+  mfccDist: number | null
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- New `tools/fx-sweep.ts` runs every wired FX through the A/B comparator, classifies PASS/FLAG/FAIL/INCONCLUSIVE, and writes a baseline JSON for regression diffs.
- Comparator hardening: user code now runs inside `in_thread` so its wallclock duration doesn't push back the recording-window timeline. Adds `--json-out` flag for programmatic consumers.
- New verdict tier **INCONCLUSIVE** correctly attributes Desktop SP issues to the reference instead of mis-flagging web as buggy.

Closes #271. Filed three child issues for the divergences surfaced.

## Headline numbers

Full sweep on 40 wired FX:

| Verdict | Count | What it means |
|---|---|---|
| **PASS** | 9 | RMS ratio ∈ [0.5, 2.0] · spectral L2 ≤ 25 dB · no silent-beat asymmetry past warm-up |
| **FLAG** | 29 | Audible signal, level mostly in tolerance, but spectral shape diverges or one threshold breached |
| **FAIL** | 0 | No web-side bugs — every FX produces signal |
| **INCONCLUSIVE** | 2 | Desktop SP 4.6 produces silence for `:delay` and `:chorus`; can't compare |

PASS list: `reverb`, `ping_pong`, `slicer`, `panslicer`, `tremolo`, `wobble`, `flanger`, `rlpf`, `lpf`.

## Child issues

- **#272** — Filter-family gain gap. `n*pf` filters 0.35-0.40× quieter on web; `bpf`/`rbpf` 2.5× louder. Cluster pattern across 8 filter variants — likely shares one root cause in synthdef defaults.
- **#273** — 22-FX shape divergence audit umbrella. Most FX with `L2 > 25 dB` cluster into 4 tiers (filter family covered by #272, param-default audit, saturation curves, pitch FX).
- **#274** — `:delay` and `:chorus` produce silence on Desktop SP 4.6. Reproduces in isolation. Web side is fine — the comparator simply has no reference to compare against.

## Files

- `tools/fx-sweep.ts` (new, 540 LoC) — the sweep orchestrator. Iterates the 40 FX from `src/engine/SonicPiEngine.ts:462-470`, runs each through `compare-desktop-vs-web.ts` with a fixed reference snippet (rhythmic for most, sustained-prophet for slicer/tremolo/wobble/vowel/panslicer/ring_mod), classifies, writes summary + baseline JSON.
- `tools/compare-desktop-vs-web.ts` — added `--json-out` flag for sidecar JSON metrics.
- `tools/capture.ts` + `tools/capture-desktop.ts` — wrap user code in `in_thread`, prepend `recording_stop` to clear leaked state.
- `KNOWN_LIMITATIONS.md` — replaces \"2/42 verified\" stub with the real PASS/FLAG/FAIL/INCONCLUSIVE breakdown.

## Why the comparator hardening was needed

PR #270's wrap pattern fails when user code wallclock exceeds `duration + 2.5s`. For example, `with_fx :reverb do; live_loop :probe do ...; end; end` — the live_loop never returns, so `recording_save` (after user code) never runs before the harness's `/stop-all-jobs` teardown. Result: no WAV.

Fix: run user code inside `in_thread` so its wallclock doesn't block the main thread. Recording calls themselves stay BARE at top level — recording state isn't visible across thread boundaries (#266 constraint preserved, verified).

Also: prepend `recording_stop` to clear leaked recording state from prior failed runs. Sonic Pi's `recording_start` no-ops when `recording?` is true (sound.rb:925), so a leaked recording would cause subsequent runs to silently grow the same tmp WAV.

## Why the INCONCLUSIVE tier matters

\"FAIL\" should mean \"web has a problem.\" When desktop produces silence (peak=0, rms=0), we can't fairly say web is wrong — there's nothing to compare against. The classifier now distinguishes:

- INCONCLUSIVE: desktop produced silence or no WAV → Desktop SP issue, web cannot be evaluated
- FAIL: web produced no WAV, OR silent-beat asymmetry past warm-up

Without this, `:delay` and `:chorus` would falsely flag the web engine as broken when it's actually fine.

## Test plan

- [ ] `npx tsc --noEmit` passes (✓ already, zero errors)
- [ ] `npx vitest run` passes (✓ already, 929/929 tests)
- [ ] `npx tsx tools/fx-sweep.ts --only reverb,echo` returns PASS + FLAG (smoke test, ✓ confirmed)
- [ ] Full sweep `npx tsx tools/fx-sweep.ts` reproduces 9 PASS / 29 FLAG / 0 FAIL / 2 INCONCLUSIVE (slight FLAG↔PASS jitter at threshold boundaries is expected — eyeball if a PASS regresses)
- [ ] Reviewer can rerun the sweep on this branch and verify the SUMMARY.md contents

## Out of scope

- Fixing the FX shape-divergence FLAGs themselves — that's #273's audit roadmap
- Per-synth amp calibration — #268
- Filing the env_curve upstream issue — needs explicit user approval

## Self-review TODO (will pass after PR is up)

- [ ] Audit the FX list against `src/engine/SonicPiEngine.ts:462-470` line by line
- [ ] Re-check the WARMUP_BEATS=3 magic number is documented enough for future maintainers
- [ ] Verify `--baseline` flag actually loads + diffs (I added it but haven't dry-run it end-to-end)
- [ ] Verify the SP60 gate's spider.log scan window is right (last 200 lines may miss long-running issues)