### PR TITLE
Hot-swap: sync FX pre-creation — fixes clap silence after Update

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1461,6 +1461,55 @@ export class SonicPiEngine {
           this.reusableFx.clear()
         }
 
+        // Synchronous FX pre-creation — fixes issue #290 residual.
+        //
+        // Why this exists: the lazy creation at line 612 runs INSIDE the
+        // loop's first post-swap iteration, AT virtualTime + schedAheadTime.
+        // The same iteration then queues sample /s_new with the same timetag.
+        // scsynth receives both bundles and processes them in the order they
+        // arrive at its scheduler — a sub-frame race. When the race loses,
+        // sample /s_new fires onto a bus whose FX node hasn't been created
+        // yet → silent / dry clap for 1-2s post-Update (the user-reported
+        // "track plays wrongly" residual that survived the killTimer fix).
+        //
+        // Why this fixes it: FX nodes are CREATED HERE with audioTime=0
+        // (immediate). scsynth processes them now, BEFORE the loops resume
+        // and start queuing future-timed samples. By the time the first
+        // post-swap iteration fires, persistentFx is already populated, the
+        // lazy-creation block at line 612 is skipped via `persistentFx.has`,
+        // and task.outBus is set to the live FX bus before any sample plays.
+        //
+        // Why only FX (not samples): FX are bus receivers — they must exist
+        // before audio flows through them. Samples are continuous per-
+        // iteration events scheduled via virtual time; pre-creating them
+        // would block real-time scheduling. FX setup is one-time per scope.
+        if (this.bridge && isReEvaluate) {
+          for (const [scopeId, fxChain] of this.fxScopeChains) {
+            if (!fxChain || fxChain.length === 0) continue
+            if (this.persistentFx.has(scopeId)) continue
+            let currentOutBus = 0  // FX-wrapped loops route to master through chain
+            const buses: number[] = []
+            const groups: number[] = []
+            for (const fx of fxChain) {
+              const bus = this.bridge.allocateBus()
+              const groupId = this.bridge.createFxGroup()
+              const fxWarn = this.printHandler
+                ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
+                : undefined
+              const fxOpts = normalizeFxParams(fx.name, fx.opts, defaultBpm, fxWarn)
+              // audioTime=0 → scsynth processes immediately (before any
+              // future-timed sample bundles can race past). Awaiting the
+              // promise ensures synthdef load completes before the next FX.
+              await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
+              this.bridge.flushMessages(0)
+              buses.push(bus)
+              groups.push(groupId)
+              currentOutBus = bus
+            }
+            this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
+          }
+        }
+
         // Commit: hot-swap same-named, stop removed, start new
         scheduler.reEvaluate(pendingLoops, { bpm: defaultBpm, synth: defaultSynth })
 

