### PR TITLE
Hot-swap FX fix stack (SP82/SP83/SP84) — closes #290

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ playwright-report/
 
 # Browser diagnostic captures (internal observation tool)
 .captures/
+tmp/
 
 # Personal learnings (not part of the project)
 LEARNINGS.md

--- a/src/engine/FxNames.ts
+++ b/src/engine/FxNames.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonical list of FX synthdef names available in Sonic Pi Web.
+ *
+ * Sourced from synthinfo.rb FX classes (desktop Sonic Pi). Each entry maps to
+ * a `sonic-pi-fx_<name>.scsyndef` binary on the SuperSonic CDN. Loaded on demand
+ * via `SuperSonicBridge.ensureSynthDefLoaded`, or in bulk via
+ * `SuperSonicBridge.preloadFxSynthDefs` (called from engine.init for warm start).
+ *
+ * Single source of truth — consumed by the DSL `fx_names` introspector
+ * (`SonicPiEngine.ts:fx_names_fn`) AND the bridge preloader. Adding an FX here
+ * makes it both queryable AND eagerly loaded on engine init.
+ */
+export const ALL_FX_NAMES: readonly string[] = [
+  'reverb','echo','delay','distortion','slicer','wobble','ixi_techno',
+  'compressor','rlpf','rhpf','hpf','lpf','normaliser','pan','band_eq',
+  'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
+  'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
+  'ping_pong','panslicer',
+  // Filter variants — from synthinfo.rb FX classes
+  'bpf','rbpf','nbpf','nrbpf','nlpf','nrlpf','nhpf','nrhpf','eq',
+] as const

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -5,6 +5,7 @@ import { queryLoopProgram, type QueryEvent } from './interpreters/QueryInterpret
 import { SuperSonicBridge, type SuperSonicBridgeOptions } from './SuperSonicBridge'
 import { Recorder } from './Recorder'
 import { normalizeFxParams } from './SoundLayer'
+import { ALL_FX_NAMES } from './FxNames'
 import { DSL_NAMES } from './DslNames'
 import { createIsolatedExecutor, validateCode, type ScopeHandle } from './Sandbox'
 import { autoTranspileDetailed } from './TreeSitterTranspiler'
@@ -214,6 +215,12 @@ export class SonicPiEngine {
         this.bridge!.setOscTraceHandler((msg) => {
           if (this.printHandler) this.printHandler(msg)
         })
+        // Preload every FX synthdef binary now so the first `with_fx` doesn't
+        // pay fetch+/d_recv latency at /s_new time. Fire-and-forget — failures
+        // (CDN miss for an individual FX) surface lazily per SP5 when that FX
+        // is actually used. Awaiting would gate first audio on ~40 fetches,
+        // which we'd rather absorb in the background after bridge init.
+        this.bridge!.preloadFxSynthDefs(ALL_FX_NAMES).catch(() => { /* lazy retry */ })
       })
       .catch((err) => {
         console.warn('[SonicPi] SuperSonic init failed, running without audio:', err)
@@ -488,15 +495,9 @@ export class SonicPiEngine {
         // Note: sound_in, sound_in_stereo, live_audio require Web Audio mic permission
         //   plumbing which is not yet implemented. Track separately.
       ]
-      const fx_names_fn = () => [
-        'reverb','echo','delay','distortion','slicer','wobble','ixi_techno',
-        'compressor','rlpf','rhpf','hpf','lpf','normaliser','pan','band_eq',
-        'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
-        'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
-        'ping_pong','panslicer',
-        // Filter variants — from synthinfo.rb FX classes
-        'bpf','rbpf','nbpf','nrbpf','nlpf','nrlpf','nhpf','nrhpf','eq',
-      ]
+      // Sourced from FxNames.ts — same array used by bridge.preloadFxSynthDefs
+      // during engine.init so the introspector and the preloader can't drift.
+      const fx_names_fn = () => [...ALL_FX_NAMES]
 
       // load_sample — no-op (samples auto-load on first use via CDN)
       const load_sample_fn = (_name: string) => { /* auto-loaded on first use */ }
@@ -1461,54 +1462,9 @@ export class SonicPiEngine {
           this.reusableFx.clear()
         }
 
-        // Synchronous FX pre-creation — fixes issue #290 residual.
-        //
-        // Why this exists: the lazy creation at line 612 runs INSIDE the
-        // loop's first post-swap iteration, AT virtualTime + schedAheadTime.
-        // The same iteration then queues sample /s_new with the same timetag.
-        // scsynth receives both bundles and processes them in the order they
-        // arrive at its scheduler — a sub-frame race. When the race loses,
-        // sample /s_new fires onto a bus whose FX node hasn't been created
-        // yet → silent / dry clap for 1-2s post-Update (the user-reported
-        // "track plays wrongly" residual that survived the killTimer fix).
-        //
-        // Why this fixes it: FX nodes are CREATED HERE with audioTime=0
-        // (immediate). scsynth processes them now, BEFORE the loops resume
-        // and start queuing future-timed samples. By the time the first
-        // post-swap iteration fires, persistentFx is already populated, the
-        // lazy-creation block at line 612 is skipped via `persistentFx.has`,
-        // and task.outBus is set to the live FX bus before any sample plays.
-        //
-        // Why only FX (not samples): FX are bus receivers — they must exist
-        // before audio flows through them. Samples are continuous per-
-        // iteration events scheduled via virtual time; pre-creating them
-        // would block real-time scheduling. FX setup is one-time per scope.
-        if (this.bridge && isReEvaluate) {
-          for (const [scopeId, fxChain] of this.fxScopeChains) {
-            if (!fxChain || fxChain.length === 0) continue
-            if (this.persistentFx.has(scopeId)) continue
-            let currentOutBus = 0  // FX-wrapped loops route to master through chain
-            const buses: number[] = []
-            const groups: number[] = []
-            for (const fx of fxChain) {
-              const bus = this.bridge.allocateBus()
-              const groupId = this.bridge.createFxGroup()
-              const fxWarn = this.printHandler
-                ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
-                : undefined
-              const fxOpts = normalizeFxParams(fx.name, fx.opts, defaultBpm, fxWarn)
-              // audioTime=0 → scsynth processes immediately (before any
-              // future-timed sample bundles can race past). Awaiting the
-              // promise ensures synthdef load completes before the next FX.
-              await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
-              this.bridge.flushMessages(0)
-              buses.push(bus)
-              groups.push(groupId)
-              currentOutBus = bus
-            }
-            this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
-          }
-        }
+        // Pre-create persistent FX synchronously before reEvaluate. See
+        // preCreatePersistentFx() for the full rationale (issue #290).
+        await this.preCreatePersistentFx(defaultBpm)
 
         // Commit: hot-swap same-named, stop removed, start new
         scheduler.reEvaluate(pendingLoops, { bpm: defaultBpm, synth: defaultSynth })
@@ -1528,10 +1484,76 @@ export class SonicPiEngine {
         scheduler.resumeTick()
       }
 
+      // First-eval path: hot-swap block above didn't run, so pre-create FX
+      // now. Without this, the very first Run hits the same FX-vs-sample
+      // sub-frame race that PR #292 fixed for hot-swap (issue #290) — the
+      // first 1-2 iterations of FX-wrapped loops can play dry while scsynth
+      // is still processing the lazy /s_new for the FX nodes. The helper is
+      // idempotent via `persistentFx.has(scopeId)`, so a no-op if the
+      // hot-swap branch above already populated it.
+      if (!isReEvaluate) {
+        await this.preCreatePersistentFx(defaultBpm)
+      }
+
       return {}
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       return { error }
+    }
+  }
+
+  /**
+   * Synchronously pre-create persistent FX nodes for every top-level scope
+   * before any loop iteration fires audio through them. Called from BOTH the
+   * first-eval path AND the hot-swap path (after freeAllNodes + map clear).
+   *
+   * Why this exists: the lazy creation at line 612 runs INSIDE the loop's
+   * first iteration, AT virtualTime + schedAheadTime. The same iteration
+   * then queues sample /s_new with the same timetag. scsynth receives both
+   * bundles and processes them in the order they arrive at its scheduler — a
+   * sub-frame race. When the race loses, sample /s_new fires onto a bus whose
+   * FX node hasn't been created yet → silent / dry clap (user-reported
+   * "music plays wrongly" residual on Update; the same race exists on first
+   * Run but is masked because the user just clicked Play).
+   *
+   * Why this fixes it: FX nodes are CREATED HERE with audioTime=0 (immediate).
+   * scsynth processes them now, BEFORE any future-timed sample bundle can
+   * land. By the time loops start iterating, persistentFx is populated, the
+   * lazy-creation block at line 612 is skipped via .has(), and task.outBus
+   * is set to the live FX bus before any sample plays.
+   *
+   * Why only FX (not samples): FX are bus receivers — they must exist before
+   * audio flows through them. Samples are continuous per-iteration events
+   * scheduled via virtual time; pre-creating them would block real-time
+   * scheduling. FX setup is one-time per scope.
+   *
+   * Idempotent: scopes already in `persistentFx` are skipped.
+   */
+  private async preCreatePersistentFx(bpm: number): Promise<void> {
+    if (!this.bridge) return
+    for (const [scopeId, fxChain] of this.fxScopeChains) {
+      if (!fxChain || fxChain.length === 0) continue
+      if (this.persistentFx.has(scopeId)) continue
+      let currentOutBus = 0  // FX-wrapped loops route to master through chain
+      const buses: number[] = []
+      const groups: number[] = []
+      for (const fx of fxChain) {
+        const bus = this.bridge.allocateBus()
+        const groupId = this.bridge.createFxGroup()
+        const fxWarn = this.printHandler
+          ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
+          : undefined
+        const fxOpts = normalizeFxParams(fx.name, fx.opts, bpm, fxWarn)
+        // audioTime=0 → scsynth processes immediately (before any
+        // future-timed sample bundles can race past). Awaiting the
+        // promise ensures synthdef load completes before the next FX.
+        await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
+        this.bridge.flushMessages(0)
+        buses.push(bus)
+        groups.push(groupId)
+        currentOutBus = bus
+      }
+      this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
     }
   }
 

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1461,6 +1461,55 @@ export class SonicPiEngine {
           this.reusableFx.clear()
         }
 
