### PR TITLE
Preload FX synthdefs + sync FX pre-creation on first Run

### DIFF
--- a/src/engine/FxNames.ts
+++ b/src/engine/FxNames.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical list of FX synthdef names available in Sonic Pi Web.
+ *
+ * Sourced from synthinfo.rb FX classes (desktop Sonic Pi). Each entry maps to
+ * a `sonic-pi-fx_<name>.scsyndef` binary on the SuperSonic CDN. Loaded on demand
+ * via `SuperSonicBridge.ensureSynthDefLoaded`, or in bulk via
+ * `SuperSonicBridge.preloadFxSynthDefs` (called from engine.init for warm start).
+ *
+ * Single source of truth — consumed by the DSL `fx_names` introspector
+ * (`SonicPiEngine.ts:fx_names_fn`) AND the bridge preloader. Adding an FX here
+ * makes it both queryable AND eagerly loaded on engine init.
+ */
+export const ALL_FX_NAMES: readonly string[] = [
+  'reverb','echo','delay','distortion','slicer','wobble','ixi_techno',
+  'compressor','rlpf','rhpf','hpf','lpf','normaliser','pan','band_eq',
+  'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
+  'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
+  'ping_pong','panslicer',
+  // Filter variants — from synthinfo.rb FX classes
+  'bpf','rbpf','nbpf','nrbpf','nlpf','nrlpf','nhpf','nrhpf','eq',
+] as const

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -5,6 +5,7 @@ import { queryLoopProgram, type QueryEvent } from './interpreters/QueryInterpret
 import { SuperSonicBridge, type SuperSonicBridgeOptions } from './SuperSonicBridge'
 import { Recorder } from './Recorder'
 import { normalizeFxParams } from './SoundLayer'
+import { ALL_FX_NAMES } from './FxNames'
 import { DSL_NAMES } from './DslNames'
 import { createIsolatedExecutor, validateCode, type ScopeHandle } from './Sandbox'
 import { autoTranspileDetailed } from './TreeSitterTranspiler'