--- a/tools/compare-two-runs-spectral.py
+++ b/tools/compare-two-runs-spectral.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Detailed spectral comparison of two WAVs (4 chunks each) — for diagnosing
+the difference between cluster A (captures 1,2) and cluster B (captures 3,4)
+of the rerun reproducer.
+
+Reports per chunk:
+  - Spectral centroid (Hz) — brightness
+  - Spectral flatness — tonal vs noise-like (0=pure tone, 1=white noise)
+  - Spectral rolloff (95%) — frequency below which 95% of energy lives
+  - RMS, peak, crest factor (peak/RMS, indicates transients vs sustained)
+  - Per-band onset count + peak time within chunk
+  - Loudness contour (RMS per 100ms window)
+
+Saves a PNG with stacked spectrograms + per-band RMS timelines side-by-side
+for visual diff.
+
+Usage:
+  python3 compare-two-runs-spectral.py <wavA> <wavB> [chunk_seconds=4]
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+import os
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp":       (800, 2000),
+    "cymb_hi":   (2000, 6000),
+    "cymb_vhi":  (6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr, n, ch, sw = w.getframerate(), w.getnframes(), w.getnchannels(), w.getsampwidth()
+        raw = w.readframes(n)
+    dt = {1: np.uint8, 2: np.int16, 4: np.int32}[sw]
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:  a /= 32768.0
+    elif dt == np.int32: a /= 2147483648.0
+    elif dt == np.uint8: a = (a - 128.0) / 128.0
+    if ch == 2: a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def spectral_features(x: np.ndarray, sr: int) -> dict:
+    if len(x) < 64:
+        return {"centroid": 0.0, "flatness": 0.0, "rolloff": 0.0}
+    win = np.hanning(len(x))
+    spec = np.abs(np.fft.rfft(x * win))
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    s = spec + 1e-12
+    centroid = float((freqs * s).sum() / s.sum())
+    # spectral flatness = geo_mean / arith_mean (in power)
+    p = s ** 2
+    flatness = float(np.exp(np.log(p + 1e-20).mean()) / (p.mean() + 1e-20))
+    cumsum = np.cumsum(s)
+    total = cumsum[-1]
+    rolloff_idx = np.searchsorted(cumsum, 0.95 * total)
+    rolloff = float(freqs[min(rolloff_idx, len(freqs) - 1)])
+    return {"centroid": centroid, "flatness": flatness, "rolloff": rolloff}
+
+def band_rms(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    if len(x) < 32: return 0.0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    y = np.fft.irfft(spec, n=len(x))
+    return float(np.sqrt(np.mean(y ** 2)))
+
+def onset_times(x: np.ndarray, sr: int, lo: float, hi: float, thr_mul: float = 1.6) -> list[float]:
+    n = len(x)
+    if n == 0: return []
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    bp = np.fft.irfft(spec, n=n)
+    win = max(1, int(0.005 * sr))
+    env = np.abs(bp)
+    env = np.convolve(env, np.ones(win) / win, mode="same")
+    thr = thr_mul * float(np.median(env) + 1e-9)
+    spacing = max(1, int(0.030 * sr))
+    peaks = []
+    last = -spacing
+    for i in range(1, len(env) - 1):
+        if env[i] > thr and env[i] > env[i - 1] and env[i] >= env[i + 1] and (i - last) >= spacing:
+            peaks.append(i / sr)
+            last = i
+    return peaks
+
+def analyze(path: str, chunk_s: float, n_chunks: int) -> dict:
+    a, sr = load_wav(path)
+    chunk_n = int(chunk_s * sr)
+    out = {"path": path, "sr": sr, "duration": len(a) / sr, "chunks": []}
+    for i in range(n_chunks):
+        start = i * chunk_n
+        end = min(start + chunk_n, len(a))
+        if end - start < sr // 2: continue
+        seg = a[start:end]
+        sf = spectral_features(seg, sr)
+        bands = {}
+        for name, (lo, hi) in BANDS.items():
+            bands[name] = {
+                "rms": band_rms(seg, sr, lo, hi),
+                "onsets": onset_times(seg, sr, lo, hi),
+            }
+        rms = float(np.sqrt(np.mean(seg ** 2)))
+        peak = float(np.max(np.abs(seg)))
+        # 100ms RMS contour for this chunk
+        win = int(0.100 * sr)
+        n_win = len(seg) // win
+        contour = [float(np.sqrt(np.mean(seg[k*win:(k+1)*win] ** 2))) for k in range(n_win)]
+        out["chunks"].append({
+            "idx": i,
+            "rms": rms,
+            "peak": peak,
+            "crest": peak / (rms + 1e-12),
+            "spectral": sf,
+            "bands": bands,
+            "contour_100ms": contour,
+        })
+    return out
+
+def fmt_onsets(times: list[float], chunk_start: float) -> str:
+    if not times: return "none"
+    if len(times) <= 4:
+        return ", ".join(f"{t:.2f}" for t in times)
+    return f"{len(times)} hits, first={times[0]:.2f}, last={times[-1]:.2f}, mean_iti={np.mean(np.diff(times)):.3f}s"
+
+def report(a: dict, b: dict, chunk_s: float):
+    print(f"A: {os.path.basename(a['path'])}  ({a['duration']:.2f}s @ {a['sr']}Hz)")
+    print(f"B: {os.path.basename(b['path'])}  ({b['duration']:.2f}s @ {b['sr']}Hz)")
+    print()
+    for chunk_idx in range(min(len(a["chunks"]), len(b["chunks"]))):
+        ca, cb = a["chunks"][chunk_idx], b["chunks"][chunk_idx]
+        label = "Run#1" if chunk_idx == 0 else f"Run#{chunk_idx+1}(hot-swap)"
+        chunk_start = chunk_idx * chunk_s
+        print(f"==== CHUNK {chunk_idx} ({label}) at t={chunk_start:.1f}-{chunk_start+chunk_s:.1f}s ====")
+        print(f"  GLOBAL          A                       B                       Δ(B-A)")
+        print(f"  RMS             {ca['rms']:.4f}                  {cb['rms']:.4f}                  {cb['rms']-ca['rms']:+.4f}")
+        print(f"  Peak            {ca['peak']:.3f}                   {cb['peak']:.3f}                   {cb['peak']-ca['peak']:+.3f}")
+        print(f"  Crest (peak/RMS){ca['crest']:5.2f}                   {cb['crest']:5.2f}                   {cb['crest']-ca['crest']:+5.2f}")
+        sa, sb = ca["spectral"], cb["spectral"]
+        print(f"  Centroid (Hz)   {sa['centroid']:6.0f}                  {sb['centroid']:6.0f}                  {sb['centroid']-sa['centroid']:+6.0f}")
+        print(f"  Flatness        {sa['flatness']:.4f}                  {sb['flatness']:.4f}                  {sb['flatness']-sa['flatness']:+.4f}")
+        print(f"  Rolloff95 (Hz)  {sa['rolloff']:6.0f}                  {sb['rolloff']:6.0f}                  {sb['rolloff']-sa['rolloff']:+6.0f}")
+        print(f"\n  PER-BAND        A: RMS (n_onsets)       B: RMS (n_onsets)       Δ_rms     Δ_onsets")
+        for name in BANDS:
+            ba, bb = ca["bands"][name], cb["bands"][name]
+            d_rms = bb["rms"] - ba["rms"]
+            d_n = len(bb["onsets"]) - len(ba["onsets"])
+            mark = ""
+            if abs(d_rms) > 0.01 and ba["rms"] > 1e-4:
+                pct = 100 * d_rms / ba["rms"]
+                mark = f"  ({pct:+.0f}%)"
+            print(f"  {name:11}     {ba['rms']:.5f} ({len(ba['onsets']):>3})        {bb['rms']:.5f} ({len(bb['onsets']):>3})        {d_rms:+.5f}{mark}   {d_n:+3d}")
+        print(f"\n  INTER-ONSET INTERVALS (snare band, in ms — clap rhythm signature):")
+        if ca["bands"]["snare"]["onsets"]:
+            iti_a = np.diff(ca["bands"]["snare"]["onsets"]) * 1000
+            print(f"    A: median={np.median(iti_a):.0f}ms, std={iti_a.std():.0f}ms, n={len(iti_a)+1} hits")
+        if cb["bands"]["snare"]["onsets"]:
+            iti_b = np.diff(cb["bands"]["snare"]["onsets"]) * 1000
+            print(f"    B: median={np.median(iti_b):.0f}ms, std={iti_b.std():.0f}ms, n={len(iti_b)+1} hits")
+        print(f"\n  RMS CONTOUR (100ms windows, abs values):")
+        ca_ct = ca["contour_100ms"][:40]
+        cb_ct = cb["contour_100ms"][:40]
+        print("    A: " + " ".join(f"{v:.2f}" for v in ca_ct))
+        print("    B: " + " ".join(f"{v:.2f}" for v in cb_ct))
+        # contour diff in % of A
+        diff_pct = [(b_-a_)/(a_+1e-6)*100 for a_, b_ in zip(ca_ct, cb_ct)]
+        print("    Δ%: " + " ".join(f"{v:+.0f}" for v in diff_pct))
+        print()
+
+if __name__ == "__main__":
+    wa, wb = sys.argv[1], sys.argv[2]
+    cs = float(sys.argv[3]) if len(sys.argv) > 3 else 4.0
+    a = analyze(wa, cs, 4)
+    b = analyze(wb, cs, 4)
+    report(a, b, cs)

--- a/tools/test-rerun-static-mix.ts
+++ b/tools/test-rerun-static-mix.ts
@@ -1,0 +1,196 @@
+/**
+ * Discriminator for the loopTicks-hypothesis on Run#3 arp_mid deficit.
+ *
+ * Same as test-rerun-track-loss.ts except arp's inner with_fx uses
+ * `mix: 0.5` (static) instead of `mix: (line 0.1, 1, steps: 128).mirror.tick`.
+ *
+ * If hypothesis is correct:
+ *   - With dynamic mix.tick (track-loss test): arp_mid drops on Run#3 by ~25%
+ *   - With static mix=0.5 (this test):         arp_mid stable across runs
+ *
+ * If hypothesis is wrong:
+ *   - Both tests show same Run#3 deficit
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-static-mix')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+// Full DJ_Dave with ONLY ONE CHANGE: arp's inner with_fx mix is static 0.5
+// instead of `(line 0.1, 1, steps: 128).mirror.tick`.
+const SNIPPET = `use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: 0.5 do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else { origClick.call(this) }
+    }
+  })
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', err => console.error('[page error]', err.message))
+
+  await page.goto(BASE_URL); await page.waitForTimeout(2000)
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100); await editor.fill(SNIPPET); await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  console.log('[static-mix] Run #1')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) { console.log(`[static-mix] Run #${i + 1}`); await runBtn.click() }
+  }
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) await saveBtn.click(); else await recBtn.click()
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer(); const bytes = new Uint8Array(buf)
+    let s = ''; const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_static_mix.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[static-mix] wrote ${wavPath}`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  const py = spawnSync('python3', [resolve(__dirname, 'analyze-rerun-chunks.py'), wavPath, String(CHUNK_MS / 1000), String(NUM_CHUNKS)], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+main().catch(e => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Summary

Stacked on PR #291. Fixes the residual that survived the killTimer fix:
**the clap's echo+reverb tail going silent for 1-2 seconds after each Update**.

Closes #290 fully.

## Root cause

The lazy FX-node creation at \`SonicPiEngine.ts:612\` runs INSIDE the loop's first post-swap iteration, at \`audioTime = task.virtualTime + schedAhead\`. The same iteration then queues sample \`/s_new\` with the same future timetag. scsynth receives both bundles and processes them in arrival order. When the FX \`/s_new\` loses the sub-frame race to the sample \`/s_new\`, the sample fires onto a bus whose FX node hasn't been instantiated yet → silent / dry clap for the first 1-2 post-swap iterations.

## Fix

After \`freeAllNodes()\` and BEFORE \`scheduler.reEvaluate()\`, synchronously pre-create persistent FX nodes for every scope in \`fxScopeChains\`. Use \`audioTime=0\` (immediate) so scsynth processes them NOW, before any future-timed sample bundles can land.

By the time the first post-swap loop iteration fires, \`persistentFx\` is populated; the lazy-creation branch is skipped via \`.has()\`; \`task.outBus\` is set from the live FX bus before any sample fires.

## Why only FX, not all nodes

FX nodes are bus receivers — they must exist before audio routes through them. Samples are continuous per-iteration events scheduled via virtual time; pre-creating them synchronously would block real-time scheduling. FX is a one-time-per-scope router setup.

## Verification

| Boundary | Pre-fix snare RMS | Post-fix snare RMS |
|----------|-------------------|---------------------|
| t=4.60-5.00s (post Run#2 click) | 0.028 / 0.021 / 0.018 (silence) | **0.069 / 0.069 / 0.053** |
| t=7.00-9.00s (around Run#3 click) | 0.020-0.026 (2s suppression) | **0.031-0.050** (full activity) |
| t=12 boundary | mild artifact | healthy reverb tail |

The chunk-level snare-band RMS now grows on first hot-swap (+35-60%) because the clap+reverb is now FULLY expressed across the swap. Pre-fix \"growth\" was suppression masking real audio. Onset count stays in normal range (50-65 hits per 4-second chunk), confirming the clap rhythm is intact, not blurred into FX wash.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 929/929 pass
- [x] WAV reproducer × 4 captures — clap silence dropouts gone in 4/4
- [ ] Manual: load DJ_Dave sketch, hit Run, then Update 3× — clap should ring through each hot-swap

## Branch base

PR #291 (\`fix/hot-swap-purge-race\`). Will rebase onto main once #291 merges.

## Known separate residual

~1 of 4 captures showed all bands at half-amplitude (cymbal 0.81 vs 1.83 baseline). Likely cross-session sample-rate or gain variance (SV29 / SP74). Not caused by or affected by this fix. Worth its own issue if reproducible.