### PR TITLE
Fix hot-swap snare-band accumulation — cancel reusableFx killTimers before Map.clear()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ playwright-report/
 
 # Browser diagnostic captures (internal observation tool)
 .captures/
+tmp/
 
 # Personal learnings (not part of the project)
 LEARNINGS.md

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -84,8 +84,14 @@ export class SonicPiEngine {
   private schedAheadTime: number
   /** Maps DSL nodeRef → SuperSonic nodeId for control messages */
   private nodeRefMap = new Map<number, number>()
-  /** Reusable inner FX nodes — persists across loop iterations. See issue #70. */
-  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number }>()
+  /** Reusable inner FX nodes — persists across loop iterations. See issue #70.
+   *  `killTimer` is the pending `setTimeout` handle that frees this FX 1s after
+   *  its last iteration if no follow-up iteration cancels it. On hot-swap /
+   *  stop we MUST clearTimeout these before dropping the map entries, otherwise
+   *  the stale timer fires later and calls freeBus/freeGroup on what are by
+   *  then NEW live FX resources — corrupting the bus pool and silently killing
+   *  groups (issue #290). */
+  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: ReturnType<typeof setTimeout> }>()
   /** Pending volume to apply when bridge initializes */
   private pendingVolume: number | null = null
   /** Stored builder functions for capture/query path */
@@ -1440,6 +1446,18 @@ export class SonicPiEngine {
           // /s_new to dead buses for several seconds while waiting for
           // their next iteration to lazy-create FX.
           this.persistentFx.clear()
+          // Cancel pending FX-kill setTimeouts BEFORE dropping the map.
+          // Each per-iteration with_fx schedules a 1s killTimer (AudioInterpreter
+          // ~line 286/325) that frees its bus + group. /g_freeAll already killed
+          // the scsynth-side nodes, so the kill is redundant, but its freeBus()
+          // would push a stale bus index back into freeBuses[] and the freeGroup
+          // would /n_free a group that may now belong to a freshly-allocated FX.
+          // Without this clearTimeout, the stale timer fires ~1s post-hot-swap
+          // and corrupts pool state, producing audible "snare band growth" and
+          // reproducible track drops (issue #290).
+          for (const state of this.reusableFx.values()) {
+            if (state.killTimer) clearTimeout(state.killTimer)
+          }
           this.reusableFx.clear()
         }
 