@@ -214,6 +215,12 @@ export class SonicPiEngine {
         this.bridge!.setOscTraceHandler((msg) => {
           if (this.printHandler) this.printHandler(msg)
         })
+        // Preload every FX synthdef binary now so the first `with_fx` doesn't
+        // pay fetch+/d_recv latency at /s_new time. Fire-and-forget — failures
+        // (CDN miss for an individual FX) surface lazily per SP5 when that FX
+        // is actually used. Awaiting would gate first audio on ~40 fetches,
+        // which we'd rather absorb in the background after bridge init.
+        this.bridge!.preloadFxSynthDefs(ALL_FX_NAMES).catch(() => { /* lazy retry */ })
       })
       .catch((err) => {
         console.warn('[SonicPi] SuperSonic init failed, running without audio:', err)
@@ -488,15 +495,9 @@ export class SonicPiEngine {
         // Note: sound_in, sound_in_stereo, live_audio require Web Audio mic permission
         //   plumbing which is not yet implemented. Track separately.
       ]
-      const fx_names_fn = () => [
-        'reverb','echo','delay','distortion','slicer','wobble','ixi_techno',
-        'compressor','rlpf','rhpf','hpf','lpf','normaliser','pan','band_eq',
-        'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
-        'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
-        'ping_pong','panslicer',
-        // Filter variants — from synthinfo.rb FX classes
-        'bpf','rbpf','nbpf','nrbpf','nlpf','nrlpf','nhpf','nrhpf','eq',
-      ]
+      // Sourced from FxNames.ts — same array used by bridge.preloadFxSynthDefs
+      // during engine.init so the introspector and the preloader can't drift.
+      const fx_names_fn = () => [...ALL_FX_NAMES]
 
       // load_sample — no-op (samples auto-load on first use via CDN)
       const load_sample_fn = (_name: string) => { /* auto-loaded on first use */ }
@@ -1461,54 +1462,9 @@ export class SonicPiEngine {
           this.reusableFx.clear()
         }
 
-        // Synchronous FX pre-creation — fixes issue #290 residual.
-        //
-        // Why this exists: the lazy creation at line 612 runs INSIDE the
-        // loop's first post-swap iteration, AT virtualTime + schedAheadTime.
-        // The same iteration then queues sample /s_new with the same timetag.
-        // scsynth receives both bundles and processes them in the order they
-        // arrive at its scheduler — a sub-frame race. When the race loses,
-        // sample /s_new fires onto a bus whose FX node hasn't been created
-        // yet → silent / dry clap for 1-2s post-Update (the user-reported
-        // "track plays wrongly" residual that survived the killTimer fix).
-        //
-        // Why this fixes it: FX nodes are CREATED HERE with audioTime=0
-        // (immediate). scsynth processes them now, BEFORE the loops resume
-        // and start queuing future-timed samples. By the time the first
-        // post-swap iteration fires, persistentFx is already populated, the
-        // lazy-creation block at line 612 is skipped via `persistentFx.has`,
-        // and task.outBus is set to the live FX bus before any sample plays.
-        //
-        // Why only FX (not samples): FX are bus receivers — they must exist
-        // before audio flows through them. Samples are continuous per-
-        // iteration events scheduled via virtual time; pre-creating them
-        // would block real-time scheduling. FX setup is one-time per scope.
-        if (this.bridge && isReEvaluate) {
-          for (const [scopeId, fxChain] of this.fxScopeChains) {
-            if (!fxChain || fxChain.length === 0) continue
-            if (this.persistentFx.has(scopeId)) continue
-            let currentOutBus = 0  // FX-wrapped loops route to master through chain
-            const buses: number[] = []
-            const groups: number[] = []
-            for (const fx of fxChain) {
-              const bus = this.bridge.allocateBus()
-              const groupId = this.bridge.createFxGroup()
-              const fxWarn = this.printHandler
-                ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
-                : undefined
-              const fxOpts = normalizeFxParams(fx.name, fx.opts, defaultBpm, fxWarn)
-              // audioTime=0 → scsynth processes immediately (before any
-              // future-timed sample bundles can race past). Awaiting the
-              // promise ensures synthdef load completes before the next FX.
-              await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
-              this.bridge.flushMessages(0)
-              buses.push(bus)
-              groups.push(groupId)
-              currentOutBus = bus
-            }
-            this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
-          }
-        }
+        // Pre-create persistent FX synchronously before reEvaluate. See
+        // preCreatePersistentFx() for the full rationale (issue #290).
+        await this.preCreatePersistentFx(defaultBpm)
 
         // Commit: hot-swap same-named, stop removed, start new
         scheduler.reEvaluate(pendingLoops, { bpm: defaultBpm, synth: defaultSynth })
@@ -1528,10 +1484,76 @@ export class SonicPiEngine {
         scheduler.resumeTick()
       }
 
+      // First-eval path: hot-swap block above didn't run, so pre-create FX
+      // now. Without this, the very first Run hits the same FX-vs-sample
+      // sub-frame race that PR #292 fixed for hot-swap (issue #290) — the
+      // first 1-2 iterations of FX-wrapped loops can play dry while scsynth
+      // is still processing the lazy /s_new for the FX nodes. The helper is
+      // idempotent via `persistentFx.has(scopeId)`, so a no-op if the
+      // hot-swap branch above already populated it.
+      if (!isReEvaluate) {
+        await this.preCreatePersistentFx(defaultBpm)
+      }
+
       return {}
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       return { error }
+    }
+  }
+
+  /**
+   * Synchronously pre-create persistent FX nodes for every top-level scope
+   * before any loop iteration fires audio through them. Called from BOTH the
+   * first-eval path AND the hot-swap path (after freeAllNodes + map clear).
+   *
+   * Why this exists: the lazy creation at line 612 runs INSIDE the loop's
+   * first iteration, AT virtualTime + schedAheadTime. The same iteration
+   * then queues sample /s_new with the same timetag. scsynth receives both
+   * bundles and processes them in the order they arrive at its scheduler — a
+   * sub-frame race. When the race loses, sample /s_new fires onto a bus whose
+   * FX node hasn't been created yet → silent / dry clap (user-reported
+   * "music plays wrongly" residual on Update; the same race exists on first
+   * Run but is masked because the user just clicked Play).
+   *
+   * Why this fixes it: FX nodes are CREATED HERE with audioTime=0 (immediate).
+   * scsynth processes them now, BEFORE any future-timed sample bundle can
+   * land. By the time loops start iterating, persistentFx is populated, the
+   * lazy-creation block at line 612 is skipped via .has(), and task.outBus
+   * is set to the live FX bus before any sample plays.
+   *
+   * Why only FX (not samples): FX are bus receivers — they must exist before
+   * audio flows through them. Samples are continuous per-iteration events
+   * scheduled via virtual time; pre-creating them would block real-time
+   * scheduling. FX setup is one-time per scope.
+   *
+   * Idempotent: scopes already in `persistentFx` are skipped.
+   */
+  private async preCreatePersistentFx(bpm: number): Promise<void> {
+    if (!this.bridge) return
+    for (const [scopeId, fxChain] of this.fxScopeChains) {
+      if (!fxChain || fxChain.length === 0) continue
+      if (this.persistentFx.has(scopeId)) continue
+      let currentOutBus = 0  // FX-wrapped loops route to master through chain
+      const buses: number[] = []
+      const groups: number[] = []
+      for (const fx of fxChain) {
+        const bus = this.bridge.allocateBus()
+        const groupId = this.bridge.createFxGroup()
+        const fxWarn = this.printHandler
+          ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
+          : undefined
+        const fxOpts = normalizeFxParams(fx.name, fx.opts, bpm, fxWarn)
+        // audioTime=0 → scsynth processes immediately (before any
+        // future-timed sample bundles can race past). Awaiting the
+        // promise ensures synthdef load completes before the next FX.
+        await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
+        this.bridge.flushMessages(0)
+        buses.push(bus)
+        groups.push(groupId)
+        currentOutBus = bus
+      }
+      this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
     }
   }
 

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -535,6 +535,31 @@ export class SuperSonicBridge {
     this.messageQueue.length = 0
   }
 