+        // Synchronous FX pre-creation — fixes issue #290 residual.
+        //
+        // Why this exists: the lazy creation at line 612 runs INSIDE the
+        // loop's first post-swap iteration, AT virtualTime + schedAheadTime.
+        // The same iteration then queues sample /s_new with the same timetag.
+        // scsynth receives both bundles and processes them in the order they
+        // arrive at its scheduler — a sub-frame race. When the race loses,
+        // sample /s_new fires onto a bus whose FX node hasn't been created
+        // yet → silent / dry clap for 1-2s post-Update (the user-reported
+        // "track plays wrongly" residual that survived the killTimer fix).
+        //
+        // Why this fixes it: FX nodes are CREATED HERE with audioTime=0
+        // (immediate). scsynth processes them now, BEFORE the loops resume
+        // and start queuing future-timed samples. By the time the first
+        // post-swap iteration fires, persistentFx is already populated, the
+        // lazy-creation block at line 612 is skipped via `persistentFx.has`,
+        // and task.outBus is set to the live FX bus before any sample plays.
+        //
+        // Why only FX (not samples): FX are bus receivers — they must exist
+        // before audio flows through them. Samples are continuous per-
+        // iteration events scheduled via virtual time; pre-creating them
+        // would block real-time scheduling. FX setup is one-time per scope.
+        if (this.bridge && isReEvaluate) {
+          for (const [scopeId, fxChain] of this.fxScopeChains) {
+            if (!fxChain || fxChain.length === 0) continue
+            if (this.persistentFx.has(scopeId)) continue
+            let currentOutBus = 0  // FX-wrapped loops route to master through chain
+            const buses: number[] = []
+            const groups: number[] = []
+            for (const fx of fxChain) {
+              const bus = this.bridge.allocateBus()
+              const groupId = this.bridge.createFxGroup()
+              const fxWarn = this.printHandler
+                ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
+                : undefined
+              const fxOpts = normalizeFxParams(fx.name, fx.opts, defaultBpm, fxWarn)
+              // audioTime=0 → scsynth processes immediately (before any
+              // future-timed sample bundles can race past). Awaiting the
+              // promise ensures synthdef load completes before the next FX.
+              await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
+              this.bridge.flushMessages(0)
+              buses.push(bus)
+              groups.push(groupId)
+              currentOutBus = bus
+            }
+            this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
+          }
+        }
+
         // Commit: hot-swap same-named, stop removed, start new
         scheduler.reEvaluate(pendingLoops, { bpm: defaultBpm, synth: defaultSynth })
 

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -84,8 +84,14 @@ export class SonicPiEngine {
   private schedAheadTime: number
   /** Maps DSL nodeRef → SuperSonic nodeId for control messages */
   private nodeRefMap = new Map<number, number>()
-  /** Reusable inner FX nodes — persists across loop iterations. See issue #70. */
-  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number }>()
+  /** Reusable inner FX nodes — persists across loop iterations. See issue #70.
+   *  `killTimer` is the pending `setTimeout` handle that frees this FX 1s after
+   *  its last iteration if no follow-up iteration cancels it. On hot-swap /
+   *  stop we MUST clearTimeout these before dropping the map entries, otherwise
+   *  the stale timer fires later and calls freeBus/freeGroup on what are by
+   *  then NEW live FX resources — corrupting the bus pool and silently killing
+   *  groups (issue #290). */
+  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: ReturnType<typeof setTimeout> }>()
   /** Pending volume to apply when bridge initializes */
   private pendingVolume: number | null = null
   /** Stored builder functions for capture/query path */