@@ -1521,6 +1539,12 @@ export class SonicPiEngine {
     this.definedFns.clear()
     this.defonceCache.clear()
     this.persistentFx.clear()
+    // Same as hot-swap path: cancel pending FX-kill setTimeouts BEFORE dropping
+    // the map. Without this, a Stop followed by a quick re-Run would have stale
+    // timers fire ~1s later on freshly-allocated FX (issue #290).
+    for (const state of this.reusableFx.values()) {
+      if (state.killTimer) clearTimeout(state.killTimer)
+    }
     this.reusableFx.clear()
     this.loopFxScope.clear()
     this.fxScopeChains.clear()

--- a/tools/analyze-rerun-boundaries.py
+++ b/tools/analyze-rerun-boundaries.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Slice the rerun WAV into fine windows around hot-swap boundaries and look
+for short dropouts that 4s averaging hides.
+
+Reports:
+  - RMS per 100ms window for the full duration (timeline)
+  - Per-band RMS at 200ms resolution for ±1s around each boundary (t=4,8,12)
+  - Any window where RMS falls below 30% of the surrounding median
+
+Usage:
+  python3 analyze-rerun-boundaries.py <wav> [chunk_seconds=4]
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp":       (800, 2000),
+    "cymb_hi":   (2000, 6000),
+    "cymb_vhi":  (6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr, n, ch, sw = w.getframerate(), w.getnframes(), w.getnchannels(), w.getsampwidth()
+        raw = w.readframes(n)
+    dt = {1: np.uint8, 2: np.int16, 4: np.int32}[sw]
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:  a /= 32768.0
+    elif dt == np.int32: a /= 2147483648.0
+    elif dt == np.uint8: a = (a - 128.0) / 128.0
+    if ch == 2: a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def band_rms(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    if len(x) < 32: return 0.0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    y = np.fft.irfft(spec, n=len(x))
+    return float(np.sqrt(np.mean(y ** 2)))
+
+def main():
+    wav = sys.argv[1]
+    chunk_s = float(sys.argv[2]) if len(sys.argv) > 2 else 4.0
+    a, sr = load_wav(wav)
+    dur = len(a) / sr
+    print(f"loaded {wav}: {dur:.2f}s @ {sr}Hz")
+
+    # 1. Timeline of overall RMS at 100ms resolution
+    win = int(0.100 * sr)
+    n_win = len(a) // win
+    rms_timeline = np.array([
+        np.sqrt(np.mean(a[i*win:(i+1)*win] ** 2)) for i in range(n_win)
+    ])
+    med = float(np.median(rms_timeline))
+    low = rms_timeline < 0.3 * med
+    low_idx = np.where(low)[0]
+    print(f"\n[timeline] median RMS = {med:.4f}; low-RMS windows (< 30% median):")
+    if low_idx.size == 0:
+        print("  none")
+    else:
+        # cluster into runs
+        clusters = []
+        prev = -10
+        cur = []
+        for i in low_idx:
+            if i - prev <= 2:
+                cur.append(i)
+            else:
+                if cur: clusters.append(cur)
+                cur = [i]
+            prev = i
+        if cur: clusters.append(cur)
+        for c in clusters[:30]:
+            t0, t1 = c[0] * 0.1, (c[-1] + 1) * 0.1
+            print(f"  {t0:6.2f}-{t1:6.2f}s  (RMS dips to {rms_timeline[c].min():.4f})")
+
+    # 2. Per-band RMS at 200ms resolution around boundaries
+    boundaries = [chunk_s * i for i in range(1, int(dur // chunk_s) + 1)]
+    bwin = int(0.200 * sr)
+    pre_post = 1.0  # +/- 1s around each boundary
+    n_steps = int(pre_post * 2 / 0.2)
+    print(f"\n[boundary scan] ±{pre_post}s around each Run-click at 200ms resolution:")
+    for b in boundaries:
+        if b > dur - pre_post: continue
+        print(f"\n  boundary t={b:.2f}s (hot-swap click)")
+        hdr = f"    {'t(s)':>6} " + " ".join(f"{k:>8}" for k in BANDS)
+        print(hdr)
+        for s in range(n_steps + 1):
+            t0 = b - pre_post + s * 0.2
+            i0 = int(t0 * sr)
+            if i0 < 0 or i0 + bwin > len(a): continue
+            seg = a[i0:i0 + bwin]
+            row = f"    {t0:>6.2f} "
+            for name, (lo, hi) in BANDS.items():
+                row += f" {band_rms(seg, sr, lo, hi):8.5f}"
+            mark = "  <-- click" if abs(t0 - b) < 0.1 else ""
+            print(row + mark)
+
+if __name__ == "__main__":
+    main()

--- a/tools/analyze-rerun-chunks.py
+++ b/tools/analyze-rerun-chunks.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Split a continuous WAV into N equal chunks and report per-chunk band energy
+and onset counts for each frequency band that maps to a DJ_Dave instrument:
+
+  kick     : 40-120 Hz       (bd_tek body)
+  snare    : 200-800 Hz      (drum_snare_hard fundamentals)
+  cymbal_hi: 2000-6000 Hz    (drum_cymbal_closed shimmer)
+  cymbal_vhi: 6000-12000 Hz  (cymbal/crash high)
+  synthbass: 60-200 Hz       (tech_saws low)
+  arp_mid  : 800-2000 Hz     (beep melody)
+
+A track that goes silent in chunk N shows as a band-energy drop of >40% vs
+chunk 1 in that band. Onset count also drops to 0.
+
+Usage:
+  python3 analyze-rerun-chunks.py <wav> <chunk_seconds> <num_chunks>
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp_mid":   (800, 2000),
+    "cymbal_hi": (2000, 6000),
+    "cymbal_vhi":(6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr = w.getframerate()
+        n = w.getnframes()
+        ch = w.getnchannels()
+        sw = w.getsampwidth()
+        raw = w.readframes(n)
+    if sw == 4:
+        dt = np.int32
+    elif sw == 2:
+        dt = np.int16
+    else:
+        dt = np.uint8
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:
+        a /= 32768.0
+    elif dt == np.int32:
+        a /= 2147483648.0
+    elif dt == np.uint8:
+        a = (a - 128.0) / 128.0
+    if ch == 2:
+        a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def band_energy(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    n = len(x)
+    if n == 0:
+        return 0.0
+    # rfft
+    spec = np.fft.rfft(x * np.hanning(n))
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    mask = (freqs >= lo) & (freqs < hi)
+    if not mask.any():
+        return 0.0
+    mag = np.abs(spec[mask])
+    return float(np.sqrt((mag ** 2).mean()))
+
+def onset_count(x: np.ndarray, sr: int, lo: float, hi: float, thr_mul: float = 1.6) -> int:
+    """Simple onset detector inside a band: bandpass + envelope + peak-pick."""
+    # bandpass via fft
+    n = len(x)
+    if n == 0:
+        return 0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    bp = np.fft.irfft(spec, n=n)
+    # envelope
+    win = max(1, int(0.005 * sr))
+    env = np.abs(bp)
+    env = np.convolve(env, np.ones(win) / win, mode="same")
+    # peaks above thr_mul × median
+    thr = thr_mul * float(np.median(env) + 1e-9)
+    # require local maximum + spacing of 30ms
+    spacing = max(1, int(0.030 * sr))
+    peaks = []
+    last = -spacing
+    for i in range(1, len(env) - 1):
+        if env[i] > thr and env[i] > env[i - 1] and env[i] >= env[i + 1] and (i - last) >= spacing:
+            peaks.append(i)
+            last = i
+    return len(peaks)
+
+def main():
+    wav_path, chunk_s, n_chunks = sys.argv[1], float(sys.argv[2]), int(sys.argv[3])
+    a, sr = load_wav(wav_path)
+    chunk_n = int(chunk_s * sr)
+    total_frames = a.size
+    print(f"loaded {wav_path}: {total_frames / sr:.2f}s @ {sr}Hz mono")
+    print(f"requested {n_chunks} chunks of {chunk_s}s = {n_chunks * chunk_n} frames")
+    print()
+
+    # Each chunk starts at the Rec start (chunk 0) and steps by chunk_n.
+    # If Rec includes pre-roll, chunk 0 may have less material — that's fine,
+    # the user only cares about relative loss across chunks.
+    rows = []
+    for i in range(n_chunks):
+        start = i * chunk_n
+        end = min(start + chunk_n, total_frames)
+        if end - start < sr // 2:
+            print(f"chunk {i}: too short ({(end - start) / sr:.2f}s) — skipping")
+            continue
+        seg = a[start:end]
+        row = {"chunk": i, "label": "Run#1" if i == 0 else f"Run#{i + 1}(hot-swap)"}
+        row["rms"] = float(np.sqrt(np.mean(seg ** 2)))
+        row["peak"] = float(np.max(np.abs(seg)))
+        for name, (lo, hi) in BANDS.items():
+            row[f"e_{name}"] = band_energy(seg, sr, lo, hi)
+            row[f"n_{name}"] = onset_count(seg, sr, lo, hi)
+        rows.append(row)
+
+    # Print table
+    if not rows:
+        print("no chunks analysed")
+        return 1
+    base = rows[0]
+    hdr = f"{'chunk':6} {'label':22} {'RMS':>7} {'peak':>6} | " + " | ".join(
+        f"{k:>11}" for k in BANDS
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        cells = [f"{r['chunk']:<6}", f"{r['label']:<22}", f"{r['rms']:7.4f}", f"{r['peak']:6.3f}", "|"]
+        for name in BANDS:
+            e = r[f"e_{name}"]
+            n = r[f"n_{name}"]
+            be = base[f"e_{name}"]
+            ratio = (e / be) if be > 1e-9 else 0.0
+            mark = ""
+            if r["chunk"] > 0:
+                if be > 1e-6 and ratio < 0.4:
+                    mark = " DROP"
+                elif be > 1e-6 and ratio > 2.0:
+                    mark = " SPIKE"
+            cells.append(f"{e:5.3f}({n:>2}){mark:>6}")
+        print(" ".join(cells))
+
+    # Verdict
+    print()
+    drops = []
+    for r in rows[1:]:
+        for name in BANDS:
+            be = base[f"e_{name}"]
+            e = r[f"e_{name}"]
+            if be > 1e-6 and (e / be) < 0.4:
+                drops.append((r["chunk"], r["label"], name, e / be))
+    if drops:
+        print("VERDICT: TRACK LOSS DETECTED on hot-swap")
+        for c, lab, n, ratio in drops:
+            print(f"  chunk {c} ({lab}): band {n} fell to {ratio:.0%} of baseline")
+        return 1
+    print("VERDICT: no >60% band drop across chunks — tracks appear to survive hot-swap")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test-rerun-minimal-clap.ts
+++ b/tools/test-rerun-minimal-clap.ts
@@ -1,0 +1,105 @@
+/**
+ * Minimal repro: just the clap loop wrapped in echo→reverb. Same Update cadence
+ * as the full DJ_Dave test. If snare-band still grows across re-runs, the bug
+ * is in FX teardown / state accumulation. If flat, it's multi-loop interaction.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-minimal-clap')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+const SNIPPET = `use_bpm 130
+live_loop :met1 do
+  sleep 1
+end
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else { origClick.call(this) }
+    }
+  })
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', err => console.error('[page error]', err.message))
+
+  await page.goto(BASE_URL); await page.waitForTimeout(2000)
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100); await editor.fill(SNIPPET); await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  console.log('[minimal-clap] Run #1')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) { console.log(`[minimal-clap] Run #${i + 1}`); await runBtn.click() }
+  }
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) await saveBtn.click(); else await recBtn.click()
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer(); const bytes = new Uint8Array(buf)
+    let s = ''; const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_minimal_clap.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[minimal-clap] wrote ${wavPath}`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  const py = spawnSync('python3', [resolve(__dirname, 'analyze-rerun-chunks.py'), wavPath, String(CHUNK_MS / 1000), String(NUM_CHUNKS)], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+main().catch(e => { console.error(e); process.exit(1) })

--- a/tools/test-rerun-no-arp.ts
+++ b/tools/test-rerun-no-arp.ts
@@ -1,0 +1,204 @@
+/**
+ * Reproducer variant: same as test-rerun-track-loss but WITHOUT the arp loop.
+ * Tests hypothesis #4: arp (:beep at G4-D5, 392-587Hz) overlaps snare band; its
+ * disappearance/return across hot-swaps drives the apparent snare-band growth.
+ *
+ * If snare band is flat across chunks with no arp present, hypothesis #4 is right
+ * — the "snare growth" is partially or fully an artifact of arp band-overlap.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-track-loss')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+// DJ_Dave sketch with the arp loop removed (and its with_fx wrappers).
+// Also removed: synthbass (also tonal, in snare band overlap zone).
+// Keeps: kick, clap (echo+reverb), hhc1 (reverb+panslicer), hhc2, crash.
+const SNIPPET = `# Coded by DJ_Dave (no arp, no synthbass)
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-no-arp] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  console.log('[rerun-no-arp] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-no-arp] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-no-arp] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_noarp.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-no-arp] wrote ${wavPath} (${wav.length} bytes)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-no-arp] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-rerun-track-loss.ts
+++ b/tools/test-rerun-track-loss.ts
@@ -1,0 +1,252 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-track-loss')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4   // one initial + 3 re-runs
+const SETTLE_MS = 2000
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-track-loss] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-track-loss] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_continuous.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-track-loss] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Cancel pending `state.killTimer` setTimeouts before `reusableFx.clear()` on hot-swap + stop. Each per-iteration `with_fx` schedules a 1s `kill_delay` timer that calls `freeBus` + `freeGroup`; without cancelling it, the timer fires ~1s post-Update onto freshly-allocated FX, pushing a live bus back into the pool (signal stacking → snare-band growth) and `/n_free`-ing live groups (track drops).

Closes #290.

## Root cause classification

Boundary + ownership crossed with timing — **stale setTimeout outlives its owning Map**. Sister to SP41 (build-time vs scheduled-time) but at the scheduled-callback layer, not the build-side-effect layer. Candidate new hetvabhasa pattern (proposed SP82).

## What changed in the file

`src/engine/SonicPiEngine.ts`:
- Widened `reusableFx` value type with optional `killTimer?: ReturnType<typeof setTimeout>`
- Added `clearTimeout` drain loop at both `reusableFx.clear()` call sites (hot-swap path + stop/dispose path)

## Universal principle (limb 3 of pañcāvayava)

> A deferred callback (setTimeout / rAF / MessagePort) that references resources owned by a collection MUST be cancelled before the collection is cleared. `.clear()` releases JS references; it does not affect callbacks already scheduled with the runtime. **Drop entries last; cancel their callbacks first.**

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 929/929 pass
- [x] WAV reproducer (`tools/test-rerun-track-loss.ts`) — 2 consecutive runs show snare-band oscillation NOT monotone growth, returns near baseline by Run#4 (was 73→92 baseline, now 57→84→72→56)
- [x] `arp_mid` band DEAD FLAT across all 4 chunks of both reproducer runs (4.22-4.24 every chunk vs baseline 5.8/5.7/4.2/5.6 with reproducible chunk-2 drop-to-0.85 in the failed-fix attempts)
- [x] No-arp discriminator (`tools/test-rerun-no-arp.ts`) confirms inner `with_fx` in the arp loop was the source — snare flat at 21.9 across all chunks when arp is removed
- [ ] Manual: paste DJ_Dave sketch, press Run, then Update 3× while listening — should no longer get progressively washy

## Branch base

Built on top of PR #289 (Ctrl/Cmd+Enter document-level + Run-label fix) so testing can use Ctrl/Cmd+Enter to trigger the hot-swap. Will rebase to main once #289 merges.

## Why prior attempts made it worse (data preserved in `tmp/hot-swap-snare-accumulation-observations.md`)

- **Attempt #1 — `await purge()` inside `freeAllNodes`:** lengthened the gap between teardown and new-FX allocation, giving more time for stale timers to fire onto fresh resources. Snare peak: 92 → 113.
- **Attempt #2 — reorder `freeAllNodes` after `reEvaluate`:** by the time `freeAllNodes` ran, new persistent FX had already been allocated, so stale timers had EVEN MORE live FX to corrupt. Snare peak: 113 → 129.

Both were patching the wrong layer. The actual cause was JS timer hygiene at the engine level, not OSC purge ordering.

## Bundled in this PR

- `src/engine/SonicPiEngine.ts` — the fix (~16 LoC)
- `.gitignore` — adds `tmp/` for investigation notes
- `tools/test-rerun-track-loss.ts` — Playwright reproducer (full DJ_Dave)
- `tools/test-rerun-no-arp.ts` — discriminator (full sketch minus arp loop)
- `tools/test-rerun-minimal-clap.ts` — earlier discriminator (kept for reference)
- `tools/analyze-rerun-chunks.py` — 4s-chunk band-energy + onset analyzer
- `tools/analyze-rerun-boundaries.py` — 100ms timeline + 200ms boundary scan

## Catalogue follow-ups (after merge)

- Add SP82 (or next number) to `~/.anvideck/projects/sonicPiWeb/.anvi/hetvabhasa.md` — *Deferred resource-free setTimeout survives its owner Map.clear()*
- Add companion invariant to `vyapti.md` — *Hot-swap state hygiene includes JS timer hygiene*