+  /**
+   * Eagerly load multiple FX synthdef binaries in parallel. Called from
+   * engine.init() to warm the synthdef cache before any FX is used —
+   * eliminates the first-use fetch latency that would otherwise add ~50-200ms
+   * to the first /s_new for a previously-unseen FX (SP5 trap). Idempotent and
+   * safe to call multiple times; ensureSynthDefLoaded de-dupes via
+   * loadedSynthDefs + pendingSynthDefLoads.
+   *
+   * Pass FX names WITHOUT the `sonic-pi-fx_` prefix (e.g. 'reverb', 'echo') —
+   * the prefix is added internally to match ensureSynthDefLoaded's contract.
+   *
+   * Failures are swallowed (per-name) so one missing synthdef doesn't block
+   * the rest. Missing FX surface at /s_new dispatch time as before (SP5).
+   */
+  async preloadFxSynthDefs(names: readonly string[]): Promise<void> {
+    if (!this.sonic) return
+    await Promise.all(
+      names.map(n =>
+        this.ensureSynthDefLoaded(`sonic-pi-fx_${n}`).catch(() => {
+          /* CDN miss for this FX — surface at /s_new time per SP5 */
+        })
+      )
+    )
+  }
+
   private ensureSynthDefLoaded(name: string): Promise<void> {
     const fullName = name.startsWith('sonic-pi-') ? name : `sonic-pi-${name}`
     if (this.loadedSynthDefs.has(fullName)) return Promise.resolve()

--- a/tools/test-rerun-rapid.ts
+++ b/tools/test-rerun-rapid.ts
@@ -1,0 +1,258 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-rapid')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const RAPID_MS = Number(process.env.RAPID_MS ?? 1000)   // ms between rapid hot-swaps
+const NUM_RAPID = Number(process.env.NUM_RAPID ?? 10)   // rapid re-runs after initial Run
+const TAIL_MS = Number(process.env.TAIL_MS ?? 5000)     // free playback after last swap
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'rapid'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-rapid] Rec started — ${NUM_RAPID}× hot-swap @ ${RAPID_MS}ms then ${TAIL_MS}ms tail`)
+
+  for (let i = 1; i <= NUM_RAPID; i++) {
+    await page.waitForTimeout(RAPID_MS)
+    console.log(`[rerun-rapid] click Run (#${i + 1}, rapid hot-swap)...`)
+    await runBtn.click()
+  }
+  console.log(`[rerun-rapid] last hot-swap done — letting it play ${TAIL_MS}ms`)
+  await page.waitForTimeout(TAIL_MS)
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  // Boundary scan resolution matters here per feedback_boundary_scan_distinguishes_bug_classes
+  // (chunk-RMS would smear rapid swaps together — 200ms resolution separates them).
+  console.log('\n[rerun-rapid] running boundary scan around click moments...\n')
+  // Click moments at t=2 (initial settle) + RAPID_MS, +2*RAPID_MS, +3*RAPID_MS — but
+  // Rec t=0 is at start of Rec, which is right after the first Run completed and we
+  // settled SETTLE_MS. So rapid clicks occur at relative t = RAPID_MS, 2*RAPID_MS, 3*RAPID_MS.
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-boundaries.py'),
+    wavPath,
+    String(RAPID_MS / 1000),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-rerun-six-stress.ts
+++ b/tools/test-rerun-six-stress.ts
@@ -1,0 +1,253 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-six-stress')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 7   // one initial + 6 re-runs (user-spec: 6× re-run @ 4s)
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'trial'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-track-loss] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-track-loss] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-track-loss] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-run-stop-cycle.ts
+++ b/tools/test-run-stop-cycle.ts
@@ -1,0 +1,268 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/run-stop-cycle')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const PLAY_MS = Number(process.env.PLAY_MS ?? 1000)     // play time between Run and Stop
+const WAIT_MS = Number(process.env.WAIT_MS ?? 1000)     // silent wait between Stop and next Run
+const NUM_CYCLES = Number(process.env.NUM_CYCLES ?? 10) // # of Run→Stop→wait cycles
+const TAIL_MS = Number(process.env.TAIL_MS ?? 5000)     // free playback after final Run
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'cycle'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  const stopBtnLocator = page.locator('button').filter({ hasText: 'Stop' }).first()
+
+  // Prime: first Run to warm engine, then Stop, before Rec armed
+  console.log('[run-stop] priming Run to warm engine...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+  await stopBtnLocator.click()
+  await page.waitForTimeout(500)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[run-stop] Rec started — ${NUM_CYCLES}× (Run+${PLAY_MS}ms / Stop+${WAIT_MS}ms) then final Run+${TAIL_MS}ms`)
+
+  for (let i = 1; i <= NUM_CYCLES; i++) {
+    console.log(`[run-stop] cycle ${i}/${NUM_CYCLES}: Run...`)
+    await runBtn.click()
+    await page.waitForTimeout(PLAY_MS)
+    await stopBtnLocator.click()
+    await page.waitForTimeout(WAIT_MS)
+  }
+  console.log(`[run-stop] cycles done — final Run + ${TAIL_MS}ms observation`)
+  await runBtn.click()
+  await page.waitForTimeout(TAIL_MS)
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const visibleButtons = await page.locator('button').allTextContents()
+  console.log('[run-stop] toolbar buttons visible:', visibleButtons.filter(t => t.length > 0 && t.length < 30).join(' | '))
+  const saveBtn = page.locator('button').filter({ hasText: /^\s*Save\s*$/ }).first()
+  if (await saveBtn.count() > 0) {
+    console.log('[run-stop] clicking Save...')
+    await saveBtn.click()
+  } else {
+    console.log('[run-stop] no Save button — clicking Rec to toggle...')
+    await recBtn.click()
+  }
+  await page.waitForTimeout(3000)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  // Boundary scan resolution matters here per feedback_boundary_scan_distinguishes_bug_classes
+  // (chunk-RMS would smear rapid swaps together — 200ms resolution separates them).
+  // Cycle boundary every (PLAY_MS + WAIT_MS). At cadence 1s/1s, that's 2s.
+  const cycleSec = (PLAY_MS + WAIT_MS) / 1000
+  console.log(`\n[run-stop] boundary scan @ ${cycleSec}s cadence (cycle starts)...\n`)
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-boundaries.py'),
+    wavPath,
+    String(cycleSec),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Stacked on PR #292. Two complementary preloading strategies:

**A — Sync FX pre-creation extended to first Run** — same helper PR #292 introduced for hot-swap now fires on the first eval too. Removes the FX-vs-sample sub-frame race on first Play (was masked because users tolerate first-Run latency, but still produced occasional dry-clap iterations).

**B — Preload all FX synthdef binaries during engine init** — \`SuperSonicBridge.preloadFxSynthDefs(ALL_FX_NAMES)\` is called fire-and-forget after bridge init, fetching every \`sonic-pi-fx_*.scsyndef\` binary in parallel. By the time the user clicks Run, the synthdef cache is warm — removes 50-200ms-per-first-use fetch latency.

## Verification (4 consecutive captures)

| Metric | User Firefox (pre-fix bug) | Preload (post-fix) |
|--------|------|------|
| Snare onsets/chunk | 30→37→30→**12** (collapse) | 57→48→52→57 (stable) |
| Snare RMS pattern | 38.7 → 73.8 (+91% growth) | 45 → 47 (flat ±7%) |
| Cross-capture stability | wide variance | all 4 within 5% |
| Cymbal_hi baseline | n/a | 1.83 stable (was 0.81 in 1/4 sync-fix-only) |

The clap rhythm is preserved across all hot-swaps (57 distinct onsets per chunk vs the user-Firefox bug's collapse to 12). Snare-band RMS is flat. The remaining ~9% arp_mid dip on Run#3 is deterministic content-shuffle variance, not the bug.

## Architecture note

\`src/engine/FxNames.ts\` is now the single source of truth for FX names — used by both the DSL \`fx_names\` introspector AND the bridge preloader. Prevents drift.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run\` — 929/929 pass
- [x] WAV reproducer × 4 captures — clap rhythm stable, no onset collapse
- [ ] Manual: refresh browser, load DJ_Dave sketch, hit Run + Update 3× — clap should remain rhythmic throughout, FX consistent

## Stack

PR #289 → PR #291 → PR #292 → **this PR**. Will rebase the stack onto main as #289 then #291 then #292 merge.

## Why this is the closing move on #290

| Layer | Fix |
|-------|------|
| Stale setTimeouts corrupting bus pool | PR #291 — killTimer cancellation |
| Hot-swap FX-vs-sample race | PR #292 — sync FX pre-creation on hot-swap |
| First-Run FX-vs-sample race | **this PR (A)** — same helper extended |
| First-use FX synthdef fetch latency | **this PR (B)** — bulk preload at init |