@@ -1440,6 +1446,18 @@ export class SonicPiEngine {
           // /s_new to dead buses for several seconds while waiting for
           // their next iteration to lazy-create FX.
           this.persistentFx.clear()
+          // Cancel pending FX-kill setTimeouts BEFORE dropping the map.
+          // Each per-iteration with_fx schedules a 1s killTimer (AudioInterpreter
+          // ~line 286/325) that frees its bus + group. /g_freeAll already killed
+          // the scsynth-side nodes, so the kill is redundant, but its freeBus()
+          // would push a stale bus index back into freeBuses[] and the freeGroup
+          // would /n_free a group that may now belong to a freshly-allocated FX.
+          // Without this clearTimeout, the stale timer fires ~1s post-hot-swap
+          // and corrupts pool state, producing audible "snare band growth" and
+          // reproducible track drops (issue #290).
+          for (const state of this.reusableFx.values()) {
+            if (state.killTimer) clearTimeout(state.killTimer)
+          }
           this.reusableFx.clear()
         }
 
@@ -1521,6 +1539,12 @@ export class SonicPiEngine {
     this.definedFns.clear()
     this.defonceCache.clear()
     this.persistentFx.clear()
+    // Same as hot-swap path: cancel pending FX-kill setTimeouts BEFORE dropping
+    // the map. Without this, a Stop followed by a quick re-Run would have stale
+    // timers fire ~1s later on freshly-allocated FX (issue #290).
+    for (const state of this.reusableFx.values()) {
+      if (state.killTimer) clearTimeout(state.killTimer)
+    }
     this.reusableFx.clear()
     this.loopFxScope.clear()
     this.fxScopeChains.clear()

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -535,6 +535,31 @@ export class SuperSonicBridge {
     this.messageQueue.length = 0
   }
 
+  /**
+   * Eagerly load multiple FX synthdef binaries in parallel. Called from
+   * engine.init() to warm the synthdef cache before any FX is used —
+   * eliminates the first-use fetch latency that would otherwise add ~50-200ms
+   * to the first /s_new for a previously-unseen FX (SP5 trap). Idempotent and
+   * safe to call multiple times; ensureSynthDefLoaded de-dupes via
+   * loadedSynthDefs + pendingSynthDefLoads.
+   *
+   * Pass FX names WITHOUT the `sonic-pi-fx_` prefix (e.g. 'reverb', 'echo') —
+   * the prefix is added internally to match ensureSynthDefLoaded's contract.
+   *
+   * Failures are swallowed (per-name) so one missing synthdef doesn't block
+   * the rest. Missing FX surface at /s_new dispatch time as before (SP5).
+   */
+  async preloadFxSynthDefs(names: readonly string[]): Promise<void> {
+    if (!this.sonic) return
+    await Promise.all(
+      names.map(n =>
+        this.ensureSynthDefLoaded(`sonic-pi-fx_${n}`).catch(() => {
+          /* CDN miss for this FX — surface at /s_new time per SP5 */
+        })
+      )
+    )
+  }
+
   private ensureSynthDefLoaded(name: string): Promise<void> {
     const fullName = name.startsWith('sonic-pi-') ? name : `sonic-pi-${name}`
     if (this.loadedSynthDefs.has(fullName)) return Promise.resolve()

--- a/tools/analyze-rerun-boundaries.py
+++ b/tools/analyze-rerun-boundaries.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Slice the rerun WAV into fine windows around hot-swap boundaries and look
+for short dropouts that 4s averaging hides.
+
+Reports:
+  - RMS per 100ms window for the full duration (timeline)
+  - Per-band RMS at 200ms resolution for ±1s around each boundary (t=4,8,12)
+  - Any window where RMS falls below 30% of the surrounding median
+
+Usage:
+  python3 analyze-rerun-boundaries.py <wav> [chunk_seconds=4]
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp":       (800, 2000),
+    "cymb_hi":   (2000, 6000),
+    "cymb_vhi":  (6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr, n, ch, sw = w.getframerate(), w.getnframes(), w.getnchannels(), w.getsampwidth()
+        raw = w.readframes(n)
+    dt = {1: np.uint8, 2: np.int16, 4: np.int32}[sw]
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:  a /= 32768.0
+    elif dt == np.int32: a /= 2147483648.0
+    elif dt == np.uint8: a = (a - 128.0) / 128.0
+    if ch == 2: a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def band_rms(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    if len(x) < 32: return 0.0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    y = np.fft.irfft(spec, n=len(x))
+    return float(np.sqrt(np.mean(y ** 2)))
+
+def main():
+    wav = sys.argv[1]
+    chunk_s = float(sys.argv[2]) if len(sys.argv) > 2 else 4.0
+    a, sr = load_wav(wav)
+    dur = len(a) / sr
+    print(f"loaded {wav}: {dur:.2f}s @ {sr}Hz")
+
+    # 1. Timeline of overall RMS at 100ms resolution
+    win = int(0.100 * sr)
+    n_win = len(a) // win
+    rms_timeline = np.array([
+        np.sqrt(np.mean(a[i*win:(i+1)*win] ** 2)) for i in range(n_win)
+    ])
+    med = float(np.median(rms_timeline))
+    low = rms_timeline < 0.3 * med
+    low_idx = np.where(low)[0]
+    print(f"\n[timeline] median RMS = {med:.4f}; low-RMS windows (< 30% median):")
+    if low_idx.size == 0:
+        print("  none")
+    else:
+        # cluster into runs
+        clusters = []
+        prev = -10
+        cur = []
+        for i in low_idx:
+            if i - prev <= 2:
+                cur.append(i)
+            else:
+                if cur: clusters.append(cur)
+                cur = [i]
+            prev = i
+        if cur: clusters.append(cur)
+        for c in clusters[:30]:
+            t0, t1 = c[0] * 0.1, (c[-1] + 1) * 0.1
+            print(f"  {t0:6.2f}-{t1:6.2f}s  (RMS dips to {rms_timeline[c].min():.4f})")
+
+    # 2. Per-band RMS at 200ms resolution around boundaries
+    boundaries = [chunk_s * i for i in range(1, int(dur // chunk_s) + 1)]
+    bwin = int(0.200 * sr)
+    pre_post = 1.0  # +/- 1s around each boundary
+    n_steps = int(pre_post * 2 / 0.2)
+    print(f"\n[boundary scan] ±{pre_post}s around each Run-click at 200ms resolution:")
+    for b in boundaries:
+        if b > dur - pre_post: continue
+        print(f"\n  boundary t={b:.2f}s (hot-swap click)")
+        hdr = f"    {'t(s)':>6} " + " ".join(f"{k:>8}" for k in BANDS)
+        print(hdr)
+        for s in range(n_steps + 1):
+            t0 = b - pre_post + s * 0.2
+            i0 = int(t0 * sr)
+            if i0 < 0 or i0 + bwin > len(a): continue
+            seg = a[i0:i0 + bwin]
+            row = f"    {t0:>6.2f} "
+            for name, (lo, hi) in BANDS.items():
+                row += f" {band_rms(seg, sr, lo, hi):8.5f}"
+            mark = "  <-- click" if abs(t0 - b) < 0.1 else ""
+            print(row + mark)
+
+if __name__ == "__main__":
+    main()

--- a/tools/analyze-rerun-chunks.py
+++ b/tools/analyze-rerun-chunks.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Split a continuous WAV into N equal chunks and report per-chunk band energy
+and onset counts for each frequency band that maps to a DJ_Dave instrument:
+
+  kick     : 40-120 Hz       (bd_tek body)
+  snare    : 200-800 Hz      (drum_snare_hard fundamentals)
+  cymbal_hi: 2000-6000 Hz    (drum_cymbal_closed shimmer)
+  cymbal_vhi: 6000-12000 Hz  (cymbal/crash high)
+  synthbass: 60-200 Hz       (tech_saws low)
+  arp_mid  : 800-2000 Hz     (beep melody)
+
+A track that goes silent in chunk N shows as a band-energy drop of >40% vs
+chunk 1 in that band. Onset count also drops to 0.
+
+Usage:
+  python3 analyze-rerun-chunks.py <wav> <chunk_seconds> <num_chunks>
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp_mid":   (800, 2000),
+    "cymbal_hi": (2000, 6000),
+    "cymbal_vhi":(6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr = w.getframerate()
+        n = w.getnframes()
+        ch = w.getnchannels()
+        sw = w.getsampwidth()
+        raw = w.readframes(n)
+    if sw == 4:
+        dt = np.int32
+    elif sw == 2:
+        dt = np.int16
+    else:
+        dt = np.uint8
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:
+        a /= 32768.0
+    elif dt == np.int32:
+        a /= 2147483648.0
+    elif dt == np.uint8:
+        a = (a - 128.0) / 128.0
+    if ch == 2:
+        a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def band_energy(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    n = len(x)
+    if n == 0:
+        return 0.0
+    # rfft
+    spec = np.fft.rfft(x * np.hanning(n))
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    mask = (freqs >= lo) & (freqs < hi)
+    if not mask.any():
+        return 0.0
+    mag = np.abs(spec[mask])
+    return float(np.sqrt((mag ** 2).mean()))
+
+def onset_count(x: np.ndarray, sr: int, lo: float, hi: float, thr_mul: float = 1.6) -> int:
+    """Simple onset detector inside a band: bandpass + envelope + peak-pick."""
+    # bandpass via fft
+    n = len(x)
+    if n == 0:
+        return 0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    bp = np.fft.irfft(spec, n=n)
+    # envelope
+    win = max(1, int(0.005 * sr))
+    env = np.abs(bp)
+    env = np.convolve(env, np.ones(win) / win, mode="same")
+    # peaks above thr_mul × median
+    thr = thr_mul * float(np.median(env) + 1e-9)
+    # require local maximum + spacing of 30ms
+    spacing = max(1, int(0.030 * sr))
+    peaks = []
+    last = -spacing
+    for i in range(1, len(env) - 1):
+        if env[i] > thr and env[i] > env[i - 1] and env[i] >= env[i + 1] and (i - last) >= spacing:
+            peaks.append(i)
+            last = i
+    return len(peaks)
+
+def main():
+    wav_path, chunk_s, n_chunks = sys.argv[1], float(sys.argv[2]), int(sys.argv[3])
+    a, sr = load_wav(wav_path)
+    chunk_n = int(chunk_s * sr)
+    total_frames = a.size
+    print(f"loaded {wav_path}: {total_frames / sr:.2f}s @ {sr}Hz mono")
+    print(f"requested {n_chunks} chunks of {chunk_s}s = {n_chunks * chunk_n} frames")
+    print()
+
+    # Each chunk starts at the Rec start (chunk 0) and steps by chunk_n.
+    # If Rec includes pre-roll, chunk 0 may have less material — that's fine,
+    # the user only cares about relative loss across chunks.
+    rows = []
+    for i in range(n_chunks):
+        start = i * chunk_n
+        end = min(start + chunk_n, total_frames)
+        if end - start < sr // 2:
+            print(f"chunk {i}: too short ({(end - start) / sr:.2f}s) — skipping")
+            continue
+        seg = a[start:end]
+        row = {"chunk": i, "label": "Run#1" if i == 0 else f"Run#{i + 1}(hot-swap)"}
+        row["rms"] = float(np.sqrt(np.mean(seg ** 2)))
+        row["peak"] = float(np.max(np.abs(seg)))
+        for name, (lo, hi) in BANDS.items():
+            row[f"e_{name}"] = band_energy(seg, sr, lo, hi)
+            row[f"n_{name}"] = onset_count(seg, sr, lo, hi)
+        rows.append(row)
+
+    # Print table
+    if not rows:
+        print("no chunks analysed")
+        return 1
+    base = rows[0]
+    hdr = f"{'chunk':6} {'label':22} {'RMS':>7} {'peak':>6} | " + " | ".join(
+        f"{k:>11}" for k in BANDS
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows:
+        cells = [f"{r['chunk']:<6}", f"{r['label']:<22}", f"{r['rms']:7.4f}", f"{r['peak']:6.3f}", "|"]
+        for name in BANDS:
+            e = r[f"e_{name}"]
+            n = r[f"n_{name}"]
+            be = base[f"e_{name}"]
+            ratio = (e / be) if be > 1e-9 else 0.0
+            mark = ""
+            if r["chunk"] > 0:
+                if be > 1e-6 and ratio < 0.4:
+                    mark = " DROP"
+                elif be > 1e-6 and ratio > 2.0:
+                    mark = " SPIKE"
+            cells.append(f"{e:5.3f}({n:>2}){mark:>6}")
+        print(" ".join(cells))
+
+    # Verdict
+    print()
+    drops = []
+    for r in rows[1:]:
+        for name in BANDS:
+            be = base[f"e_{name}"]
+            e = r[f"e_{name}"]
+            if be > 1e-6 and (e / be) < 0.4:
+                drops.append((r["chunk"], r["label"], name, e / be))
+    if drops:
+        print("VERDICT: TRACK LOSS DETECTED on hot-swap")
+        for c, lab, n, ratio in drops:
+            print(f"  chunk {c} ({lab}): band {n} fell to {ratio:.0%} of baseline")
+        return 1
+    print("VERDICT: no >60% band drop across chunks — tracks appear to survive hot-swap")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/compare-two-runs-spectral.py
+++ b/tools/compare-two-runs-spectral.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Detailed spectral comparison of two WAVs (4 chunks each) — for diagnosing
+the difference between cluster A (captures 1,2) and cluster B (captures 3,4)
+of the rerun reproducer.
+
+Reports per chunk:
+  - Spectral centroid (Hz) — brightness
+  - Spectral flatness — tonal vs noise-like (0=pure tone, 1=white noise)
+  - Spectral rolloff (95%) — frequency below which 95% of energy lives
+  - RMS, peak, crest factor (peak/RMS, indicates transients vs sustained)
+  - Per-band onset count + peak time within chunk
+  - Loudness contour (RMS per 100ms window)
+
+Saves a PNG with stacked spectrograms + per-band RMS timelines side-by-side
+for visual diff.
+
+Usage:
+  python3 compare-two-runs-spectral.py <wavA> <wavB> [chunk_seconds=4]
+"""
+from __future__ import annotations
+import sys
+import numpy as np
+import wave
+import os
+
+BANDS = {
+    "kick":      (40, 120),
+    "synthbass": (60, 200),
+    "snare":     (200, 800),
+    "arp":       (800, 2000),
+    "cymb_hi":   (2000, 6000),
+    "cymb_vhi":  (6000, 12000),
+}
+
+def load_wav(path: str) -> tuple[np.ndarray, int]:
+    with wave.open(path, "rb") as w:
+        sr, n, ch, sw = w.getframerate(), w.getnframes(), w.getnchannels(), w.getsampwidth()
+        raw = w.readframes(n)
+    dt = {1: np.uint8, 2: np.int16, 4: np.int32}[sw]
+    a = np.frombuffer(raw, dtype=dt).astype(np.float32)
+    if dt == np.int16:  a /= 32768.0
+    elif dt == np.int32: a /= 2147483648.0
+    elif dt == np.uint8: a = (a - 128.0) / 128.0
+    if ch == 2: a = a.reshape(-1, 2).mean(axis=1)
+    return a, sr
+
+def spectral_features(x: np.ndarray, sr: int) -> dict:
+    if len(x) < 64:
+        return {"centroid": 0.0, "flatness": 0.0, "rolloff": 0.0}
+    win = np.hanning(len(x))
+    spec = np.abs(np.fft.rfft(x * win))
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    s = spec + 1e-12
+    centroid = float((freqs * s).sum() / s.sum())
+    # spectral flatness = geo_mean / arith_mean (in power)
+    p = s ** 2
+    flatness = float(np.exp(np.log(p + 1e-20).mean()) / (p.mean() + 1e-20))
+    cumsum = np.cumsum(s)
+    total = cumsum[-1]
+    rolloff_idx = np.searchsorted(cumsum, 0.95 * total)
+    rolloff = float(freqs[min(rolloff_idx, len(freqs) - 1)])
+    return {"centroid": centroid, "flatness": flatness, "rolloff": rolloff}
+
+def band_rms(x: np.ndarray, sr: int, lo: float, hi: float) -> float:
+    if len(x) < 32: return 0.0
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(len(x), 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    y = np.fft.irfft(spec, n=len(x))
+    return float(np.sqrt(np.mean(y ** 2)))
+
+def onset_times(x: np.ndarray, sr: int, lo: float, hi: float, thr_mul: float = 1.6) -> list[float]:
+    n = len(x)
+    if n == 0: return []
+    spec = np.fft.rfft(x)
+    freqs = np.fft.rfftfreq(n, 1 / sr)
+    spec[(freqs < lo) | (freqs >= hi)] = 0
+    bp = np.fft.irfft(spec, n=n)
+    win = max(1, int(0.005 * sr))
+    env = np.abs(bp)
+    env = np.convolve(env, np.ones(win) / win, mode="same")
+    thr = thr_mul * float(np.median(env) + 1e-9)
+    spacing = max(1, int(0.030 * sr))
+    peaks = []
+    last = -spacing
+    for i in range(1, len(env) - 1):
+        if env[i] > thr and env[i] > env[i - 1] and env[i] >= env[i + 1] and (i - last) >= spacing:
+            peaks.append(i / sr)
+            last = i
+    return peaks
+
+def analyze(path: str, chunk_s: float, n_chunks: int) -> dict:
+    a, sr = load_wav(path)
+    chunk_n = int(chunk_s * sr)
+    out = {"path": path, "sr": sr, "duration": len(a) / sr, "chunks": []}
+    for i in range(n_chunks):
+        start = i * chunk_n
+        end = min(start + chunk_n, len(a))
+        if end - start < sr // 2: continue
+        seg = a[start:end]
+        sf = spectral_features(seg, sr)
+        bands = {}
+        for name, (lo, hi) in BANDS.items():
+            bands[name] = {
+                "rms": band_rms(seg, sr, lo, hi),
+                "onsets": onset_times(seg, sr, lo, hi),
+            }
+        rms = float(np.sqrt(np.mean(seg ** 2)))
+        peak = float(np.max(np.abs(seg)))
+        # 100ms RMS contour for this chunk
+        win = int(0.100 * sr)
+        n_win = len(seg) // win
+        contour = [float(np.sqrt(np.mean(seg[k*win:(k+1)*win] ** 2))) for k in range(n_win)]
+        out["chunks"].append({
+            "idx": i,
+            "rms": rms,
+            "peak": peak,
+            "crest": peak / (rms + 1e-12),
+            "spectral": sf,
+            "bands": bands,
+            "contour_100ms": contour,
+        })
+    return out
+
+def fmt_onsets(times: list[float], chunk_start: float) -> str:
+    if not times: return "none"
+    if len(times) <= 4:
+        return ", ".join(f"{t:.2f}" for t in times)
+    return f"{len(times)} hits, first={times[0]:.2f}, last={times[-1]:.2f}, mean_iti={np.mean(np.diff(times)):.3f}s"
+
+def report(a: dict, b: dict, chunk_s: float):
+    print(f"A: {os.path.basename(a['path'])}  ({a['duration']:.2f}s @ {a['sr']}Hz)")
+    print(f"B: {os.path.basename(b['path'])}  ({b['duration']:.2f}s @ {b['sr']}Hz)")
+    print()
+    for chunk_idx in range(min(len(a["chunks"]), len(b["chunks"]))):
+        ca, cb = a["chunks"][chunk_idx], b["chunks"][chunk_idx]
+        label = "Run#1" if chunk_idx == 0 else f"Run#{chunk_idx+1}(hot-swap)"
+        chunk_start = chunk_idx * chunk_s
+        print(f"==== CHUNK {chunk_idx} ({label}) at t={chunk_start:.1f}-{chunk_start+chunk_s:.1f}s ====")
+        print(f"  GLOBAL          A                       B                       Δ(B-A)")
+        print(f"  RMS             {ca['rms']:.4f}                  {cb['rms']:.4f}                  {cb['rms']-ca['rms']:+.4f}")
+        print(f"  Peak            {ca['peak']:.3f}                   {cb['peak']:.3f}                   {cb['peak']-ca['peak']:+.3f}")
+        print(f"  Crest (peak/RMS){ca['crest']:5.2f}                   {cb['crest']:5.2f}                   {cb['crest']-ca['crest']:+5.2f}")
+        sa, sb = ca["spectral"], cb["spectral"]
+        print(f"  Centroid (Hz)   {sa['centroid']:6.0f}                  {sb['centroid']:6.0f}                  {sb['centroid']-sa['centroid']:+6.0f}")
+        print(f"  Flatness        {sa['flatness']:.4f}                  {sb['flatness']:.4f}                  {sb['flatness']-sa['flatness']:+.4f}")
+        print(f"  Rolloff95 (Hz)  {sa['rolloff']:6.0f}                  {sb['rolloff']:6.0f}                  {sb['rolloff']-sa['rolloff']:+6.0f}")
+        print(f"\n  PER-BAND        A: RMS (n_onsets)       B: RMS (n_onsets)       Δ_rms     Δ_onsets")
+        for name in BANDS:
+            ba, bb = ca["bands"][name], cb["bands"][name]
+            d_rms = bb["rms"] - ba["rms"]
+            d_n = len(bb["onsets"]) - len(ba["onsets"])
+            mark = ""
+            if abs(d_rms) > 0.01 and ba["rms"] > 1e-4:
+                pct = 100 * d_rms / ba["rms"]
+                mark = f"  ({pct:+.0f}%)"
+            print(f"  {name:11}     {ba['rms']:.5f} ({len(ba['onsets']):>3})        {bb['rms']:.5f} ({len(bb['onsets']):>3})        {d_rms:+.5f}{mark}   {d_n:+3d}")
+        print(f"\n  INTER-ONSET INTERVALS (snare band, in ms — clap rhythm signature):")
+        if ca["bands"]["snare"]["onsets"]:
+            iti_a = np.diff(ca["bands"]["snare"]["onsets"]) * 1000
+            print(f"    A: median={np.median(iti_a):.0f}ms, std={iti_a.std():.0f}ms, n={len(iti_a)+1} hits")
+        if cb["bands"]["snare"]["onsets"]:
+            iti_b = np.diff(cb["bands"]["snare"]["onsets"]) * 1000
+            print(f"    B: median={np.median(iti_b):.0f}ms, std={iti_b.std():.0f}ms, n={len(iti_b)+1} hits")
+        print(f"\n  RMS CONTOUR (100ms windows, abs values):")
+        ca_ct = ca["contour_100ms"][:40]
+        cb_ct = cb["contour_100ms"][:40]
+        print("    A: " + " ".join(f"{v:.2f}" for v in ca_ct))
+        print("    B: " + " ".join(f"{v:.2f}" for v in cb_ct))
+        # contour diff in % of A
+        diff_pct = [(b_-a_)/(a_+1e-6)*100 for a_, b_ in zip(ca_ct, cb_ct)]
+        print("    Δ%: " + " ".join(f"{v:+.0f}" for v in diff_pct))
+        print()
+
+if __name__ == "__main__":
+    wa, wb = sys.argv[1], sys.argv[2]
+    cs = float(sys.argv[3]) if len(sys.argv) > 3 else 4.0
+    a = analyze(wa, cs, 4)
+    b = analyze(wb, cs, 4)
+    report(a, b, cs)

--- a/tools/test-rerun-minimal-clap.ts
+++ b/tools/test-rerun-minimal-clap.ts
@@ -1,0 +1,105 @@
+/**
+ * Minimal repro: just the clap loop wrapped in echo→reverb. Same Update cadence
+ * as the full DJ_Dave test. If snare-band still grows across re-runs, the bug
+ * is in FX teardown / state accumulation. If flat, it's multi-loop interaction.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-minimal-clap')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+const SNIPPET = `use_bpm 130
+live_loop :met1 do
+  sleep 1
+end
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else { origClick.call(this) }
+    }
+  })
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', err => console.error('[page error]', err.message))
+
+  await page.goto(BASE_URL); await page.waitForTimeout(2000)
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100); await editor.fill(SNIPPET); await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  console.log('[minimal-clap] Run #1')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) { console.log(`[minimal-clap] Run #${i + 1}`); await runBtn.click() }
+  }
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) await saveBtn.click(); else await recBtn.click()
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer(); const bytes = new Uint8Array(buf)
+    let s = ''; const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_minimal_clap.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[minimal-clap] wrote ${wavPath}`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  const py = spawnSync('python3', [resolve(__dirname, 'analyze-rerun-chunks.py'), wavPath, String(CHUNK_MS / 1000), String(NUM_CHUNKS)], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+main().catch(e => { console.error(e); process.exit(1) })

--- a/tools/test-rerun-no-arp.ts
+++ b/tools/test-rerun-no-arp.ts
@@ -1,0 +1,204 @@
+/**
+ * Reproducer variant: same as test-rerun-track-loss but WITHOUT the arp loop.
+ * Tests hypothesis #4: arp (:beep at G4-D5, 392-587Hz) overlaps snare band; its
+ * disappearance/return across hot-swaps drives the apparent snare-band growth.
+ *
+ * If snare band is flat across chunks with no arp present, hypothesis #4 is right
+ * — the "snare growth" is partially or fully an artifact of arp band-overlap.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-track-loss')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+// DJ_Dave sketch with the arp loop removed (and its with_fx wrappers).
+// Also removed: synthbass (also tonal, in snare band overlap zone).
+// Keeps: kick, clap (echo+reverb), hhc1 (reverb+panslicer), hhc2, crash.
+const SNIPPET = `# Coded by DJ_Dave (no arp, no synthbass)
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-no-arp] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  console.log('[rerun-no-arp] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-no-arp] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-no-arp] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_noarp.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-no-arp] wrote ${wavPath} (${wav.length} bytes)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-no-arp] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-rerun-rapid.ts
+++ b/tools/test-rerun-rapid.ts
@@ -1,0 +1,258 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-rapid')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const RAPID_MS = Number(process.env.RAPID_MS ?? 1000)   // ms between rapid hot-swaps
+const NUM_RAPID = Number(process.env.NUM_RAPID ?? 10)   // rapid re-runs after initial Run
+const TAIL_MS = Number(process.env.TAIL_MS ?? 5000)     // free playback after last swap
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'rapid'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-rapid] Rec started — ${NUM_RAPID}× hot-swap @ ${RAPID_MS}ms then ${TAIL_MS}ms tail`)
+
+  for (let i = 1; i <= NUM_RAPID; i++) {
+    await page.waitForTimeout(RAPID_MS)
+    console.log(`[rerun-rapid] click Run (#${i + 1}, rapid hot-swap)...`)
+    await runBtn.click()
+  }
+  console.log(`[rerun-rapid] last hot-swap done — letting it play ${TAIL_MS}ms`)
+  await page.waitForTimeout(TAIL_MS)
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  // Boundary scan resolution matters here per feedback_boundary_scan_distinguishes_bug_classes
+  // (chunk-RMS would smear rapid swaps together — 200ms resolution separates them).
+  console.log('\n[rerun-rapid] running boundary scan around click moments...\n')
+  // Click moments at t=2 (initial settle) + RAPID_MS, +2*RAPID_MS, +3*RAPID_MS — but
+  // Rec t=0 is at start of Rec, which is right after the first Run completed and we
+  // settled SETTLE_MS. So rapid clicks occur at relative t = RAPID_MS, 2*RAPID_MS, 3*RAPID_MS.
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-boundaries.py'),
+    wavPath,
+    String(RAPID_MS / 1000),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-rerun-six-stress.ts
+++ b/tools/test-rerun-six-stress.ts
@@ -1,0 +1,253 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-six-stress')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 7   // one initial + 6 re-runs (user-spec: 6× re-run @ 4s)
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'trial'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-track-loss] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-track-loss] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-track-loss] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-rerun-static-mix.ts
+++ b/tools/test-rerun-static-mix.ts
@@ -1,0 +1,196 @@
+/**
+ * Discriminator for the loopTicks-hypothesis on Run#3 arp_mid deficit.
+ *
+ * Same as test-rerun-track-loss.ts except arp's inner with_fx uses
+ * `mix: 0.5` (static) instead of `mix: (line 0.1, 1, steps: 128).mirror.tick`.
+ *
+ * If hypothesis is correct:
+ *   - With dynamic mix.tick (track-loss test): arp_mid drops on Run#3 by ~25%
+ *   - With static mix=0.5 (this test):         arp_mid stable across runs
+ *
+ * If hypothesis is wrong:
+ *   - Both tests show same Run#3 deficit
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-static-mix')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4
+const SETTLE_MS = 2000
+
+// Full DJ_Dave with ONLY ONE CHANGE: arp's inner with_fx mix is static 0.5
+// instead of `(line 0.1, 1, steps: 128).mirror.tick`.
+const SNIPPET = `use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: 0.5 do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else { origClick.call(this) }
+    }
+  })
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', err => console.error('[page error]', err.message))
+
+  await page.goto(BASE_URL); await page.waitForTimeout(2000)
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100); await editor.fill(SNIPPET); await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  console.log('[static-mix] Run #1')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) { console.log(`[static-mix] Run #${i + 1}`); await runBtn.click() }
+  }
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) await saveBtn.click(); else await recBtn.click()
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer(); const bytes = new Uint8Array(buf)
+    let s = ''; const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_static_mix.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[static-mix] wrote ${wavPath}`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  const py = spawnSync('python3', [resolve(__dirname, 'analyze-rerun-chunks.py'), wavPath, String(CHUNK_MS / 1000), String(NUM_CHUNKS)], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+main().catch(e => { console.error(e); process.exit(1) })

--- a/tools/test-rerun-track-loss.ts
+++ b/tools/test-rerun-track-loss.ts
@@ -1,0 +1,252 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-track-loss')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const CHUNK_MS = 4000
+const NUM_CHUNKS = 4   // one initial + 3 re-runs
+const SETTLE_MS = 2000
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-track-loss] Rec started — capturing ${NUM_CHUNKS}×${CHUNK_MS}ms across re-runs`)
+
+  for (let i = 1; i <= NUM_CHUNKS; i++) {
+    await page.waitForTimeout(CHUNK_MS)
+    if (i < NUM_CHUNKS) {
+      console.log(`[rerun-track-loss] click Run (#${i + 1}, hot-swap)...`)
+      await runBtn.click()
+    }
+  }
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'rerun_continuous.wav')
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  console.log('\n[rerun-track-loss] analysing chunks...\n')
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-chunks.py'),
+    wavPath,
+    String(CHUNK_MS / 1000),
+    String(NUM_CHUNKS),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-run-stop-cycle.ts
+++ b/tools/test-run-stop-cycle.ts
@@ -1,0 +1,268 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/run-stop-cycle')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const PLAY_MS = Number(process.env.PLAY_MS ?? 1000)     // play time between Run and Stop
+const WAIT_MS = Number(process.env.WAIT_MS ?? 1000)     // silent wait between Stop and next Run
+const NUM_CYCLES = Number(process.env.NUM_CYCLES ?? 10) // # of Run→Stop→wait cycles
+const TAIL_MS = Number(process.env.TAIL_MS ?? 5000)     // free playback after final Run
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'cycle'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  const stopBtnLocator = page.locator('button').filter({ hasText: 'Stop' }).first()
+
+  // Prime: first Run to warm engine, then Stop, before Rec armed
+  console.log('[run-stop] priming Run to warm engine...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+  await stopBtnLocator.click()
+  await page.waitForTimeout(500)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[run-stop] Rec started — ${NUM_CYCLES}× (Run+${PLAY_MS}ms / Stop+${WAIT_MS}ms) then final Run+${TAIL_MS}ms`)
+
+  for (let i = 1; i <= NUM_CYCLES; i++) {
+    console.log(`[run-stop] cycle ${i}/${NUM_CYCLES}: Run...`)
+    await runBtn.click()
+    await page.waitForTimeout(PLAY_MS)
+    await stopBtnLocator.click()
+    await page.waitForTimeout(WAIT_MS)
+  }
+  console.log(`[run-stop] cycles done — final Run + ${TAIL_MS}ms observation`)
+  await runBtn.click()
+  await page.waitForTimeout(TAIL_MS)
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const visibleButtons = await page.locator('button').allTextContents()
+  console.log('[run-stop] toolbar buttons visible:', visibleButtons.filter(t => t.length > 0 && t.length < 30).join(' | '))
+  const saveBtn = page.locator('button').filter({ hasText: /^\s*Save\s*$/ }).first()
+  if (await saveBtn.count() > 0) {
+    console.log('[run-stop] clicking Save...')
+    await saveBtn.click()
+  } else {
+    console.log('[run-stop] no Save button — clicking Rec to toggle...')
+    await recBtn.click()
+  }
+  await page.waitForTimeout(3000)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  // Boundary scan resolution matters here per feedback_boundary_scan_distinguishes_bug_classes
+  // (chunk-RMS would smear rapid swaps together — 200ms resolution separates them).
+  // Cycle boundary every (PLAY_MS + WAIT_MS). At cadence 1s/1s, that's 2s.
+  const cycleSec = (PLAY_MS + WAIT_MS) / 1000
+  console.log(`\n[run-stop] boundary scan @ ${cycleSec}s cadence (cycle starts)...\n`)
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-boundaries.py'),
+    wavPath,
+    String(cycleSec),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Why

Closes #290. Resurrects the engine fixes from PRs #291/#292/#293 — those PRs
squash-merged into their stacked bases (rather than retargeted to main first),
so only the UI commits from #289 actually reached \`main\`. The SP82/SP83/SP84
engine fixes were left stranded on intermediate branches. This PR brings the
3 engine commits + stress-test tooling onto \`main\` as a single review unit.

## What's included

| Commit | Catalogue | Fix |
|---|---|---|
| \`484bb27\` (was #291) | SP82 | Cancel \`reusableFx\` killTimers before \`Map.clear()\` on hot-swap and stop — orphan 1s timers were firing on freshly-allocated bus indices, corrupting the bus pool |
| \`97cd578\` (was #292) | SP83 | Sync \`preCreatePersistentFx(bpm)\` between \`freeAllNodes\` and \`reEvaluate\` on hot-swap — eliminates FX-vs-sample sub-frame race that left first iteration playing onto a dead bus |
| \`e7d9ba8\` (was #293) | SP84 | Preload all FX synthdefs at engine init; extend sync FX pre-creation to first-eval path — eliminates the 50-200ms \`/d_recv\` latency on first use of a previously-unseen FX |
| \`ce87abc\` (new) | — | Three stress reproducers: \`test-rerun-six-stress.ts\` (1 + 6 hot-swaps @ 4s), \`test-rerun-rapid.ts\` (configurable rapid hot-swap), \`test-run-stop-cycle.ts\` (Run/Stop cycle, exposed #294) |

## Verification

929/929 unit tests pass, \`tsc --noEmit\` clean.

Audio verification (each captured + analyzed via Playwright + WAV band-energy
+ 200ms boundary scan):

| Stress test | Result |
|---|---|
| 6× hot-swap @ 4s × 2 trials | PASS — cymbal_hi flat 1.83, snare onsets 46-61, no monotone growth, cross-trial within 10% |
| 3× hot-swap @ 1.5s + 5s tail | PASS — boundary scan clean at every click |
| 10× hot-swap @ 1s + 5s tail | PASS — transient FX-wash accumulation during burst, decays cleanly below baseline in 5s tail |

User's original Firefox WAV signature for #290 (snare onsets 30→12 collapse +
snare RMS +91% growth) does not reproduce on this stack across any of the
above regimes.

## Known follow-up

Issue #294 — different bug class (persistent arp/cymbal degradation after
5-6 Run→Stop→Run cycles) — was found by \`test-run-stop-cycle.ts\` and is filed
separately. Not addressed by this PR. The stack closes #290 cleanly under all
hot-swap regimes; #294 requires separate diagnosis of the Stop-teardown path.

## Test plan

- [x] Vitest suite 929/929
- [x] tsc --noEmit clean
- [x] Audio reproducer for #290 no longer reproduces
- [x] Stress variants confirm durability beyond original 4-chunk repro