### PR TITLE
fix(engine): use_bpm leak from in_thread into nested live_loop (SP72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,14 @@ artifacts/*
 # Planning artifacts (internal)
 .planning/
 
-# Test results
+# Playwright test results
 test-results/
+
+# FX A/B inspector — mirrors .captures/ artifacts (≈80 MB of WAVs per build)
+# Built by `npm run inspect`. The HTML viewer (test_results/index.html) is
+# the only checked-in file; everything else is regenerated on demand.
+test_results/fx/
+test_results/fx-baseline.json
 
 # Playwright
 playwright-report/

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -52,12 +52,12 @@ The same composition will sound recognizably similar but not bit-identical to de
 
 ### FX coverage
 
-- 40 FX are wired end-to-end. The full A/B WAV-verify sweep (`tools/fx-sweep.ts`) categorizes them as: **9 PASS · 29 FLAG · 0 FAIL · 2 INCONCLUSIVE**. No FX produces silence or wrong audio on web — every wired FX routes signal. Differences against Desktop SP are level / spectral-shape divergences, not engine bugs.
-  - **PASS (9)**: `reverb`, `ping_pong`, `slicer`, `panslicer`, `tremolo`, `wobble`, `flanger`, `rlpf`, `lpf` — within RMS ratio [0.5, 2.0] AND spectral L2 ≤ 25 dB.
-  - **FLAG (29)**: spectral shape diverges (most often L2 ~26-34 dB) or RMS / peak outside the tolerance band. Audible signal, but not bit-for-bit parity. See [#273](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/273) for the audit roadmap.
-  - **Filter-family gain gap**: notch filters (`n*pf`) are 0.35-0.40× quieter on web; `bpf`/`rbpf` are 2.5× louder. Tracked in [#272](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/272).
-  - **INCONCLUSIVE (2)**: `delay`, `chorus` produce silence on Desktop SP 4.6 — comparator can't evaluate parity until that's understood. Web side is fine. Tracked in [#274](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/274).
-- Run `npx tsx tools/fx-sweep.ts` against any branch to regenerate `.captures/fx-baseline.json` and diff.
+- 40 FX are wired end-to-end. The full A/B WAV-verify sweep (`tools/fx-sweep.ts`) categorizes them as: **4 HIGH · 26 MID · 8 LOW · 2 INCONCLUSIVE**. No FX produces silence or wrong audio on web — every wired FX routes signal. Differences against Desktop SP are level / spectral-shape divergences, not engine bugs. Tier definitions ([#278](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/278)):
+  - **HIGH (4)** — score ≥ 70 AND MFCC dist ≤ 180 (close in level AND timbre): `panslicer`, `slicer`, `wobble`, `tremolo`. All sustained-flavor — those use `:prophet` pad snippets where the FX shape is directly comparable.
+  - **MID (26)** — score 50–70 (audible divergence; recognizable but not parity): `mono`, `pan`, `ping_pong`, `lpf`, `compressor`, `flanger`, `band_eq`, `eq`, `reverb`, `level`, `rlpf`, `bitcrusher`, `vowel`, `hpf`, `tanh`, `pitch_shift`, `ring_mod`, `rhpf`, `whammy`, `octaver`, `echo`, `krush`, `gverb`, `distortion`, `ixi_techno`, `nrbpf`. Spectral-shape divergence audit at [#273](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/273).
+  - **LOW (8)** — score < 50 (significantly different): `bpf`, `rbpf`, `nbpf`, `nlpf`, `nrlpf`, `nhpf`, `nrhpf`, `normaliser`. The filter-family gain gap is the dominant cause — notch filters 0.35–0.40× quieter, `bpf`/`rbpf` 2.5× louder. Tracked in [#272](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/272).
+  - **INCONCLUSIVE (2)** — Desktop SP 4.6 produces silence: `delay`, `chorus`. Comparator can't evaluate parity until that's understood; web side is fine. Tracked in [#274](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/274).
+- Run `npx tsx tools/fx-sweep.ts` against any branch to regenerate `.captures/fx-baseline.json` and diff. To re-classify under different thresholds without re-recording, run `npx tsx tools/fx-sweep.ts --reclassify-only`.
 - Audition the sweep results side-by-side: `npm run inspect` builds `test_results/fx/<fx>/` from the cached `.captures/` artifacts and serves the inspector at `http://localhost:8080`. Each FX shows desktop ↔ web `<audio>` players, sync-play, spectrogram, per-beat divergence, snippet, and metrics.
 
 ### Specific synths/samples with known issues

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -58,6 +58,7 @@ The same composition will sound recognizably similar but not bit-identical to de
   - **Filter-family gain gap**: notch filters (`n*pf`) are 0.35-0.40× quieter on web; `bpf`/`rbpf` are 2.5× louder. Tracked in [#272](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/272).
   - **INCONCLUSIVE (2)**: `delay`, `chorus` produce silence on Desktop SP 4.6 — comparator can't evaluate parity until that's understood. Web side is fine. Tracked in [#274](https://github.com/MrityunjayBhardwaj/SonicPi.js/issues/274).
 - Run `npx tsx tools/fx-sweep.ts` against any branch to regenerate `.captures/fx-baseline.json` and diff.
+- Audition the sweep results side-by-side: `npm run inspect` builds `test_results/fx/<fx>/` from the cached `.captures/` artifacts and serves the inspector at `http://localhost:8080`. Each FX shows desktop ↔ web `<audio>` players, sync-play, spectrogram, per-beat divergence, snippet, and metrics.
 
 ### Specific synths/samples with known issues
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "build:docs": "vitepress build docs",
     "dev:docs": "vitepress dev docs",
     "build:all": "npm run build:single && npm run build:docs",
+    "inspect:build": "tsx tools/build-test-results.ts",
+    "inspect": "tsx tools/build-test-results.ts && python3 -m http.server -d test_results 8080",
     "postinstall": "cp node_modules/web-tree-sitter/web-tree-sitter.wasm public/tree-sitter.wasm 2>/dev/null; cp node_modules/tree-sitter-wasms/out/tree-sitter-ruby.wasm public/tree-sitter-ruby.wasm 2>/dev/null; true"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "build:docs": "vitepress build docs",
     "dev:docs": "vitepress dev docs",
     "build:all": "npm run build:single && npm run build:docs",
-    "inspect:build": "tsx tools/build-test-results.ts",
-    "inspect": "tsx tools/build-test-results.ts && python3 -m http.server -d test_results 8080",
+    "inspect:build": "npx tsx tools/build-test-results.ts",
+    "inspect": "npx tsx tools/build-test-results.ts && python3 -m http.server -d test_results 8080",
     "postinstall": "cp node_modules/web-tree-sitter/web-tree-sitter.wasm public/tree-sitter.wasm 2>/dev/null; cp node_modules/tree-sitter-wasms/out/tree-sitter-ruby.wasm public/tree-sitter-ruby.wasm 2>/dev/null; true"
   },
   "engines": {

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -150,6 +150,18 @@ export class ProgramBuilder {
     return this
   }
 
+  /** Read-only view of the builder's current bpm. Used by SonicPiEngine when a
+   *  nested `live_loop` registers from inside another's builderFn — the
+   *  nested loop must inherit the *parent's* in-flight bpm (set by `b.use_bpm`
+   *  during this build phase), not the engine-level `defaultBpm` (which is
+   *  only mutated by top-level `use_bpm`). See SP72. */
+  get currentBpm(): number { return this._currentBpm }
+
+  /** Read-only view of the builder's current default synth. Same rationale as
+   *  currentBpm: nested `live_loop` registrations need the parent's in-flight
+   *  synth, not the engine-level `defaultSynth`. */
+  get currentDefaultSynth(): string { return this.currentSynth }
+
   /** Set BPM to match a sample's natural tempo. */
   use_sample_bpm(name: string, opts?: Record<string, unknown>): this {
     const dur = this.sample_duration(name, opts)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -108,6 +108,19 @@ export class SonicPiEngine {
   private buildNestingDepth = 0
   /** Names that already received the "nested live_loop" warning so we don't spam. */
   private nestedWarned = new Set<string>()
+  /**
+   * The ProgramBuilder currently executing its synchronous builderFn (SP72).
+   * Set in `asyncFn` around the `builderFn(builder)` call, restored on exit.
+   * When a nested `live_loop` registers from inside another's builderFn,
+   * `wrappedLiveLoop` reads `currentBuildBuilder.currentBpm` /
+   * `currentBuildBuilder.currentDefaultSynth` to inherit the parent's
+   * in-flight bpm/synth — which is what `b.use_bpm(N)` / `b.use_synth(:n)`
+   * inside the parent's body just set. The engine-level `defaultBpm` /
+   * `defaultSynth` are mutated only by *top-level* `use_bpm` / `use_synth`,
+   * so they would yield the wrong value here (commonly 60 / 'beep' for
+   * code wrapped in `in_thread` by capture tools).
+   */
+  private currentBuildBuilder: ProgramBuilder | null = null
   /** Persistent top-level FX state — keyed by scope ID, shared across loops in same with_fx. */
   private persistentFx = new Map<string, { buses: number[]; groups: number[]; outBus: number }>()
   /** Maps loop name → FX scope ID (loops under same with_fx share a scope). */
@@ -642,9 +655,22 @@ export class SonicPiEngine {
           // so an instance-level counter is safe.
           scopeHandle?.enterScope(name)
           this.buildNestingDepth++
+          // SP72: expose this builder to nested wrappedLiveLoop calls that fire
+          // synchronously inside builderFn. They need our `_currentBpm` /
+          // `currentSynth` (mutated by `b.use_bpm` / `b.use_synth` during this
+          // build phase) to inherit the correct values, instead of reading
+          // engine-level defaultBpm / defaultSynth (which are mutated only by
+          // top-level use_bpm / use_synth and would yield 60 / 'beep' for code
+          // wrapped in `in_thread` by capture tools). JS is single-threaded so
+          // builderFn never interleaves with another asyncFn — a single field
+          // is safe; we still push/restore so nested live_loops nested in
+          // ANOTHER live_loop's body still see the correct (innermost) parent.
+          const prevBuildBuilder = this.currentBuildBuilder
+          this.currentBuildBuilder = builder
           try {
             builderFn(builder)
           } finally {
+            this.currentBuildBuilder = prevBuildBuilder
             this.buildNestingDepth--
             scopeHandle?.exitScope()
           }
@@ -676,6 +702,19 @@ export class SonicPiEngine {
           scheduler.fireCue(name, name)
         }
 
+        // SP72: when this registration fires from inside a parent builderFn
+        // (buildNestingDepth > 0), the user's intent is "inherit the in-flight
+        // bpm/synth from my parent thread/loop". The parent's `b.use_bpm(N)` /
+        // `b.use_synth(:n)` mutated the parent ProgramBuilder's local state but
+        // did NOT touch engine-level defaultBpm/defaultSynth (those mutate only
+        // from top-level use_bpm/use_synth). Read from the parent builder if
+        // we have one, else fall back to engine defaults.
+        const parentBuilder = this.currentBuildBuilder
+        const inheritedBpm = (this.buildNestingDepth > 0 && parentBuilder)
+          ? parentBuilder.currentBpm : defaultBpm
+        const inheritedSynth = (this.buildNestingDepth > 0 && parentBuilder)
+          ? parentBuilder.currentDefaultSynth : defaultSynth
+
         if (this.buildNestingDepth > 0 && isReEvaluate) {
           // Nested hot-swap (issue #199): this call is firing from inside an
           // outer live_loop's iteration, AFTER the top-level evaluate()'s
@@ -690,12 +729,13 @@ export class SonicPiEngine {
             // the outer's reEvaluate, so the inner's old loopBus is dead. Bind
             // task.outBus to the freshly-allocated bus, and refresh bpm /
             // currentSynth so a top-level use_bpm/use_synth change propagates.
-            existing.bpm = defaultBpm
-            existing.currentSynth = defaultSynth
+            // SP72: nested hot-swap inherits from parent builder, not defaults.
+            existing.bpm = inheritedBpm
+            existing.currentSynth = inheritedSynth
             existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
-            scheduler.registerLoop(name, asyncFn, { bpm: defaultBpm, synth: defaultSynth })
+            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth })
             const task = scheduler.getTask(name)
             if (task) task.outBus = loopBus
           }
@@ -706,8 +746,12 @@ export class SonicPiEngine {
           scheduler.registerLoop(name, asyncFn)
           const task = scheduler.getTask(name)
           if (task) {
-            task.bpm = defaultBpm
-            task.currentSynth = defaultSynth
+            // SP72: nested initial registration inherits parent builder's bpm
+            // and synth (set by `b.use_bpm`/`b.use_synth` inside the parent's
+            // builderFn body). Top-level registrations (depth=0) use the
+            // engine-level defaults — unchanged from prior behavior.
+            task.bpm = inheritedBpm
+            task.currentSynth = inheritedSynth
             task.outBus = loopBus
           }
         }

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -130,17 +130,17 @@
       .chip[data-on="1"] {
         color: var(--text);
       }
-      .chip[data-verdict="PASS"][data-on="1"] {
+      .chip[data-verdict="HIGH"][data-on="1"] {
         background: rgba(158, 206, 106, 0.15);
         border-color: var(--pass);
         color: var(--pass);
       }
-      .chip[data-verdict="FLAG"][data-on="1"] {
+      .chip[data-verdict="MID"][data-on="1"] {
         background: rgba(224, 175, 104, 0.15);
         border-color: var(--flag);
         color: var(--flag);
       }
-      .chip[data-verdict="FAIL"][data-on="1"] {
+      .chip[data-verdict="LOW"][data-on="1"] {
         background: rgba(247, 118, 142, 0.15);
         border-color: var(--fail);
         color: var(--fail);
@@ -200,15 +200,15 @@
         line-height: 1;
         display: inline-block;
       }
-      .badge.PASS {
+      .badge.HIGH {
         background: rgba(158, 206, 106, 0.15);
         color: var(--pass);
       }
-      .badge.FLAG {
+      .badge.MID {
         background: rgba(224, 175, 104, 0.15);
         color: var(--flag);
       }
-      .badge.FAIL {
+      .badge.LOW {
         background: rgba(247, 118, 142, 0.15);
         color: var(--fail);
       }
@@ -457,10 +457,10 @@
               spellcheck="false"
             />
             <div class="filters" id="filters">
-              <button class="chip" data-verdict="PASS" data-on="1">PASS</button>
-              <button class="chip" data-verdict="FLAG" data-on="1">FLAG</button>
-              <button class="chip" data-verdict="FAIL" data-on="1">FAIL</button>
-              <button class="chip" data-verdict="INCONCLUSIVE" data-on="1">
+              <button class="chip" data-verdict="HIGH" data-on="1" title="score ≥ 70 AND MFCC ≤ 180">HIGH</button>
+              <button class="chip" data-verdict="MID" data-on="1" title="50 ≤ score &lt; 70, or HIGH-by-score-only-but-MFCC-too-high">MID</button>
+              <button class="chip" data-verdict="LOW" data-on="1" title="score &lt; 50">LOW</button>
+              <button class="chip" data-verdict="INCONCLUSIVE" data-on="1" title="desktop side silent or missing">
                 INCONCLUSIVE
               </button>
             </div>
@@ -484,7 +484,7 @@
         entries: [],
         filtered: [],
         selectedFx: null,
-        verdicts: { PASS: true, FLAG: true, FAIL: true, INCONCLUSIVE: true },
+        verdicts: { HIGH: true, MID: true, LOW: true, INCONCLUSIVE: true },
         search: "",
         sort: "score-desc",
       };
@@ -535,10 +535,10 @@
         const dt = new Date(data.generatedAt);
         const ago = humanAgo(dt);
         return `
-          <span><b class="ratio-good">${c.PASS}</b> PASS</span>
-          <span><b class="ratio-mid">${c.FLAG}</b> FLAG</span>
-          <span><b class="ratio-bad">${c.FAIL}</b> FAIL</span>
-          <span><b>${c.INCONCLUSIVE}</b> incon</span>
+          <span><b class="ratio-good">${c.HIGH ?? 0}</b> HIGH</span>
+          <span><b class="ratio-mid">${c.MID ?? 0}</b> MID</span>
+          <span><b class="ratio-bad">${c.LOW ?? 0}</b> LOW</span>
+          <span><b>${c.INCONCLUSIVE ?? 0}</b> incon</span>
           <span title="${dt.toISOString()}">· ${ago}</span>
         `;
       }
@@ -566,7 +566,7 @@
       }
 
       function comparator(mode) {
-        const verdictOrder = { PASS: 0, FLAG: 1, FAIL: 2, INCONCLUSIVE: 3 };
+        const verdictOrder = { HIGH: 0, MID: 1, LOW: 2, INCONCLUSIVE: 3 };
         const inconLast = (a, b) => {
           const ai = a.verdict === "INCONCLUSIVE" ? 1 : 0;
           const bi = b.verdict === "INCONCLUSIVE" ? 1 : 0;
@@ -597,9 +597,17 @@
         const html = state.filtered
           .map((e) => {
             const score = e.verdict === "INCONCLUSIVE" ? "—" : e.score.toFixed(1);
+            const mfccCls =
+              e.mfccDist == null
+                ? "ratio-bad"
+                : e.mfccDist <= 180
+                ? "ratio-good"
+                : e.mfccDist <= 250
+                ? "ratio-mid"
+                : "ratio-bad";
             const sub = e.verdict === "INCONCLUSIVE"
               ? "no shared signal"
-              : `RMS ${fmtRatio(e.rmsRatio)}× · Peak ${fmtRatio(e.peakRatio)}× · L2 ${e.l2MelDb.toFixed(1)} · MFCC ${Math.round(e.mfccDist)}`;
+              : `RMS ${fmtRatio(e.rmsRatio)}× · L2 ${e.l2MelDb.toFixed(1)}dB · <span class="${mfccCls}">MFCC ${Math.round(e.mfccDist)}</span>`;
             return `
               <div class="row" data-fx="${e.fx}" ${state.selectedFx === e.fx ? 'data-active="1"' : ""}>
                 <div class="row-name">${e.fx}</div>
@@ -680,11 +688,19 @@
         if (desktopUrl) links.push(`<a href="${desktopUrl}" target="_blank">desktop.wav ↗</a>`);
         if (webUrl) links.push(`<a href="${webUrl}" target="_blank">web.wav ↗</a>`);
 
+        const mfccBadgeCls =
+          e.mfccDist == null
+            ? "ratio-bad"
+            : e.mfccDist <= 180
+            ? "ratio-good"
+            : e.mfccDist <= 250
+            ? "ratio-mid"
+            : "ratio-bad";
         $("detail").innerHTML = `
           <div class="detail-head">
             <h1>:${e.fx}</h1>
             <span class="badge ${e.verdict}">${e.verdict}</span>
-            <span class="meta" style="margin:0">${e.flavor} · bpm ${e.bpm} · ${e.beats || "—"} beats</span>
+            <span class="meta" style="margin:0">${e.flavor} · bpm ${e.bpm} · ${e.beats || "—"} beats · <span class="${mfccBadgeCls}">MFCC ${e.mfccDist == null ? "—" : Math.round(e.mfccDist)}</span></span>
             <div class="score">${score} <small>/ 100</small></div>
           </div>
 
@@ -719,8 +735,14 @@
           <div class="links">${links.join("")}</div>
 
           <div class="footer-meta">
-            Score formula: 0.30·ratio(rms) + 0.15·ratio(peak) + 0.30·l2 + 0.25·mfcc.
-            Source artifacts: <code>.captures/</code> · this folder is a copy.
+            <strong>Tiers:</strong>
+            <span class="ratio-good">HIGH</span> = score ≥ 70 AND MFCC ≤ 180 ·
+            <span class="ratio-mid">MID</span> = 50 ≤ score &lt; 70 (or HIGH-by-score-only-but-MFCC > 180) ·
+            <span class="ratio-bad">LOW</span> = score &lt; 50 ·
+            INCONCLUSIVE = desktop silent.
+            <br />
+            Score: 0.30·ratio(rms) + 0.15·ratio(peak) + 0.30·l2 + 0.25·mfcc.
+            Source: <code>.captures/</code>.
           </div>
         `;
 

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -1,0 +1,843 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>SonicPi.js — FX A/B Inspector</title>
+    <style>
+      :root {
+        --bg: #1a1b26;
+        --bg-elev: #1f2335;
+        --bg-row: #16161e;
+        --bg-row-hover: #232540;
+        --bg-row-active: #2a2f4a;
+        --border: #2a2e46;
+        --text: #c0caf5;
+        --text-dim: #7a85b3;
+        --text-mute: #565f89;
+        --accent: #ff1493;
+        --accent-2: #7aa2f7;
+        --pass: #9ece6a;
+        --flag: #e0af68;
+        --fail: #f7768e;
+        --incon: #565f89;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+          "Liberation Mono", monospace;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
+          sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        font-size: 13px;
+        overflow: hidden;
+      }
+      .app {
+        display: grid;
+        grid-template-columns: 380px 1fr;
+        height: 100vh;
+      }
+      /* ───────── sidebar ───────── */
+      .sidebar {
+        background: var(--bg-elev);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+      .sidebar-head {
+        padding: 14px 16px 10px;
+        border-bottom: 1px solid var(--border);
+      }
+      .sidebar-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-dim);
+        margin: 0 0 8px;
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        justify-content: space-between;
+      }
+      .sidebar-title strong {
+        color: var(--text);
+        letter-spacing: 0;
+        text-transform: none;
+        font-size: 14px;
+      }
+      .summary {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        font-size: 11px;
+        color: var(--text-dim);
+        margin-bottom: 10px;
+      }
+      .summary span {
+        display: inline-flex;
+        gap: 4px;
+        align-items: center;
+      }
+      .summary b {
+        color: var(--text);
+        font-weight: 600;
+      }
+      .controls {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .controls input[type="search"],
+      .controls select {
+        background: var(--bg);
+        border: 1px solid var(--border);
+        color: var(--text);
+        padding: 6px 10px;
+        border-radius: 6px;
+        font: inherit;
+        outline: none;
+      }
+      .controls input[type="search"]:focus,
+      .controls select:focus {
+        border-color: var(--accent-2);
+      }
+      .filters {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+      }
+      .chip {
+        cursor: pointer;
+        user-select: none;
+        font-size: 11px;
+        padding: 3px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        color: var(--text-dim);
+        background: transparent;
+        font-weight: 600;
+      }
+      .chip[data-on="1"] {
+        color: var(--text);
+      }
+      .chip[data-verdict="PASS"][data-on="1"] {
+        background: rgba(158, 206, 106, 0.15);
+        border-color: var(--pass);
+        color: var(--pass);
+      }
+      .chip[data-verdict="FLAG"][data-on="1"] {
+        background: rgba(224, 175, 104, 0.15);
+        border-color: var(--flag);
+        color: var(--flag);
+      }
+      .chip[data-verdict="FAIL"][data-on="1"] {
+        background: rgba(247, 118, 142, 0.15);
+        border-color: var(--fail);
+        color: var(--fail);
+      }
+      .chip[data-verdict="INCONCLUSIVE"][data-on="1"] {
+        background: rgba(86, 95, 137, 0.2);
+        border-color: var(--incon);
+        color: var(--text-dim);
+      }
+      .list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 6px 0;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 4px 12px;
+        padding: 9px 16px;
+        cursor: pointer;
+        border-left: 3px solid transparent;
+        align-items: center;
+      }
+      .row:hover {
+        background: var(--bg-row-hover);
+      }
+      .row[data-active="1"] {
+        background: var(--bg-row-active);
+        border-left-color: var(--accent);
+      }
+      .row-name {
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--text);
+      }
+      .row-score {
+        font-family: var(--mono);
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--text);
+        text-align: right;
+        line-height: 1;
+      }
+      .row-sub {
+        grid-column: 1 / 2;
+        font-size: 11px;
+        color: var(--text-mute);
+        font-family: var(--mono);
+      }
+      .badge {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 2px 6px;
+        border-radius: 3px;
+        line-height: 1;
+        display: inline-block;
+      }
+      .badge.PASS {
+        background: rgba(158, 206, 106, 0.15);
+        color: var(--pass);
+      }
+      .badge.FLAG {
+        background: rgba(224, 175, 104, 0.15);
+        color: var(--flag);
+      }
+      .badge.FAIL {
+        background: rgba(247, 118, 142, 0.15);
+        color: var(--fail);
+      }
+      .badge.INCONCLUSIVE {
+        background: rgba(86, 95, 137, 0.2);
+        color: var(--text-dim);
+      }
+      /* ───────── detail ───────── */
+      .detail {
+        overflow-y: auto;
+        padding: 24px 32px 64px;
+      }
+      .detail-empty {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100%;
+        color: var(--text-mute);
+        font-size: 14px;
+      }
+      .detail-head {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        margin-bottom: 8px;
+      }
+      .detail-head h1 {
+        margin: 0;
+        font-family: var(--mono);
+        font-size: 22px;
+        font-weight: 600;
+        color: var(--text);
+      }
+      .detail-head .score {
+        margin-left: auto;
+        font-family: var(--mono);
+        font-size: 28px;
+        font-weight: 600;
+      }
+      .detail-head .score small {
+        color: var(--text-mute);
+        font-size: 14px;
+        font-weight: 400;
+      }
+      .meta {
+        color: var(--text-dim);
+        font-size: 12px;
+        margin-bottom: 18px;
+      }
+      .meta code {
+        font-family: var(--mono);
+        color: var(--text);
+      }
+      .audio-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+        margin-bottom: 14px;
+      }
+      .audio-card {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 12px 14px;
+      }
+      .audio-card h3 {
+        margin: 0 0 8px;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-dim);
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+      }
+      .audio-card h3 span {
+        font-family: var(--mono);
+        text-transform: none;
+        letter-spacing: 0;
+        color: var(--text-mute);
+        font-size: 11px;
+        font-weight: 400;
+      }
+      .audio-card audio {
+        width: 100%;
+        height: 32px;
+      }
+      .sync-bar {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 24px;
+      }
+      .sync-btn {
+        background: var(--accent);
+        color: #fff;
+        border: 0;
+        padding: 8px 14px;
+        border-radius: 6px;
+        font: inherit;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .sync-btn.sec {
+        background: transparent;
+        color: var(--text-dim);
+        border: 1px solid var(--border);
+      }
+      .sync-btn:hover {
+        filter: brightness(1.1);
+      }
+      .section-h {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--text-dim);
+        margin: 24px 0 8px;
+      }
+      .png-block {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px;
+        margin-bottom: 8px;
+      }
+      .png-block img {
+        max-width: 100%;
+        display: block;
+        border-radius: 4px;
+      }
+      .png-missing {
+        color: var(--text-mute);
+        font-style: italic;
+        padding: 16px;
+      }
+      pre.snippet {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 14px 18px;
+        overflow-x: auto;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        line-height: 1.55;
+        color: var(--text);
+        margin: 0 0 8px;
+        white-space: pre;
+      }
+      table.metrics {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+      table.metrics th,
+      table.metrics td {
+        padding: 6px 10px;
+        text-align: right;
+        border-bottom: 1px solid var(--border);
+      }
+      table.metrics th:first-child,
+      table.metrics td:first-child {
+        text-align: left;
+        color: var(--text-dim);
+      }
+      table.metrics thead th {
+        color: var(--text-dim);
+        font-weight: 600;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+      table.metrics tbody tr:hover {
+        background: var(--bg-row-hover);
+      }
+      table.perbeat {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: var(--mono);
+        font-size: 11.5px;
+      }
+      table.perbeat th,
+      table.perbeat td {
+        padding: 4px 8px;
+        text-align: right;
+        border-bottom: 1px solid var(--border);
+      }
+      table.perbeat th:first-child,
+      table.perbeat td:first-child {
+        text-align: left;
+        color: var(--text-dim);
+      }
+      table.perbeat thead th {
+        color: var(--text-dim);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        font-size: 10px;
+      }
+      table.perbeat tr.divergent td {
+        background: rgba(247, 118, 142, 0.08);
+      }
+      .links {
+        margin-top: 24px;
+        font-size: 12px;
+      }
+      .links a {
+        color: var(--accent-2);
+        text-decoration: none;
+        margin-right: 16px;
+      }
+      .links a:hover {
+        text-decoration: underline;
+      }
+      .footer-meta {
+        margin-top: 32px;
+        padding-top: 16px;
+        border-top: 1px solid var(--border);
+        font-size: 11px;
+        color: var(--text-mute);
+      }
+      .ratio-good {
+        color: var(--pass);
+      }
+      .ratio-mid {
+        color: var(--flag);
+      }
+      .ratio-bad {
+        color: var(--fail);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <div class="sidebar-head">
+          <h2 class="sidebar-title">
+            <strong>FX A/B Inspector</strong><span id="count"></span>
+          </h2>
+          <div class="summary" id="summary"></div>
+          <div class="controls">
+            <input
+              id="search"
+              type="search"
+              placeholder="search fx (e.g. verb, lpf, delay)"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div class="filters" id="filters">
+              <button class="chip" data-verdict="PASS" data-on="1">PASS</button>
+              <button class="chip" data-verdict="FLAG" data-on="1">FLAG</button>
+              <button class="chip" data-verdict="FAIL" data-on="1">FAIL</button>
+              <button class="chip" data-verdict="INCONCLUSIVE" data-on="1">
+                INCONCLUSIVE
+              </button>
+            </div>
+            <select id="sort">
+              <option value="score-desc">Sort: score (high → low)</option>
+              <option value="score-asc">Sort: score (low → high)</option>
+              <option value="name">Sort: name (a → z)</option>
+              <option value="verdict">Sort: verdict</option>
+            </select>
+          </div>
+        </div>
+        <div class="list" id="list"></div>
+      </aside>
+      <main class="detail" id="detail">
+        <div class="detail-empty">Select an FX from the sidebar.</div>
+      </main>
+    </div>
+
+    <script>
+      const state = {
+        entries: [],
+        filtered: [],
+        selectedFx: null,
+        verdicts: { PASS: true, FLAG: true, FAIL: true, INCONCLUSIVE: true },
+        search: "",
+        sort: "score-desc",
+      };
+
+      const $ = (id) => document.getElementById(id);
+
+      async function init() {
+        let data;
+        try {
+          const res = await fetch("fx-baseline.json", { cache: "no-store" });
+          data = await res.json();
+        } catch (e) {
+          $("detail").innerHTML =
+            '<div class="detail-empty">Could not load fx-baseline.json — run <code>npx tsx tools/build-test-results.ts</code> first.</div>';
+          return;
+        }
+        state.entries = data.entries;
+
+        $("count").textContent = `${state.entries.length} FX`;
+        $("summary").innerHTML = renderSummary(data);
+
+        $("search").addEventListener("input", (e) => {
+          state.search = e.target.value.trim().toLowerCase();
+          render();
+        });
+        $("sort").addEventListener("change", (e) => {
+          state.sort = e.target.value;
+          render();
+        });
+        for (const chip of $("filters").querySelectorAll(".chip")) {
+          chip.addEventListener("click", () => {
+            const v = chip.dataset.verdict;
+            state.verdicts[v] = !state.verdicts[v];
+            chip.dataset.on = state.verdicts[v] ? "1" : "0";
+            render();
+          });
+        }
+        document.addEventListener("keydown", onKey);
+
+        render();
+        if (state.filtered.length) select(state.filtered[0].fx);
+      }
+
+      function renderSummary(data) {
+        const c = data.counts;
+        const dt = new Date(data.generatedAt);
+        const ago = humanAgo(dt);
+        return `
+          <span><b class="ratio-good">${c.PASS}</b> PASS</span>
+          <span><b class="ratio-mid">${c.FLAG}</b> FLAG</span>
+          <span><b class="ratio-bad">${c.FAIL}</b> FAIL</span>
+          <span><b>${c.INCONCLUSIVE}</b> incon</span>
+          <span title="${dt.toISOString()}">· ${ago}</span>
+        `;
+      }
+
+      function humanAgo(dt) {
+        const ms = Date.now() - dt.getTime();
+        const m = Math.round(ms / 60000);
+        if (m < 1) return "just now";
+        if (m < 60) return `${m}m ago`;
+        const h = Math.round(m / 60);
+        if (h < 24) return `${h}h ago`;
+        const d = Math.round(h / 24);
+        return `${d}d ago`;
+      }
+
+      function applyFilter() {
+        const q = state.search;
+        let list = state.entries.filter((e) => {
+          if (!state.verdicts[e.verdict]) return false;
+          if (q && !e.fx.toLowerCase().includes(q)) return false;
+          return true;
+        });
+        list.sort(comparator(state.sort));
+        state.filtered = list;
+      }
+
+      function comparator(mode) {
+        const verdictOrder = { PASS: 0, FLAG: 1, FAIL: 2, INCONCLUSIVE: 3 };
+        const inconLast = (a, b) => {
+          const ai = a.verdict === "INCONCLUSIVE" ? 1 : 0;
+          const bi = b.verdict === "INCONCLUSIVE" ? 1 : 0;
+          return ai - bi;
+        };
+        switch (mode) {
+          case "score-desc":
+            return (a, b) => inconLast(a, b) || b.score - a.score;
+          case "score-asc":
+            return (a, b) => inconLast(a, b) || a.score - b.score;
+          case "name":
+            return (a, b) => a.fx.localeCompare(b.fx);
+          case "verdict":
+            return (a, b) =>
+              verdictOrder[a.verdict] - verdictOrder[b.verdict] ||
+              b.score - a.score;
+          default:
+            return (a, b) => b.score - a.score;
+        }
+      }
+
+      function render() {
+        applyFilter();
+        renderList();
+      }
+
+      function renderList() {
+        const html = state.filtered
+          .map((e) => {
+            const score = e.verdict === "INCONCLUSIVE" ? "—" : e.score.toFixed(1);
+            const sub = e.verdict === "INCONCLUSIVE"
+              ? "no shared signal"
+              : `RMS ${fmtRatio(e.rmsRatio)}× · Peak ${fmtRatio(e.peakRatio)}× · L2 ${e.l2MelDb.toFixed(1)} · MFCC ${Math.round(e.mfccDist)}`;
+            return `
+              <div class="row" data-fx="${e.fx}" ${state.selectedFx === e.fx ? 'data-active="1"' : ""}>
+                <div class="row-name">${e.fx}</div>
+                <div class="row-score">${score}</div>
+                <div class="row-sub"><span class="badge ${e.verdict}">${e.verdict}</span> ${sub}</div>
+              </div>
+            `;
+          })
+          .join("");
+        const list = $("list");
+        list.innerHTML = html || '<div class="png-missing">No FX match the current filters.</div>';
+        for (const row of list.querySelectorAll(".row")) {
+          row.addEventListener("click", () => select(row.dataset.fx));
+        }
+      }
+
+      function fmtRatio(r) {
+        if (r === null || r === undefined) return "—";
+        return r.toFixed(2);
+      }
+
+      function select(fx) {
+        state.selectedFx = fx;
+        for (const row of $("list").querySelectorAll(".row")) {
+          row.dataset.active = row.dataset.fx === fx ? "1" : "0";
+        }
+        const e = state.entries.find((x) => x.fx === fx);
+        if (e) renderDetail(e);
+      }
+
+      function renderDetail(e) {
+        const a = e.artifacts;
+        const desktopUrl = a.desktopWav ? encodeURI(a.desktopWav) : null;
+        const webUrl = a.webWav ? encodeURI(a.webWav) : null;
+        const score = e.verdict === "INCONCLUSIVE" ? "—" : e.score.toFixed(1);
+        const desktopStats = e.desktopStats;
+        const webStats = e.webStats;
+
+        const audioHtml = `
+          <div class="audio-grid">
+            <div class="audio-card">
+              <h3>Desktop SP <span>${desktopStats.duration.toFixed(2)}s · RMS ${desktopStats.rms.toFixed(4)} · peak ${desktopStats.peak.toFixed(4)}</span></h3>
+              ${
+                desktopUrl
+                  ? `<audio id="audio-desktop" controls preload="metadata" src="${desktopUrl}"></audio>`
+                  : '<div class="png-missing">desktop.wav missing</div>'
+              }
+            </div>
+            <div class="audio-card">
+              <h3>SonicPi.js (web) <span>${webStats.duration.toFixed(2)}s · RMS ${webStats.rms.toFixed(4)} · peak ${webStats.peak.toFixed(4)}</span></h3>
+              ${
+                webUrl
+                  ? `<audio id="audio-web" controls preload="metadata" src="${webUrl}"></audio>`
+                  : '<div class="png-missing">web.wav missing</div>'
+              }
+            </div>
+          </div>
+        `;
+
+        const syncHtml = `
+          <div class="sync-bar">
+            <button class="sync-btn" id="sync-play">▶ Play both</button>
+            <button class="sync-btn sec" id="sync-stop">■ Stop both</button>
+          </div>
+        `;
+
+        const spectroHtml = a.spectrogramPng
+          ? `<div class="png-block"><img src="${encodeURI(a.spectrogramPng)}" alt="spectrogram"></div>`
+          : '<div class="png-missing">spectrogram.png missing</div>';
+        const perBeatHtml = a.perBeatPng
+          ? `<div class="png-block"><img src="${encodeURI(a.perBeatPng)}" alt="per-beat metrics"></div>`
+          : '<div class="png-missing">perbeat.png missing.</div>';
+
+        const links = [];
+        if (a.report) links.push(`<a href="${encodeURI(a.report)}" target="_blank">comparator report.md ↗</a>`);
+        if (a.metrics) links.push(`<a href="${encodeURI(a.metrics)}" target="_blank">metrics.json ↗</a>`);
+        if (a.snippet) links.push(`<a href="${encodeURI(a.snippet)}" target="_blank">snippet.rb ↗</a>`);
+        if (desktopUrl) links.push(`<a href="${desktopUrl}" target="_blank">desktop.wav ↗</a>`);
+        if (webUrl) links.push(`<a href="${webUrl}" target="_blank">web.wav ↗</a>`);
+
+        $("detail").innerHTML = `
+          <div class="detail-head">
+            <h1>:${e.fx}</h1>
+            <span class="badge ${e.verdict}">${e.verdict}</span>
+            <span class="meta" style="margin:0">${e.flavor} · bpm ${e.bpm} · ${e.beats || "—"} beats</span>
+            <div class="score">${score} <small>/ 100</small></div>
+          </div>
+
+          ${audioHtml}
+          ${syncHtml}
+
+          <div class="section-h">Reference snippet</div>
+          <pre class="snippet" id="snippet-block">loading…</pre>
+
+          <div class="section-h">Spectrogram comparison (Desktop SP vs Web)</div>
+          ${spectroHtml}
+
+          <div class="section-h">Per-beat divergence</div>
+          ${perBeatHtml}
+
+          <div class="section-h">Stats</div>
+          <table class="metrics">
+            <thead><tr><th>Metric</th><th>Desktop SP</th><th>SonicPi.js</th><th>ratio (web/desktop)</th></tr></thead>
+            <tbody>
+              <tr><td>Duration (s)</td><td>${desktopStats.duration.toFixed(3)}</td><td>${webStats.duration.toFixed(3)}</td><td>${ratioCell(webStats.duration, desktopStats.duration)}</td></tr>
+              <tr><td>Peak</td><td>${desktopStats.peak.toFixed(4)}</td><td>${webStats.peak.toFixed(4)}</td><td>${ratioCell(webStats.peak, desktopStats.peak)}</td></tr>
+              <tr><td>RMS</td><td>${desktopStats.rms.toFixed(4)}</td><td>${webStats.rms.toFixed(4)}</td><td>${ratioCell(webStats.rms, desktopStats.rms)}</td></tr>
+              <tr><td>Clipping (%)</td><td>${desktopStats.clipping.toFixed(2)}</td><td>${webStats.clipping.toFixed(2)}</td><td>—</td></tr>
+              <tr><td>Sample rate</td><td>${desktopStats.sampleRate}</td><td>${webStats.sampleRate}</td><td>—</td></tr>
+              <tr><td>L2 (mel-dB)</td><td colspan="2" style="text-align:center;color:var(--text)">${e.l2MelDb.toFixed(2)}</td><td>—</td></tr>
+              <tr><td>MFCC distance</td><td colspan="2" style="text-align:center;color:var(--text)">${e.mfccDist.toFixed(2)}</td><td>—</td></tr>
+            </tbody>
+          </table>
+
+          ${e.perBeat.length ? renderPerBeat(e) : ""}
+
+          <div class="links">${links.join("")}</div>
+
+          <div class="footer-meta">
+            Score formula: 0.30·ratio(rms) + 0.15·ratio(peak) + 0.30·l2 + 0.25·mfcc.
+            Source artifacts: <code>.captures/</code> · this folder is a copy.
+          </div>
+        `;
+
+        if (a.snippet) {
+          fetch(a.snippet)
+            .then((r) => r.text())
+            .then((t) => {
+              const el = $("snippet-block");
+              if (el) el.textContent = t;
+            })
+            .catch(() => {
+              const el = $("snippet-block");
+              if (el) el.textContent = "(could not load snippet — try serving over http)";
+            });
+        }
+
+        wireSyncButtons();
+      }
+
+      function ratioCell(num, denom) {
+        if (!denom || !num) return "—";
+        const r = num / denom;
+        const cls = Math.abs(Math.log2(r)) <= 0.5
+          ? "ratio-good"
+          : Math.abs(Math.log2(r)) <= 1
+          ? "ratio-mid"
+          : "ratio-bad";
+        return `<span class="${cls}">${r.toFixed(2)}×</span>`;
+      }
+
+      function renderPerBeat(e) {
+        const div = new Set(e.mostDivergentBeats);
+        const rows = e.perBeat
+          .map(
+            (r) => `
+          <tr class="${div.has(r.beat) ? "divergent" : ""}">
+            <td>${r.beat}</td>
+            <td>${r.desktop_rms.toFixed(4)}</td>
+            <td>${r.web_rms.toFixed(4)}</td>
+            <td>${r.desktop_peak.toFixed(4)}</td>
+            <td>${r.web_peak.toFixed(4)}</td>
+            <td>${r.mfcc_distance.toFixed(2)}</td>
+          </tr>
+        `,
+          )
+          .join("");
+        return `
+          <div class="section-h">Per-beat table (highlighted = top-3 most divergent)</div>
+          <table class="perbeat">
+            <thead><tr><th>Beat</th><th>desktop RMS</th><th>web RMS</th><th>desktop peak</th><th>web peak</th><th>MFCC dist</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        `;
+      }
+
+      function wireSyncButtons() {
+        const play = $("sync-play");
+        const stop = $("sync-stop");
+        const desk = $("audio-desktop");
+        const web = $("audio-web");
+        if (!play || !stop) return;
+        play.addEventListener("click", async () => {
+          if (!desk && !web) return;
+          if (desk) desk.currentTime = 0;
+          if (web) web.currentTime = 0;
+          const promises = [];
+          if (desk) promises.push(desk.play());
+          if (web) promises.push(web.play());
+          try {
+            await Promise.all(promises);
+          } catch (err) {
+            console.warn("[inspector] sync play blocked by browser autoplay policy?", err);
+          }
+        });
+        stop.addEventListener("click", () => {
+          if (desk) {
+            desk.pause();
+            desk.currentTime = 0;
+          }
+          if (web) {
+            web.pause();
+            web.currentTime = 0;
+          }
+        });
+      }
+
+      function onKey(ev) {
+        if (
+          ev.target instanceof HTMLInputElement ||
+          ev.target instanceof HTMLSelectElement ||
+          ev.target instanceof HTMLTextAreaElement
+        )
+          return;
+        const list = state.filtered;
+        if (!list.length) return;
+        const i = list.findIndex((x) => x.fx === state.selectedFx);
+        if (ev.key === "ArrowDown" || ev.key === "j") {
+          ev.preventDefault();
+          select(list[Math.min(list.length - 1, i + 1)].fx);
+          scrollSelectedIntoView();
+        } else if (ev.key === "ArrowUp" || ev.key === "k") {
+          ev.preventDefault();
+          select(list[Math.max(0, i - 1)].fx);
+          scrollSelectedIntoView();
+        } else if (ev.key === " ") {
+          const btn = $("sync-play");
+          if (btn) {
+            ev.preventDefault();
+            btn.click();
+          }
+        }
+      }
+
+      function scrollSelectedIntoView() {
+        const row = $("list").querySelector('.row[data-active="1"]');
+        if (row) row.scrollIntoView({ block: "nearest" });
+      }
+
+      init();
+    </script>
+  </body>
+</html>

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -497,8 +497,10 @@
           const res = await fetch("fx-baseline.json", { cache: "no-store" });
           data = await res.json();
         } catch (e) {
-          $("detail").innerHTML =
-            '<div class="detail-empty">Could not load fx-baseline.json — run <code>npx tsx tools/build-test-results.ts</code> first.</div>';
+          const isFile = location.protocol === "file:";
+          $("detail").innerHTML = isFile
+            ? '<div class="detail-empty">Browsers block <code>fetch()</code> on <code>file://</code>. Serve with <code>npm run inspect</code> (or <code>python3 -m http.server -d test_results 8080</code>) and open <code>http://localhost:8080</code>.</div>'
+            : '<div class="detail-empty">Could not load fx-baseline.json — run <code>npm run inspect:build</code> first.</div>';
           return;
         }
         state.entries = data.entries;

--- a/tools/build-test-results.ts
+++ b/tools/build-test-results.ts
@@ -40,8 +40,10 @@ const OUT_DIR = path.join(REPO_ROOT, 'test_results');
 const OUT_FX_DIR = path.join(OUT_DIR, 'fx');
 const OUT_BASELINE_PATH = path.join(OUT_DIR, 'fx-baseline.json');
 
+type Verdict = 'HIGH' | 'MID' | 'LOW' | 'INCONCLUSIVE';
+
 interface BaselineEntry {
-  verdict: 'PASS' | 'FLAG' | 'FAIL' | 'INCONCLUSIVE';
+  verdict: Verdict;
   score: number;
   rmsRatio: number | null;
   peakRatio: number | null;
@@ -270,8 +272,8 @@ function emptyStats(): AudioStats {
   return { duration: 0, peak: 0, rms: 0, clipping: 0, sampleRate: 0, channels: 0 };
 }
 
-function tally(entries: InspectorEntry[]): Record<string, number> {
-  const t: Record<string, number> = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 };
+function tally(entries: InspectorEntry[]): Record<Verdict, number> {
+  const t: Record<Verdict, number> = { HIGH: 0, MID: 0, LOW: 0, INCONCLUSIVE: 0 };
   for (const e of entries) t[e.verdict] = (t[e.verdict] ?? 0) + 1;
   return t;
 }

--- a/tools/build-test-results.ts
+++ b/tools/build-test-results.ts
@@ -108,7 +108,6 @@ interface InspectorEntry extends BaselineEntry {
   webStats: AudioStats;
   perBeat: PerBeatRow[];
   mostDivergentBeats: number[];
-  meanPerBeatMfcc: number;
   artifacts: {
     desktopWav: string | null;
     webWav: string | null;
@@ -118,9 +117,10 @@ interface InspectorEntry extends BaselineEntry {
     metrics: string | null;
     report: string | null;
   };
-  hasReport: boolean;
 }
 
+// Mirror of the sustained-flavor list in tools/fx-sweep.ts (search SnippetFlavor).
+// Kept in sync manually — small set, low churn.
 const SUSTAINED_FX = new Set([
   'panslicer',
   'slicer',
@@ -143,6 +143,18 @@ function copyIfExists(src: string | null | undefined, dst: string): boolean {
 
 function ensureDir(dir: string): void {
   fs.mkdirSync(dir, { recursive: true });
+}
+
+function pruneStaleDirs(parent: string, keep: Set<string>): number {
+  if (!fs.existsSync(parent)) return 0;
+  let n = 0;
+  for (const entry of fs.readdirSync(parent, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (keep.has(entry.name)) continue;
+    fs.rmSync(path.join(parent, entry.name), { recursive: true, force: true });
+    n++;
+  }
+  return n;
 }
 
 function readJson<T>(p: string): T {
@@ -171,6 +183,9 @@ function build(): void {
   console.log(`[inspector] ${fxNames.length} FX in baseline`);
 
   ensureDir(OUT_FX_DIR);
+  const expected = new Set(fxNames);
+  const pruned = pruneStaleDirs(OUT_FX_DIR, expected);
+  if (pruned > 0) console.log(`[inspector] pruned ${pruned} stale FX dir(s)`);
 
   const entries: InspectorEntry[] = [];
   let copied = 0;
@@ -226,7 +241,6 @@ function build(): void {
       webStats: stats?.web ?? emptyStats(),
       perBeat: pb?.rows ?? [],
       mostDivergentBeats: pb?.most_divergent_beats ?? [],
-      meanPerBeatMfcc: pb?.mean_per_beat_mfcc_distance ?? 0,
       artifacts: {
         desktopWav: okDesktop ? `fx/${fx}/desktop.wav` : null,
         webWav: okWeb ? `fx/${fx}/web.wav` : null,
@@ -236,7 +250,6 @@ function build(): void {
         metrics: okMetrics ? `fx/${fx}/metrics.json` : null,
         report: okReport ? `fx/${fx}/report.md` : null,
       },
-      hasReport: okReport,
     });
   }
 

--- a/tools/build-test-results.ts
+++ b/tools/build-test-results.ts
@@ -1,0 +1,275 @@
+/**
+ * test_results/ inspector builder — mirrors the FX sweep artifacts from
+ * `.captures/` into one folder per FX so a single index.html can audition
+ * each desktop ↔ web pair side-by-side.
+ *
+ * Why: PR #275 emits per-FX artifacts to four scattered locations
+ * (`.captures/fx-sweep/<fx>.json`, `.captures/desktop-recordings/*`,
+ * `.captures/2026-*_inline_audio.wav`, `.captures/compare_*_fx-<fx>_*`).
+ * Auditing 40 FX in 4 dirs each is friction. This tool consolidates each
+ * FX's artifacts into `test_results/fx/<fx>/` and emits a baseline JSON
+ * shaped for the inspector HTML.
+ *
+ * `.captures/` stays canonical — this tool only copies, never moves.
+ *
+ * Usage:
+ *   npx tsx tools/build-test-results.ts
+ *
+ * Output:
+ *   test_results/index.html              (left in place, never overwritten)
+ *   test_results/fx-baseline.json        (regenerated)
+ *   test_results/fx/<fx>/desktop.wav     (copy)
+ *   test_results/fx/<fx>/web.wav         (copy)
+ *   test_results/fx/<fx>/spectrogram.png (copy)
+ *   test_results/fx/<fx>/perbeat.png     (copy, may be missing for INCONCLUSIVE)
+ *   test_results/fx/<fx>/snippet.rb      (copy)
+ *   test_results/fx/<fx>/metrics.json    (copy of sidecar)
+ *   test_results/fx/<fx>/report.md       (copy of comparator report)
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CAPTURES_DIR = path.join(REPO_ROOT, '.captures');
+const SWEEP_DIR = path.join(CAPTURES_DIR, 'fx-sweep');
+const BASELINE_PATH = path.join(CAPTURES_DIR, 'fx-baseline.json');
+const OUT_DIR = path.join(REPO_ROOT, 'test_results');
+const OUT_FX_DIR = path.join(OUT_DIR, 'fx');
+const OUT_BASELINE_PATH = path.join(OUT_DIR, 'fx-baseline.json');
+
+interface BaselineEntry {
+  verdict: 'PASS' | 'FLAG' | 'FAIL' | 'INCONCLUSIVE';
+  score: number;
+  rmsRatio: number | null;
+  peakRatio: number | null;
+  l2MelDb: number;
+  mfccDist: number;
+}
+
+interface PerBeatRow {
+  beat: number;
+  desktop_rms: number;
+  web_rms: number;
+  desktop_peak: number;
+  web_peak: number;
+  mfcc_distance: number;
+}
+
+interface SidecarPerBeat {
+  bpm: number;
+  beats: number;
+  rows: PerBeatRow[];
+  most_divergent_beats: number[];
+  mean_per_beat_mfcc_distance: number;
+  per_beat_png?: string;
+}
+
+interface SidecarSpectrogram {
+  l2_mel_db: number;
+  mfcc_distance: number;
+  frames_compared: number;
+  spectrogram_png?: string;
+  desktop_peak_freq_hz?: number;
+  web_peak_freq_hz?: number;
+  per_beat?: SidecarPerBeat;
+}
+
+interface Sidecar {
+  timestamp: string;
+  code: string;
+  duration: number;
+  name: string;
+  desktop: { wavPath: string; stats: AudioStats; ok: boolean };
+  web: { wavPath: string; stats: AudioStats; ok: boolean };
+  spectrogram?: SidecarSpectrogram;
+  spectrogramError?: string | null;
+  reportPath?: string;
+}
+
+interface AudioStats {
+  duration: number;
+  peak: number;
+  rms: number;
+  clipping: number;
+  sampleRate: number;
+  channels: number;
+}
+
+interface InspectorEntry extends BaselineEntry {
+  fx: string;
+  flavor: 'rhythmic' | 'sustained';
+  duration: number;
+  bpm: number;
+  beats: number;
+  desktopStats: AudioStats;
+  webStats: AudioStats;
+  perBeat: PerBeatRow[];
+  mostDivergentBeats: number[];
+  meanPerBeatMfcc: number;
+  artifacts: {
+    desktopWav: string | null;
+    webWav: string | null;
+    spectrogramPng: string | null;
+    perBeatPng: string | null;
+    snippet: string | null;
+    metrics: string | null;
+    report: string | null;
+  };
+  hasReport: boolean;
+}
+
+const SUSTAINED_FX = new Set([
+  'panslicer',
+  'slicer',
+  'wobble',
+  'tremolo',
+  'vowel',
+  'ring_mod',
+]);
+
+function flavor(fx: string): 'rhythmic' | 'sustained' {
+  return SUSTAINED_FX.has(fx) ? 'sustained' : 'rhythmic';
+}
+
+function copyIfExists(src: string | null | undefined, dst: string): boolean {
+  if (!src) return false;
+  if (!fs.existsSync(src)) return false;
+  fs.copyFileSync(src, dst);
+  return true;
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJson<T>(p: string): T {
+  return JSON.parse(fs.readFileSync(p, 'utf-8')) as T;
+}
+
+function loadBaseline(): Record<string, BaselineEntry> {
+  if (!fs.existsSync(BASELINE_PATH)) {
+    throw new Error(
+      `fx-baseline.json not found at ${BASELINE_PATH}. Run \`npm run fx-sweep\` first.`,
+    );
+  }
+  return readJson<Record<string, BaselineEntry>>(BASELINE_PATH);
+}
+
+function loadSidecar(fx: string): Sidecar | null {
+  const sidecarPath = path.join(SWEEP_DIR, `${fx}.json`);
+  if (!fs.existsSync(sidecarPath)) return null;
+  return readJson<Sidecar>(sidecarPath);
+}
+
+function build(): void {
+  console.log('[inspector] reading baseline + sidecars from .captures/');
+  const baseline = loadBaseline();
+  const fxNames = Object.keys(baseline);
+  console.log(`[inspector] ${fxNames.length} FX in baseline`);
+
+  ensureDir(OUT_FX_DIR);
+
+  const entries: InspectorEntry[] = [];
+  let copied = 0;
+  let missing = 0;
+
+  for (const fx of fxNames) {
+    const base = baseline[fx];
+    const sidecar = loadSidecar(fx);
+    const fxDir = path.join(OUT_FX_DIR, fx);
+    ensureDir(fxDir);
+
+    const snippetSrc = path.join(SWEEP_DIR, `snippet-${fx}.rb`);
+    const sidecarSrc = path.join(SWEEP_DIR, `${fx}.json`);
+
+    const desktopWav = path.join(fxDir, 'desktop.wav');
+    const webWav = path.join(fxDir, 'web.wav');
+    const spectrogramPng = path.join(fxDir, 'spectrogram.png');
+    const perBeatPng = path.join(fxDir, 'perbeat.png');
+    const snippetDst = path.join(fxDir, 'snippet.rb');
+    const metricsDst = path.join(fxDir, 'metrics.json');
+    const reportDst = path.join(fxDir, 'report.md');
+
+    const okDesktop = copyIfExists(sidecar?.desktop?.wavPath, desktopWav);
+    const okWeb = copyIfExists(sidecar?.web?.wavPath, webWav);
+    const okSpectro = copyIfExists(sidecar?.spectrogram?.spectrogram_png, spectrogramPng);
+    const okPerBeat = copyIfExists(sidecar?.spectrogram?.per_beat?.per_beat_png, perBeatPng);
+    const okSnippet = copyIfExists(snippetSrc, snippetDst);
+    const okMetrics = copyIfExists(sidecarSrc, metricsDst);
+    const okReport = copyIfExists(sidecar?.reportPath, reportDst);
+
+    if (okDesktop) copied++; else missing++;
+    if (okWeb) copied++; else missing++;
+
+    const stats = sidecar
+      ? { desktop: sidecar.desktop.stats, web: sidecar.web.stats }
+      : null;
+    const sg = sidecar?.spectrogram;
+    const pb = sg?.per_beat;
+
+    entries.push({
+      fx,
+      flavor: flavor(fx),
+      verdict: base.verdict,
+      score: base.score,
+      rmsRatio: base.rmsRatio,
+      peakRatio: base.peakRatio,
+      l2MelDb: base.l2MelDb,
+      mfccDist: base.mfccDist,
+      duration: sidecar?.duration ?? 5000,
+      bpm: pb?.bpm ?? 120,
+      beats: pb?.beats ?? 0,
+      desktopStats: stats?.desktop ?? emptyStats(),
+      webStats: stats?.web ?? emptyStats(),
+      perBeat: pb?.rows ?? [],
+      mostDivergentBeats: pb?.most_divergent_beats ?? [],
+      meanPerBeatMfcc: pb?.mean_per_beat_mfcc_distance ?? 0,
+      artifacts: {
+        desktopWav: okDesktop ? `fx/${fx}/desktop.wav` : null,
+        webWav: okWeb ? `fx/${fx}/web.wav` : null,
+        spectrogramPng: okSpectro ? `fx/${fx}/spectrogram.png` : null,
+        perBeatPng: okPerBeat ? `fx/${fx}/perbeat.png` : null,
+        snippet: okSnippet ? `fx/${fx}/snippet.rb` : null,
+        metrics: okMetrics ? `fx/${fx}/metrics.json` : null,
+        report: okReport ? `fx/${fx}/report.md` : null,
+      },
+      hasReport: okReport,
+    });
+  }
+
+  const out = {
+    generatedAt: new Date().toISOString(),
+    sourceBaseline: path.relative(REPO_ROOT, BASELINE_PATH),
+    counts: tally(entries),
+    entries: sortEntries(entries),
+  };
+
+  fs.writeFileSync(OUT_BASELINE_PATH, JSON.stringify(out, null, 2));
+  console.log(`[inspector] wrote ${OUT_BASELINE_PATH}`);
+  console.log(`[inspector] copied ${copied} WAV files (${missing} absent)`);
+  console.log(`[inspector] open: file://${path.join(OUT_DIR, 'index.html')}`);
+}
+
+function emptyStats(): AudioStats {
+  return { duration: 0, peak: 0, rms: 0, clipping: 0, sampleRate: 0, channels: 0 };
+}
+
+function tally(entries: InspectorEntry[]): Record<string, number> {
+  const t: Record<string, number> = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 };
+  for (const e of entries) t[e.verdict] = (t[e.verdict] ?? 0) + 1;
+  return t;
+}
+
+function sortEntries(entries: InspectorEntry[]): InspectorEntry[] {
+  return entries.slice().sort((a, b) => {
+    const aIncon = a.verdict === 'INCONCLUSIVE' ? 1 : 0;
+    const bIncon = b.verdict === 'INCONCLUSIVE' ? 1 : 0;
+    if (aIncon !== bIncon) return aIncon - bIncon;
+    return b.score - a.score;
+  });
+}
+
+build();

--- a/tools/fx-sweep.ts
+++ b/tools/fx-sweep.ts
@@ -1,6 +1,6 @@
 /**
  * FX WAV-verify sweep — runs every wired FX through the A/B comparator,
- * categorizes each as PASS / FLAG / FAIL, and writes a baseline JSON for
+ * categorizes each as HIGH / MID / LOW / INCONCLUSIVE, and writes a baseline JSON for
  * regression checks.
  *
  * Why: 40 FX are wired in src/engine/SonicPiEngine.ts:462-470 but only a
@@ -22,7 +22,7 @@
  * Output:
  *   .captures/fx-sweep/snippet-<fx>.rb       — per-FX snippet (re-runnable)
  *   .captures/fx-sweep/<fx>.json             — sidecar metrics
- *   .captures/fx-sweep/SUMMARY.md            — PASS/FLAG/FAIL table
+ *   .captures/fx-sweep/SUMMARY.md            — HIGH/MID/LOW/INCONCLUSIVE table
  *   .captures/fx-baseline.json               — baseline for regression diffs
  */
 
@@ -223,6 +223,68 @@ interface FxComparisonJson {
   reportPath: string
 }
 
+function emptyMetrics(fx: FxSpec, jsonPath: string): FxMetrics {
+  return {
+    fx: fx.name,
+    flavor: fx.flavor,
+    desktop: null,
+    web: null,
+    rmsRatio: null,
+    peakRatio: null,
+    l2MelDb: null,
+    mfccDist: null,
+    silentDesktopBeats: [],
+    silentWebBeats: [],
+    silentBeatAsymmetry: false,
+    meanPerBeatMfcc: null,
+    reportPath: '',
+    jsonPath,
+    errors: [],
+  }
+}
+
+// Hydrate FxMetrics from a per-FX sidecar JSON written by a prior sweep run.
+// Used by both runFx (after the comparator subprocess writes the file) and
+// --reclassify-only (which skips recording entirely).
+function metricsFromSidecar(fx: FxSpec, jsonPath: string): FxMetrics {
+  const m = emptyMetrics(fx, jsonPath)
+  if (!existsSync(jsonPath)) {
+    m.errors.push('sidecar JSON not found')
+    return m
+  }
+  try {
+    const j = JSON.parse(readFileSync(jsonPath, 'utf8')) as FxComparisonJson
+    m.reportPath = j.reportPath
+    m.desktop = j.desktop.stats ? {
+      rms: j.desktop.stats.rms, peak: j.desktop.stats.peak, duration: j.desktop.stats.duration,
+    } : null
+    m.web = j.web.stats ? {
+      rms: j.web.stats.rms, peak: j.web.stats.peak, duration: j.web.stats.duration,
+    } : null
+    if (m.desktop && m.web) {
+      m.rmsRatio = m.desktop.rms > 0 ? m.web.rms / m.desktop.rms : null
+      m.peakRatio = m.desktop.peak > 0 ? m.web.peak / m.desktop.peak : null
+    }
+    if (j.spectrogram) {
+      m.l2MelDb = j.spectrogram.l2_mel_db
+      m.mfccDist = j.spectrogram.mfcc_distance
+      if (j.spectrogram.per_beat) {
+        m.meanPerBeatMfcc = j.spectrogram.per_beat.mean_per_beat_mfcc_distance
+        m.silentDesktopBeats = j.spectrogram.per_beat.rows
+          .filter((r) => r.desktop_rms < 0.001).map((r) => r.beat)
+        m.silentWebBeats = j.spectrogram.per_beat.rows
+          .filter((r) => r.web_rms < 0.001).map((r) => r.beat)
+        const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
+        const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
+        m.silentBeatAsymmetry = dPost.length !== wPost.length
+      }
+    }
+  } catch (err) {
+    m.errors.push(`failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  return m
+}
+
 async function runFx(fx: FxSpec): Promise<FxMetrics> {
   const snippetPath = resolve(SWEEP_DIR, `snippet-${fx.name}.rb`)
   writeFileSync(snippetPath, renderSnippet(fx))
@@ -248,74 +310,58 @@ async function runFx(fx: FxSpec): Promise<FxMetrics> {
     child.stdout.on('data', (b) => { stdout += b.toString() })
     child.stderr.on('data', (b) => { stderr += b.toString() })
     child.on('close', () => {
-      const m: FxMetrics = {
-        fx: fx.name,
-        flavor: fx.flavor,
-        desktop: null,
-        web: null,
-        rmsRatio: null,
-        peakRatio: null,
-        l2MelDb: null,
-        mfccDist: null,
-        silentDesktopBeats: [],
-        silentWebBeats: [],
-        silentBeatAsymmetry: false,
-        meanPerBeatMfcc: null,
-        reportPath: '',
-        jsonPath,
-        errors: [],
-      }
       if (!existsSync(jsonPath)) {
+        const m = emptyMetrics(fx, jsonPath)
         m.errors.push('comparator did not write JSON sidecar')
         m.errors.push(`stdout: ${stdout.trim().slice(-300)}`)
         if (stderr.trim()) m.errors.push(`stderr: ${stderr.trim().slice(-300)}`)
         resolveP(m)
         return
       }
-      try {
-        const j = JSON.parse(readFileSync(jsonPath, 'utf8')) as FxComparisonJson
-        m.reportPath = j.reportPath
-        m.desktop = j.desktop.stats ? {
-          rms: j.desktop.stats.rms, peak: j.desktop.stats.peak, duration: j.desktop.stats.duration,
-        } : null
-        m.web = j.web.stats ? {
-          rms: j.web.stats.rms, peak: j.web.stats.peak, duration: j.web.stats.duration,
-        } : null
-        if (m.desktop && m.web) {
-          m.rmsRatio = m.desktop.rms > 0 ? m.web.rms / m.desktop.rms : null
-          m.peakRatio = m.desktop.peak > 0 ? m.web.peak / m.desktop.peak : null
-        }
-        if (j.spectrogram) {
-          m.l2MelDb = j.spectrogram.l2_mel_db
-          m.mfccDist = j.spectrogram.mfcc_distance
-          if (j.spectrogram.per_beat) {
-            m.meanPerBeatMfcc = j.spectrogram.per_beat.mean_per_beat_mfcc_distance
-            m.silentDesktopBeats = j.spectrogram.per_beat.rows
-              .filter((r) => r.desktop_rms < 0.001).map((r) => r.beat)
-            m.silentWebBeats = j.spectrogram.per_beat.rows
-              .filter((r) => r.web_rms < 0.001).map((r) => r.beat)
-            // Asymmetry check excludes WARMUP_BEATS leading beats — desktop's
-            // scsynth needs ~2 beats to settle before audio fires (SP22). Web
-            // doesn't have this delay, so beats 0..WARMUP_BEATS-1 will always
-            // look asymmetric without indicating an FX bug.
-            const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
-            const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
-            m.silentBeatAsymmetry = dPost.length !== wPost.length
-          }
-        }
-      } catch (err) {
-        m.errors.push(`failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`)
-      }
-      resolveP(m)
+      // Hydrate from the freshly-written sidecar. Asymmetry check excludes
+      // WARMUP_BEATS leading beats — desktop's scsynth needs ~2 beats to
+      // settle before audio fires (SP22). Web doesn't have this delay, so
+      // beats 0..WARMUP_BEATS-1 always look asymmetric without indicating
+      // a real bug.
+      resolveP(metricsFromSidecar(fx, jsonPath))
     })
   })
 }
 
 // ---------------------------------------------------------------------------
-// PASS / FLAG / FAIL classification
+// Score-band classification (HIGH / MID / LOW / INCONCLUSIVE)
 // ---------------------------------------------------------------------------
+//
+// Original PASS/FLAG/FAIL scheme was retired in #278 — PASS only required
+// L2 ≤ 25 dB (≈17× per-band divergence) and ignored MFCC entirely, so 9 of
+// 9 PASS verdicts had spectrograms that visibly didn't match desktop. The
+// new tiers are pure score-band labels with a single hard MFCC gate on the
+// top tier.
+//
+//   HIGH         score ≥ 70 AND MFCC dist ≤ 180   (close in level AND timbre)
+//   MID          50 ≤ score < 70, OR HIGH-score-but-MFCC > 180
+//   LOW          score < 50  (significantly different)
+//   INCONCLUSIVE desktop side missing or silent — can't compare
+//
+// FAIL-style breakage (web-side missing, silent-beat asymmetry past warm-up)
+// produces score < 50 → LOW with a reason explaining why. We don't reuse
+// FAIL as a separate label because the score band already places these at
+// the bottom and the reason text disambiguates.
 
-type Verdict = 'PASS' | 'FLAG' | 'FAIL' | 'INCONCLUSIVE'
+type Verdict = 'HIGH' | 'MID' | 'LOW' | 'INCONCLUSIVE'
+
+const HIGH_SCORE_THRESHOLD = 70
+const HIGH_MFCC_THRESHOLD = 180
+const MID_SCORE_THRESHOLD = 50
+
+function verdictTag(v: Verdict): string {
+  switch (v) {
+    case 'HIGH': return '✓'
+    case 'MID': return '~'
+    case 'LOW': return '✗'
+    case 'INCONCLUSIVE': return '?'
+  }
+}
 
 // Composite consistency score 0-100 against Desktop SP. 100 = identical, 0 =
 // unrelated. Weighted average of four parity components:
@@ -347,7 +393,7 @@ function consistencyScore(m: FxMetrics): number | null {
   )
 }
 
-function classify(m: FxMetrics): { verdict: Verdict; reasons: string[] } {
+function classify(m: FxMetrics, score: number | null): { verdict: Verdict; reasons: string[] } {
   const reasons: string[] = []
   // INCONCLUSIVE: desktop side is broken (silent or empty), so we can't
   // compare. Likely a Desktop SP bug for that FX, not a web issue.
@@ -359,38 +405,48 @@ function classify(m: FxMetrics): { verdict: Verdict; reasons: string[] } {
     reasons.push(`desktop produced silence (peak=${m.desktop.peak}, rms=${m.desktop.rms}) — Desktop SP issue, web cannot be evaluated`)
     return { verdict: 'INCONCLUSIVE', reasons }
   }
-  // FAIL: empty WAV on web side, OR silent-beat asymmetry past warm-up
+  // Web missing → score is null → tier by score logic below would fail. Route
+  // to LOW with explicit reason. Past sweep runs have never hit this; included
+  // for completeness.
   if (!m.web) {
     reasons.push('web produced no WAV')
-    return { verdict: 'FAIL', reasons }
+    return { verdict: 'LOW', reasons }
   }
+  // Silent-beat asymmetry past warm-up is a real signal-path break, not just
+  // a level/shape divergence. Surface it via reason text; tier still falls out
+  // of the score band (will land in MID or LOW depending on numbers).
   if (m.silentBeatAsymmetry) {
     const dPost = m.silentDesktopBeats.filter((b) => b >= WARMUP_BEATS)
     const wPost = m.silentWebBeats.filter((b) => b >= WARMUP_BEATS)
     reasons.push(
       `silent-beat asymmetry past warm-up: desktop silent on [${dPost.join(',') || '–'}] · web silent on [${wPost.join(',') || '–'}]`,
     )
-    return { verdict: 'FAIL', reasons }
-  }
-  if (m.mfccDist !== null && m.mfccDist > 200 && m.rmsRatio !== null && (m.rmsRatio < 0.3 || m.rmsRatio > 3.0)) {
-    reasons.push(`mfcc=${m.mfccDist.toFixed(0)} paired with rmsRatio=${m.rmsRatio.toFixed(2)}× — likely silent or wrong-FX path`)
-    return { verdict: 'FAIL', reasons }
   }
 
-  // FLAG: one threshold breached but not catastrophic
-  if (m.rmsRatio !== null && (m.rmsRatio < 0.5 || m.rmsRatio > 2.0)) {
-    reasons.push(`rms ratio ${m.rmsRatio.toFixed(2)}× outside [0.5, 2.0]`)
+  if (score === null) {
+    reasons.push('score not computable')
+    return { verdict: 'LOW', reasons }
   }
-  if (m.peakRatio !== null && (m.peakRatio < 0.5 || m.peakRatio > 2.0)) {
-    reasons.push(`peak ratio ${m.peakRatio.toFixed(2)}× outside [0.5, 2.0]`)
-  }
-  if (m.l2MelDb !== null && m.l2MelDb > 25) {
-    reasons.push(`spectral L2 ${m.l2MelDb.toFixed(2)}dB > 25 (divergent shape)`)
-  }
-  if (reasons.length > 0) return { verdict: 'FLAG', reasons }
 
-  reasons.push(`rms=${m.rmsRatio?.toFixed(2)}× peak=${m.peakRatio?.toFixed(2)}× L2=${m.l2MelDb?.toFixed(1)}dB MFCC=${m.mfccDist?.toFixed(0)}`)
-  return { verdict: 'PASS', reasons }
+  // Tier by score, gated by MFCC for the top band
+  if (score >= HIGH_SCORE_THRESHOLD && m.mfccDist !== null && m.mfccDist <= HIGH_MFCC_THRESHOLD) {
+    reasons.push(
+      `score ${score.toFixed(1)} · MFCC ${m.mfccDist.toFixed(0)} (≥${HIGH_SCORE_THRESHOLD} AND ≤${HIGH_MFCC_THRESHOLD})`,
+    )
+    return { verdict: 'HIGH', reasons }
+  }
+  if (score >= HIGH_SCORE_THRESHOLD && m.mfccDist !== null && m.mfccDist > HIGH_MFCC_THRESHOLD) {
+    reasons.push(
+      `score ${score.toFixed(1)} would qualify for HIGH but MFCC ${m.mfccDist.toFixed(0)} > ${HIGH_MFCC_THRESHOLD} (timbre diverges)`,
+    )
+    return { verdict: 'MID', reasons }
+  }
+  if (score >= MID_SCORE_THRESHOLD) {
+    reasons.push(`score ${score.toFixed(1)} (audible divergence — recognisable but not parity)`)
+    return { verdict: 'MID', reasons }
+  }
+  reasons.push(`score ${score.toFixed(1)} (significantly different)`)
+  return { verdict: 'LOW', reasons }
 }
 
 // ---------------------------------------------------------------------------
@@ -407,7 +463,7 @@ interface SweepRow {
 }
 
 function writeSummary(rows: SweepRow[], summaryPath: string): void {
-  const counts = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 }
+  const counts: Record<Verdict, number> = { HIGH: 0, MID: 0, LOW: 0, INCONCLUSIVE: 0 }
   for (const r of rows) counts[r.verdict]++
 
   const lines: string[] = []
@@ -415,7 +471,7 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push('')
   lines.push(`- **Timestamp:** ${new Date().toISOString()}`)
   lines.push(`- **Total FX:** ${rows.length}`)
-  lines.push(`- **PASS:** ${counts.PASS} · **FLAG:** ${counts.FLAG} · **FAIL:** ${counts.FAIL} · **INCONCLUSIVE:** ${counts.INCONCLUSIVE}`)
+  lines.push(`- **HIGH:** ${counts.HIGH} · **MID:** ${counts.MID} · **LOW:** ${counts.LOW} · **INCONCLUSIVE:** ${counts.INCONCLUSIVE}`)
   const evaluated = rows.filter((r) => r.score !== null)
   if (evaluated.length > 0) {
     const mean = evaluated.reduce((s, r) => s + (r.score ?? 0), 0) / evaluated.length
@@ -452,10 +508,10 @@ function writeSummary(rows: SweepRow[], summaryPath: string): void {
   lines.push('Rhythmic snippet: `:bd_haus + :sn_dub` at 120 bpm, 8 beats.')
   lines.push('Sustained snippet: `:prophet` pad with sustained notes (slicer / tremolo / vowel / wobble / panslicer / ring_mod need this to have signal to modulate).')
   lines.push('')
-  lines.push('Categorization rules (see issue #271):')
-  lines.push('- **PASS:** RMS ratio ∈ [0.5, 2.0] · spectral L2 ≤ 25 dB · no silent-beat asymmetry past warm-up')
-  lines.push('- **FLAG:** any single threshold breached (eyeball needed)')
-  lines.push('- **FAIL:** web produced no WAV, web-side silent-beat asymmetry past warm-up, OR MFCC > 200 + RMS ratio outside [0.3, 3.0]')
+  lines.push('Categorization rules (see issues #271, #278):')
+  lines.push(`- **HIGH:** score ≥ ${HIGH_SCORE_THRESHOLD} AND MFCC dist ≤ ${HIGH_MFCC_THRESHOLD} (close in level AND timbre)`)
+  lines.push(`- **MID:** ${MID_SCORE_THRESHOLD} ≤ score < ${HIGH_SCORE_THRESHOLD}, OR HIGH-by-score-only-but-MFCC > ${HIGH_MFCC_THRESHOLD} (audible divergence)`)
+  lines.push(`- **LOW:** score < ${MID_SCORE_THRESHOLD} (significantly different) — also covers web-missing and silent-beat asymmetry`)
   lines.push('- **INCONCLUSIVE:** desktop produced silence or no WAV — Desktop SP issue, web cannot be evaluated against it')
   lines.push('')
   lines.push('Consistency score (0-100):')
@@ -479,25 +535,92 @@ interface SweepArgs {
   only: string[] | null
   skip: string[]
   baseline: string | null
+  reclassifyOnly: boolean
 }
 
 function parseArgs(argv: string[]): SweepArgs {
   let only: string[] | null = null
   let skip: string[] = []
   let baseline: string | null = null
+  let reclassifyOnly = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--only') only = argv[++i].split(',').map(s => s.trim())
     else if (a === '--skip') skip = argv[++i].split(',').map(s => s.trim())
     else if (a === '--baseline') baseline = argv[++i]
+    else if (a === '--reclassify-only') reclassifyOnly = true
   }
-  return { only, skip, baseline }
+  return { only, skip, baseline, reclassifyOnly }
+}
+
+async function reclassifyOnly(args: SweepArgs): Promise<void> {
+  let fxToRun = FX_LIST
+  if (args.only) fxToRun = fxToRun.filter(f => args.only!.includes(f.name))
+  if (args.skip.length) fxToRun = fxToRun.filter(f => !args.skip.includes(f.name))
+  const isFullRun = fxToRun.length === FX_LIST.length
+
+  console.log(`▶ Reclassifying ${fxToRun.length} FX from existing sidecars (no recording)`)
+  const rows: SweepRow[] = []
+  let missing = 0
+  for (const fx of fxToRun) {
+    const jsonPath = resolve(SWEEP_DIR, `${fx.name}.json`)
+    if (!existsSync(jsonPath)) {
+      console.log(`  ? ${fx.name}: sidecar missing — skipped`)
+      missing++
+      continue
+    }
+    const m = metricsFromSidecar(fx, jsonPath)
+    const score = consistencyScore(m)
+    const cls = classify(m, score)
+    rows.push({ fx: fx.name, flavor: fx.flavor, verdict: cls.verdict, reasons: cls.reasons, score, m })
+    const tag = verdictTag(cls.verdict)
+    const scoreStr = score === null ? '' : ` (score ${score.toFixed(1)})`
+    const mfccStr = m.mfccDist === null ? '' : ` MFCC=${m.mfccDist.toFixed(0)}`
+    console.log(`  ${tag} ${fx.name.padEnd(12)} ${cls.verdict.padEnd(12)}${scoreStr}${mfccStr}`)
+  }
+
+  const summaryPath = resolve(SWEEP_DIR, 'SUMMARY.md')
+  writeSummary(rows, summaryPath)
+
+  const baseline: Record<string, BaselineEntry> = {}
+  for (const r of rows) {
+    baseline[r.fx] = {
+      verdict: r.verdict,
+      score: r.score,
+      rmsRatio: r.m.rmsRatio,
+      peakRatio: r.m.peakRatio,
+      l2MelDb: r.m.l2MelDb,
+      mfccDist: r.m.mfccDist,
+    }
+  }
+
+  const counts: Record<Verdict, number> = { HIGH: 0, MID: 0, LOW: 0, INCONCLUSIVE: 0 }
+  for (const r of rows) counts[r.verdict]++
+
+  console.log(`\n✓ Summary: ${summaryPath}`)
+  if (isFullRun) {
+    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2))
+    console.log(`✓ Baseline: ${BASELINE_PATH}`)
+  } else {
+    console.log(`  (partial reclassify — baseline.json unchanged)`)
+  }
+  console.log(`  HIGH ${counts.HIGH} · MID ${counts.MID} · LOW ${counts.LOW} · INCONCLUSIVE ${counts.INCONCLUSIVE} (of ${rows.length})`)
+  if (missing > 0) console.log(`  ${missing} sidecar(s) missing — re-run \`npm run fx-sweep\` to regenerate`)
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2))
 
   mkdirSync(SWEEP_DIR, { recursive: true })
+
+  // --reclassify-only: skip recording entirely. Re-read each per-FX sidecar
+  // produced by a prior sweep, re-run classify() + consistencyScore(), and
+  // emit a fresh baseline.json + SUMMARY.md. Lets us iterate on tier
+  // thresholds (#278) without burning a 30-minute sweep cycle.
+  if (args.reclassifyOnly) {
+    await reclassifyOnly(args)
+    return
+  }
 
   // Preconditions
   console.log('[precondition] checking dev server on :5173...')
@@ -539,13 +662,13 @@ async function main(): Promise<void> {
     const fx = fxToRun[i]
     process.stdout.write(`[${i + 1}/${fxToRun.length}] :${fx.name} (${fx.flavor})... `)
     const m = await runFx(fx)
-    const cls = classify(m)
     const score = consistencyScore(m)
+    const cls = classify(m, score)
     rows.push({ fx: fx.name, flavor: fx.flavor, verdict: cls.verdict, reasons: cls.reasons, score, m })
-    const tag = cls.verdict === 'PASS' ? '✓' : cls.verdict === 'FLAG' ? '⚠' : '✗'
+    const tag = verdictTag(cls.verdict)
     const scoreStr = score === null ? '' : ` (score ${score.toFixed(1)})`
     console.log(`${tag} ${cls.verdict}${scoreStr}`)
-    if (cls.verdict !== 'PASS') {
+    if (cls.verdict !== 'HIGH') {
       for (const reason of cls.reasons) console.log(`     ${reason}`)
     }
   }
@@ -570,7 +693,7 @@ async function main(): Promise<void> {
   // would either overwrite the canonical baseline with an incomplete snapshot
   // (silently breaking future regression diffs) or shrink it to just the
   // subset. Either way is a footgun.
-  const counts = { PASS: 0, FLAG: 0, FAIL: 0, INCONCLUSIVE: 0 }
+  const counts: Record<Verdict, number> = { HIGH: 0, MID: 0, LOW: 0, INCONCLUSIVE: 0 }
   for (const r of rows) counts[r.verdict]++
 
   console.log(`\n✓ Summary: ${summaryPath}`)
@@ -580,7 +703,7 @@ async function main(): Promise<void> {
   } else {
     console.log(`  (partial run — baseline.json unchanged)`)
   }
-  console.log(`  PASS ${counts.PASS} · FLAG ${counts.FLAG} · FAIL ${counts.FAIL} · INCONCLUSIVE ${counts.INCONCLUSIVE} (of ${rows.length})`)
+  console.log(`  HIGH ${counts.HIGH} · MID ${counts.MID} · LOW ${counts.LOW} · INCONCLUSIVE ${counts.INCONCLUSIVE} (of ${rows.length})`)
 
   // Diff against prior baseline if requested. priorBaseline was read into
   // memory BEFORE the new baseline was written, so even when --baseline points
@@ -591,13 +714,16 @@ async function main(): Promise<void> {
     let improved = 0
     let scoreDelta = 0
     let scoreCompared = 0
+    const tierRank: Record<string, number> = { HIGH: 3, MID: 2, LOW: 1, INCONCLUSIVE: 0, PASS: 3, FLAG: 2, FAIL: 1 }
     for (const r of rows) {
       const p = priorBaseline[r.fx]
       if (!p) continue
-      if (p.verdict === 'PASS' && r.verdict !== 'PASS') {
+      const pr = tierRank[p.verdict] ?? 0
+      const rr = tierRank[r.verdict] ?? 0
+      if (rr < pr) {
         console.log(`  ✗ regression: ${r.fx} ${p.verdict} → ${r.verdict}`)
         regressed++
-      } else if (p.verdict !== 'PASS' && r.verdict === 'PASS') {
+      } else if (rr > pr) {
         console.log(`  ✓ improvement: ${r.fx} ${p.verdict} → ${r.verdict}`)
         improved++
       }


### PR DESCRIPTION
## Summary
- Engine fix for SP72: nested `live_loop` registrations now inherit bpm/synth from the in-flight parent builder rather than engine-level defaults.
- ~25 LoC across 2 files (`ProgramBuilder.ts` + `SonicPiEngine.ts`).
- 929/929 unit tests pass; tsc clean.

## Why this matters

`tools/capture.ts --wrap-recording` wraps user code in an `in_thread`. Inside that wrap, `b.use_bpm(120)` mutates the parent builder's `_currentBpm` only — engine-level `defaultBpm` stays at 60. Nested `live_loop` registrations were reading the engine value, so every comparator capture acquired via `--wrap-recording` ran web at bpm=60 against desktop bpm=120. Months of "filter family cluster" parity variance trace back to this confound.

## Fix sketch

- `ProgramBuilder.ts` — add read-only getters `currentBpm` / `currentDefaultSynth`.
- `SonicPiEngine.ts` — track `currentBuildBuilder` (push/restore around `builderFn(builder)` so nested `live_loop` inside another's body still sees the innermost parent). `wrappedLiveLoop` reads `inheritedBpm` / `inheritedSynth` from that builder when `buildNestingDepth > 0`. Top-level registrations (depth=0) still use engine defaults — unchanged path.

## Test plan
- [x] `npx vitest run` — 929/929 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `tools/capture.ts --wrap-recording` on `use_bpm 120; live_loop :p { sample :bd_haus; sleep 0.5 }` fires `/s_new` at 0.25s deltas (was 0.5s pre-fix), confirmed via OSC trace.
- [ ] FX-sweep + e2e re-baseline (deferred — must run on a single SR-consistent scsynth session per SP74/SV29).

## Catalogue

- hetvabhasa **SP72** — \`use_bpm\` / \`use_synth\` Leak From \`in_thread\` Body Into Nested \`live_loop\` Registration
- vyapti **SV28** — Build-Phase State Must Be Visible To Synchronous Registrations Inside \`builderFn\`

Closes #279.