### PR TITLE
🐛 fix(engine): SP86 loop-based hot-swap + SP87 reusableFx race + SP88 applyFx nodeId leak — closes #296

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1458,6 +1458,20 @@ export class SonicPiEngine {
         //      lifecycle. SP82 + SP85 hygiene (cancel timer, free group, free
         //      bus) still applies here.
         if (this.bridge) {
+          // (0) Purge future-scheduled bundles from the WASM scheduler queue
+          //     WITHOUT touching already-rendering synths. Each iteration
+          //     batches /s_news with future timetags spanning the schedAhead
+          //     window (SV9). Bundles for the OLD body's NEXT iterations are
+          //     in this queue; if we don't cancel them they fire on top of
+          //     the new body's audio, audibly stacking samples on rapid
+          //     changed-code re-runs (verified via tools/test-rerun-rapid-
+          //     changed.ts — pre-purge snare onsets 18→200 across 10 cycles).
+          //     Already-rendering synth nodes in group 100 are NOT in this
+          //     queue — they live in scsynth's running-node graph and decay
+          //     per their envelopes. This separation is the desktop-SP
+          //     analog: their Kernel.sleep blocks so no future bundles exist
+          //     to begin with; our schedAhead queue needs explicit drain.
+          this.bridge.purgePendingBundles()
           // (1) Persistent FX scopes: free only those whose scopeId does NOT
           //     appear in the new program. fxScopeChains was rebuilt during
           //     sandbox.execute above; persistentFx still holds the prior

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1437,43 +1437,63 @@ export class SonicPiEngine {
         // Pause ticking so no old events fire during transition
         scheduler.pauseTick()
 
-        // Free old audio — clean cut on every re-evaluate
+        // SP86 (#296): loop-based reconciliation — preserve in-flight audio
+        // whose shape didn't change. The previous nuclear path (freeAllNodes
+        // + persistentFx.clear + recreate) killed every synth in mid-envelope
+        // and tore down every FX node even when its content-addressed scopeId
+        // was identical in the new program. That's the source of the audible
+        // "click on Run" and the FX-tail accumulation during rapid hot-swap.
+        //
+        // Strategy now:
+        //   1. Synth group 100: untouched. Notes in mid-envelope finish their
+        //      decay naturally (matches Desktop SP behavior).
+        //   2. FX group 101: set-difference between persistentFx.keys() (old)
+        //      and fxScopeChains.keys() (new). Free only orphaned scopes.
+        //      Matching scopes keep their FX node + bus alive — reverb tail
+        //      and echo state persist across Run.
+        //   3. Monitors group 102: free only monitors for removed loops.
+        //      Surviving loops keep their per-track AnalyserNode routing.
+        //   4. reusableFx (per-iteration inner with_fx): always orphaned —
+        //      those FX are tied to a specific iteration's killTimer
+        //      lifecycle. SP82 + SP85 hygiene (cancel timer, free group, free
+        //      bus) still applies here.
         if (this.bridge) {
-          this.bridge.freeAllNodes()
-          this.nodeRefMap.clear()
-          // Clear persistent FX node tracking — freeAllNodes killed the FX
-          // nodes in group 101. They'll be recreated immediately below
-          // (eager) so in-flight iterations of long-cycle loops don't write
-          // /s_new to dead buses for several seconds while waiting for
-          // their next iteration to lazy-create FX.
-          // SP85 (#294): return persistentFx bus indices to the bridge pool
-          // BEFORE dropping the map. freeAllNodes() above killed the scsynth-
-          // side nodes via /g_freeAll, but the JS bus indices were leaked —
-          // nextBusNum then climbed past SuperSonic's numAudioBusChannels=128
-          // default after ~6 changed-code hot-swaps, silencing all FX-routed
-          // audio. /n_free for groups is redundant (already killed) and risks
-          // SP82-class double-allocation, so we only restore the bus pool.
-          for (const state of this.persistentFx.values()) {
+          // (1) Persistent FX scopes: free only those whose scopeId does NOT
+          //     appear in the new program. fxScopeChains was rebuilt during
+          //     sandbox.execute above; persistentFx still holds the prior
+          //     run's allocations. The intersection is what we preserve.
+          const survivingScopes = new Set(this.fxScopeChains.keys())
+          for (const [scopeId, state] of this.persistentFx) {
+            if (survivingScopes.has(scopeId)) continue  // keep alive
+            for (const group of state.groups) this.bridge.freeGroup(group)
             for (const bus of state.buses) this.bridge.freeBus(bus)
+            this.persistentFx.delete(scopeId)
           }
-          this.persistentFx.clear()
-          // Cancel pending FX-kill setTimeouts BEFORE dropping the map.
-          // Each per-iteration with_fx schedules a 1s killTimer (AudioInterpreter
-          // ~line 286/325) that frees its bus + group. /g_freeAll already killed
-          // the scsynth-side nodes, so the kill is redundant, but its freeBus()
-          // would push a stale bus index back into freeBuses[] and the freeGroup
-          // would /n_free a group that may now belong to a freshly-allocated FX.
-          // Without this clearTimeout, the stale timer fires ~1s post-hot-swap
-          // and corrupts pool state, producing audible "snare band growth" and
-          // reproducible track drops (issue #290).
-          // SP85 (#294): the timer body would have called freeBus(state.bus); do
-          // it synchronously here so the bus index returns to the pool instead
-          // of leaking (same root cause as the persistentFx loop above).
+          // (2) Per-iteration inner FX: always disposed across hot-swap. The
+          //     new code's iterations will allocate their own reusableFx
+          //     entries on first execution. Hygiene order matters (SV36 +
+          //     SV38): cancel killTimer before freeing, then /n_free the
+          //     group (live — /g_freeAll isn't called anymore), then return
+          //     the bus index to the pool.
           for (const state of this.reusableFx.values()) {
             if (state.killTimer) clearTimeout(state.killTimer)
+            this.bridge.freeGroup(state.groupId)
             this.bridge.freeBus(state.bus)
           }
           this.reusableFx.clear()
+          // (3) Loop monitors: free only those whose loop disappeared. Kept
+          //     loops re-use their existing monitor (createLoopMonitor is
+          //     idempotent by name).
+          for (const name of removedLoops) {
+            this.bridge.freeLoopMonitor(name)
+          }
+          // (4) nodeRefMap: drop all entries. NodeRefs are build-time symbols
+          //     and the new program built fresh ones; old refs are
+          //     unreachable from user code. Surviving persistent-FX scopes
+          //     re-register through AudioInterpreter on their first new-code
+          //     iteration that re-enters their with_fx Step (existing nodeId
+          //     reused via persistentFx.has(scopeId) short-circuit).
+          this.nodeRefMap.clear()
         }
 
         // Pre-create persistent FX synchronously before reEvaluate. See

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -86,13 +86,13 @@ export class SonicPiEngine {
   /** Maps DSL nodeRef → SuperSonic nodeId for control messages */
   private nodeRefMap = new Map<number, number>()
   /** Reusable inner FX nodes — persists across loop iterations. See issue #70.
-   *  `killTimer` is the pending `setTimeout` handle that frees this FX 1s after
-   *  its last iteration if no follow-up iteration cancels it. On hot-swap /
-   *  stop we MUST clearTimeout these before dropping the map entries, otherwise
-   *  the stale timer fires later and calls freeBus/freeGroup on what are by
-   *  then NEW live FX resources — corrupting the bus pool and silently killing
-   *  groups (issue #290). */
-  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: ReturnType<typeof setTimeout> }>()
+   *  `killTimer` is the pending virtual-time-scheduled kill handle (SV41) that
+   *  frees this FX after kill_delay seconds of virtual time if no follow-up
+   *  iteration cancels it. On hot-swap / stop we MUST `.cancel()` these before
+   *  dropping the map entries, otherwise the stale callback fires later and
+   *  calls freeBus/freeGroup on what are by then NEW live FX resources —
+   *  corrupting the bus pool and silently killing groups (issue #290, SP82). */
+  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: { cancel: () => void } }>()
   /** Pending volume to apply when bridge initializes */
   private pendingVolume: number | null = null
   /** Stored builder functions for capture/query path */
@@ -129,7 +129,7 @@ export class SonicPiEngine {
    */
   private currentBuildBuilder: ProgramBuilder | null = null
   /** Persistent top-level FX state — keyed by scope ID, shared across loops in same with_fx. */
-  private persistentFx = new Map<string, { buses: number[]; groups: number[]; outBus: number }>()
+  private persistentFx = new Map<string, { buses: number[]; groups: number[]; nodeIds: number[]; outBus: number }>()
   /** Maps loop name → FX scope ID (loops under same with_fx share a scope). */
   private loopFxScope = new Map<string, string>()
   /** Maps FX scope ID → FX chain definition. */
@@ -617,6 +617,7 @@ export class SonicPiEngine {
               let currentOutBus = task.outBus
               const buses: number[] = []
               const groups: number[] = []
+              const nodeIds: number[] = []
 
               // Create FX chain: outermost first
               // Signal flow: synth → innermost FX bus → ... → outermost FX → output
@@ -627,14 +628,19 @@ export class SonicPiEngine {
                   ? (m: string) => this.printHandler!(`[Warning] with_fx :${fx.name} — ${m}`)
                   : undefined
                 const fxOpts = normalizeFxParams(fx.name, fx.opts, task.bpm, fxWarn)
-                await this.bridge.applyFx(fx.name, audioTime, fxOpts, bus, currentOutBus)
+                // Capture nodeId — applyFxImmediate dispatches /s_new with the
+                // FX synth as a direct child of group 101 (NOT this container
+                // group), so freeGroup alone won't reach the synth on teardown.
+                // We /n_free this id explicitly when the scope is orphaned.
+                const nodeId = await this.bridge.applyFx(fx.name, audioTime, fxOpts, bus, currentOutBus)
                 this.bridge.flushMessages()
                 buses.push(bus)
                 groups.push(groupId)
+                nodeIds.push(nodeId)
                 currentOutBus = bus
               }
 
-              this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
+              this.persistentFx.set(scopeId, { buses, groups, nodeIds, outBus: currentOutBus })
             }
           }
 
@@ -1479,6 +1485,11 @@ export class SonicPiEngine {
           const survivingScopes = new Set(this.fxScopeChains.keys())
           for (const [scopeId, state] of this.persistentFx) {
             if (survivingScopes.has(scopeId)) continue  // keep alive
+            // /n_free the FX synth itself first. applyFxImmediate placed it
+            // as a direct child of root FX group 101 (NOT inside this
+            // container), so freeGroup alone would free an empty container
+            // while the FX synth keeps rendering on the master bus.
+            for (const nodeId of state.nodeIds) this.bridge.freeNode(nodeId)
             for (const group of state.groups) this.bridge.freeGroup(group)
             for (const bus of state.buses) this.bridge.freeBus(bus)
             this.persistentFx.delete(scopeId)
@@ -1490,7 +1501,12 @@ export class SonicPiEngine {
           //     group (live — /g_freeAll isn't called anymore), then return
           //     the bus index to the pool.
           for (const state of this.reusableFx.values()) {
-            if (state.killTimer) clearTimeout(state.killTimer)
+            state.killTimer?.cancel()
+            // /n_free the FX synth — applyFxImmediate placed it in root group
+            // 101, not the container group, so freeGroup alone leaves the
+            // synth alive and audibly ringing into outer FX scopes (SP87
+            // residual on :arp's outer reverb after hot-swap).
+            this.bridge.freeNode(state.nodeId)
             this.bridge.freeGroup(state.groupId)
             this.bridge.freeBus(state.bus)
           }
@@ -1585,6 +1601,7 @@ export class SonicPiEngine {
       let currentOutBus = 0  // FX-wrapped loops route to master through chain
       const buses: number[] = []
       const groups: number[] = []
+      const nodeIds: number[] = []
       for (const fx of fxChain) {
         const bus = this.bridge.allocateBus()
         const groupId = this.bridge.createFxGroup()
@@ -1595,13 +1612,17 @@ export class SonicPiEngine {
         // audioTime=0 → scsynth processes immediately (before any
         // future-timed sample bundles can race past). Awaiting the
         // promise ensures synthdef load completes before the next FX.
-        await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
+        // Capture nodeId — applyFxImmediate puts the FX synth in group 101
+        // (not this container group), so we must /n_free it explicitly on
+        // orphan teardown.
+        const nodeId = await this.bridge.applyFx(fx.name, 0, fxOpts, bus, currentOutBus)
         this.bridge.flushMessages(0)
         buses.push(bus)
         groups.push(groupId)
+        nodeIds.push(nodeId)
         currentOutBus = bus
       }
-      this.persistentFx.set(scopeId, { buses, groups, outBus: currentOutBus })
+      this.persistentFx.set(scopeId, { buses, groups, nodeIds, outBus: currentOutBus })
     }
   }
 
@@ -1676,7 +1697,7 @@ export class SonicPiEngine {
     // synchronously here so the bus index returns to the pool instead of
     // leaking (same root cause as the persistentFx loop above).
     for (const state of this.reusableFx.values()) {
-      if (state.killTimer) clearTimeout(state.killTimer)
+      state.killTimer?.cancel()
       this.bridge?.freeBus(state.bus)
     }
     this.reusableFx.clear()

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -1173,6 +1173,29 @@ export class SuperSonicBridge {
     this.clearLoopMonitors()            // return loopBuses to pool + clear map
   }
 
+  /**
+   * Drain future-scheduled bundles from the WASM scheduler queue WITHOUT
+   * killing currently-rendering synths.
+   *
+   * Use case: hot-swap (#296). Each iteration of a live_loop batches its
+   * /s_new bundles per SV9 and ships them with future timetags spanning the
+   * iteration. On hot-swap, those queued bundles belong to the OLD body; if
+   * left alone, they fire on top of the new body's bundles, audibly stacking
+   * samples on rapid changed-code re-runs. /g_freeAll would also kill
+   * already-rendering envelopes (the click-on-Run), so this separates the
+   * two concerns: cancel queued plans, preserve rendered audio.
+   *
+   * Bundles that have ALREADY been processed by scsynth (synth node spawned,
+   * currently rendering) are NOT affected — those live in group 100 and
+   * decay naturally per their envelopes. This matches Desktop SP behavior,
+   * where Kernel.sleep blocks the Ruby thread so no future bundles are ever
+   * queued in the first place.
+   */
+  purgePendingBundles(): void {
+    if (!this.sonic) return
+    this.sonic.purge().catch(() => {})
+  }
+
   /** Create a new group inside the FX group (101). Returns group ID. */
   createFxGroup(): number {
     if (!this.sonic) throw new Error('SuperSonic not initialized')

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -73,6 +73,22 @@ export interface SleepEntry {
   order: number
 }
 
+/**
+ * Pending one-shot callback bound to audio time (SV41).
+ *
+ * Used by AudioInterpreter's reusableFx kill_delay — virtual-time-scheduled
+ * kill so cancellation by next-iteration reuse is independent of real-time
+ * iter pacing (SP87). Fired at `audioTime <= getAudioTime()` (no schedAhead),
+ * which is one schedAhead behind sleep entries — this guarantees that when
+ * an iter resumes via tick() and cancels its kill in its microtask, the
+ * cancellation lands before the corresponding kill horizon is checked.
+ */
+interface PendingCallback {
+  audioTime: number
+  cb: () => void
+  cancelled: boolean
+}
+
 export interface TaskState {
   id: string
   virtualTime: number
@@ -159,6 +175,8 @@ export class VirtualTimeScheduler {
     taskId: string
     resolve: (payload: SyncPayload) => void
   }>>()
+  /** One-shot audio-time-bound callbacks (SV41 — backs scheduleAtVirtualTime). */
+  private pendingCallbacks: PendingCallback[] = []
 
   constructor(options: SchedulerOptions = {}) {
     this.getAudioTime = options.getAudioTime ?? (() => 0)
@@ -319,6 +337,30 @@ export class VirtualTimeScheduler {
     })
   }
 
+  /**
+   * Schedule a one-shot callback to fire when audio time reaches `audioTime` (SV41).
+   *
+   * Distinct from `scheduleSleep`:
+   * - sleep entries fire at `audioTime + schedAhead >= entry.time` (lookahead horizon)
+   * - pending callbacks fire at `audioTime >= entry.audioTime` (no lookahead)
+   *
+   * The schedAhead-stripped horizon is intentional: it gives a task that resumed
+   * from a sleep firing in the same tick (lookahead horizon) time to drain its
+   * microtask queue and call `.cancel()` before the corresponding callback's
+   * horizon is checked. Used by `AudioInterpreter.reusableFx` to schedule
+   * inner-FX kill_delay in virtual time instead of real-time setTimeout
+   * (SP87, SV41 — iter pacing in real time is unstable post SV40 purge).
+   *
+   * Returns `{ cancel }` — call it to prevent the callback from firing.
+   */
+  scheduleAtVirtualTime(audioTime: number, cb: () => void): { cancel: () => void } {
+    const entry: PendingCallback = { audioTime, cb, cancelled: false }
+    this.pendingCallbacks.push(entry)
+    return {
+      cancel: () => { entry.cancelled = true },
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Event dispatch
   // ---------------------------------------------------------------------------
@@ -427,6 +469,40 @@ export class VirtualTimeScheduler {
       const entry = this.queue.pop()!
       entry.resolve()
     }
+
+    // SV41: fire/cleanup pending audio-time-bound callbacks AFTER sleep entries.
+    // Horizon is `target - schedAhead` (the underlying audio time), so any task
+    // resumed from the sleep heap above has a chance to drain its microtask
+    // queue and cancel its kill before the kill's horizon is reached.
+    //
+    // CRITICAL: fired callbacks are deferred via `queueMicrotask`. Sleep entries
+    // resolved above queued their await-resumption microtasks FIRST; deferring
+    // the kill fire ensures an iter that resumes from sleep and synchronously
+    // cancels its kill in a with_fx reuse-check lands BEFORE the kill wrapper
+    // checks `cancelled`. Without the deferral, kill fires synchronously inside
+    // tick() (before any microtask drain), so when the same tick resolves both
+    // iter N+1's sleep and the kill horizon, the kill executes before iter N+1
+    // can call .cancel() — and the FX is wrongly freed (SP87).
+    if (this.pendingCallbacks.length > 0) {
+      const cbHorizon = target - this.schedAheadTime
+      let writeIdx = 0
+      for (let i = 0; i < this.pendingCallbacks.length; i++) {
+        const pc = this.pendingCallbacks[i]
+        if (pc.cancelled) continue // drop cancelled
+        if (pc.audioTime <= cbHorizon) {
+          const fired = pc
+          queueMicrotask(() => {
+            if (fired.cancelled) return
+            try { fired.cb() } catch (err) {
+              if (this.loopErrorHandler) this.loopErrorHandler('__pendingCallback__', err as Error)
+            }
+          })
+          continue // drop fired (queued)
+        }
+        this.pendingCallbacks[writeIdx++] = pc
+      }
+      this.pendingCallbacks.length = writeIdx
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -476,6 +552,7 @@ export class VirtualTimeScheduler {
     this.eventHandlers.length = 0
     this.cueMap.clear()
     this.syncWaiters.clear()
+    this.pendingCallbacks.length = 0
   }
 
   // ---------------------------------------------------------------------------

--- a/src/engine/__tests__/WithFx.test.ts
+++ b/src/engine/__tests__/WithFx.test.ts
@@ -92,8 +92,11 @@ describe('with_fx', () => {
     expect(bridge.calls).toContain('alloc:16')
     expect(bridge.calls).toContain('fx:reverb:in16:out0')
     expect(bridge.calls).toContain('createGroup:5000')
-    // Group freeing is delayed by kill_delay (default 1s) — advance timers
-    await new Promise(r => setTimeout(r, 1100))
+    // Group freeing is delayed by kill_delay (default 1s of VIRTUAL time, SV41)
+    // — advance the scheduler past the kill horizon. cbHorizon = target -
+    // schedAhead, so target=200 with schedAhead=100 → cbHorizon=100 ≥ 1.5.
+    scheduler.tick(200)
+    await flushMicrotasks()
     expect(bridge.calls).toContain('freeGroup:5000')
     expect(bridge.calls).toContain('free:16')
   })

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -25,8 +25,14 @@ interface ReusableFxState {
   groupId: number
   nodeId: number
   outBus: number
-  /** Pending kill_delay timer — cancelled if FX is reused before it fires. */
-  killTimer?: ReturnType<typeof setTimeout>
+  /**
+   * Pending kill_delay handle — cancelled if FX is reused before it fires (SV41).
+   * Backed by `scheduler.scheduleAtVirtualTime` (audio-time scheduled) instead
+   * of `setTimeout` (real-time scheduled) so cancellation is independent of
+   * real-time iter pacing (SP87 — post-purge real-time-paced iterations broke
+   * the setTimeout-based reuse logic).
+   */
+  killTimer?: { cancel: () => void }
 }
 
 export interface AudioContext {
@@ -269,7 +275,7 @@ export async function runProgram(
         if (existing) {
           // Reuse — cancel pending kill timer, route through existing FX bus
           if (existing.killTimer) {
-            clearTimeout(existing.killTimer)
+            existing.killTimer.cancel()
             existing.killTimer = undefined
           }
           if (step.nodeRef && existing.nodeId !== undefined) {
@@ -281,13 +287,30 @@ export async function runProgram(
           } finally {
             task.outBus = prevOutBus
             ctx.bridge.flushMessages()
-            // Schedule kill — cancelled if next iteration reuses before it fires
-            const killDelay = (step.opts.kill_delay as number) ?? 1.0
-            existing.killTimer = setTimeout(() => {
-              ctx.bridge!.freeGroup(existing.groupId)
-              ctx.bridge!.freeBus(existing.bus)
-              ctx.reusableFx.delete(fxKey)
-            }, killDelay * 1000)
+            // Schedule kill in VIRTUAL TIME (SV41) — cancelled if next iter
+            // reuses before its horizon. setTimeout-based (real-time) scheduling
+            // raced post-SV40-purge real-time-paced iterations (SP87).
+            //
+            // GUARD: only schedule if our `existing` state is STILL the active
+            // entry in the Map. After SonicPiEngine's hot-swap reusableFx.clear,
+            // this iter's `existing` reference becomes stale (resources already
+            // freed by clear); a scheduled kill would (a) leak an uncancellable
+            // callback and (b) eventually run /n_free + freeBus on the freed
+            // (and possibly re-allocated) resources. The next iter will hit
+            // CREATE branch and own the new state's killTimer.
+            if (ctx.reusableFx.get(fxKey) === existing) {
+              const killDelay = (step.opts.kill_delay as number) ?? 1.0
+              const killAt = task.virtualTime + killDelay
+              existing.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
+                // /n_free the FX synth itself — applyFxImmediate puts it in
+                // root group 101 (not the container group), so freeGroup
+                // alone leaves the synth running and ringing into outer FX.
+                ctx.bridge!.freeNode(existing.nodeId)
+                ctx.bridge!.freeGroup(existing.groupId)
+                ctx.bridge!.freeBus(existing.bus)
+                ctx.reusableFx.delete(fxKey)
+              })
+            }
           }
         } else {
           // First iteration — create FX node
@@ -318,15 +341,17 @@ export async function runProgram(
           } finally {
             task.outBus = prevOutBus
             ctx.bridge.flushMessages()
-            // Schedule kill — if next iteration reuses, timer is cancelled
+            // Schedule kill in VIRTUAL TIME (SV41) — if next iter reuses, cancelled
             const killDelay = (step.opts.kill_delay as number) ?? 1.0
             const state = ctx.reusableFx.get(fxKey)
             if (state) {
-              state.killTimer = setTimeout(() => {
+              const killAt = task.virtualTime + killDelay
+              state.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
+                ctx.bridge!.freeNode(state.nodeId)
                 ctx.bridge!.freeGroup(state.groupId)
                 ctx.bridge!.freeBus(state.bus)
                 ctx.reusableFx.delete(fxKey)
-              }, killDelay * 1000)
+              })
             }
           }
         }

--- a/tools/analyze-hot-swap-tail.py
+++ b/tools/analyze-hot-swap-tail.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Quantify the click-on-Run artifact for #296.
+
+The reproducer (tools/test-hot-swap-tail.ts) records a single pad note
+that starts at Run #1 and is hit with Run #2 around t=2.5s of the recording.
+
+Three metrics over the WAV:
+1. Pre-click RMS (1s window before Run #2)
+2. Post-click RMS (200ms after Run #2)
+3. Click magnitude — max absolute sample within ±50ms of Run #2 normalized
+   by pre-click RMS. A clean transition has click_magnitude near 1.0; a
+   sharp cut spikes to 4-10x.
+
+Usage: python3 tools/analyze-hot-swap-tail.py <wav> [run2_time_s=2.5]
+"""
+import sys, struct, wave, math
+
+def load_wav(path):
+    with wave.open(path, "rb") as w:
+        sr = w.getframerate()
+        nf = w.getnframes()
+        ch = w.getnchannels()
+        sw = w.getsampwidth()
+        raw = w.readframes(nf)
+    if sw == 2:
+        fmt = f"<{nf*ch}h"
+        ints = struct.unpack(fmt, raw)
+        a = [s / 32768.0 for s in ints]
+    elif sw == 4:
+        fmt = f"<{nf*ch}f"
+        a = list(struct.unpack(fmt, raw))
+    else:
+        raise SystemExit(f"unsupported sample width {sw}")
+    if ch == 2:
+        a = [(a[2*i] + a[2*i+1]) * 0.5 for i in range(nf)]
+    return a, sr
+
+def rms(samples):
+    if not samples: return 0.0
+    return math.sqrt(sum(s*s for s in samples) / len(samples))
+
+def peak(samples):
+    if not samples: return 0.0
+    return max(abs(s) for s in samples)
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    wav_path = sys.argv[1]
+    run2_t = float(sys.argv[2]) if len(sys.argv) > 2 else 2.5
+    # the script's Rec starts a small fraction before Run #1, plus SETTLE_MS=1.5s priming
+    # tail.ts: SETTLE_MS(1.5s) is BEFORE Rec, then Rec, then Run#1, then PRE_RUN_MS(2.5s)
+    # So Run #2 happens ~2.5s into the recording, plus a small playwright click latency.
+    # Allow override via cli.
+
+    a, sr = load_wav(wav_path)
+    dur = len(a) / sr
+    print(f"loaded {wav_path}: {dur:.2f}s @ {sr}Hz mono, peak={peak(a):.3f}")
+    print(f"Run #2 expected at t={run2_t:.2f}s")
+
+    # Three windows
+    pre_start = max(0, int((run2_t - 1.0) * sr))
+    pre_end   = int(run2_t * sr)
+    post_start = int(run2_t * sr)
+    post_end   = int((run2_t + 0.2) * sr)
+    click_start = max(0, int((run2_t - 0.05) * sr))
+    click_end   = int((run2_t + 0.05) * sr)
+    tail_start = int((run2_t + 0.5) * sr)
+    tail_end   = min(len(a), int((run2_t + 1.5) * sr))
+
+    pre_rms  = rms(a[pre_start:pre_end])
+    post_rms = rms(a[post_start:post_end])
+    tail_rms = rms(a[tail_start:tail_end])
+    click_peak = peak(a[click_start:click_end])
+    click_norm = click_peak / pre_rms if pre_rms > 1e-9 else 0.0
+
+    # Find min RMS in a 50ms window centered on Run #2 — captures dip from cut
+    min_rms = float('inf')
+    win = int(0.020 * sr)  # 20ms windows
+    for i in range(click_start, click_end - win, win // 4):
+        r = rms(a[i:i+win])
+        if r < min_rms:
+            min_rms = r
+    dip_ratio = (pre_rms - min_rms) / pre_rms if pre_rms > 1e-9 else 0.0
+
+    print()
+    print(f"  pre-click RMS  (t={(run2_t-1.0):.2f}-{run2_t:.2f}s):   {pre_rms:.4f}")
+    print(f"  click window peak (±50ms around Run #2):    {click_peak:.4f} ({click_norm:.2f}× pre-RMS)")
+    print(f"  20ms-window min RMS within click region:     {min_rms:.4f}")
+    print(f"  RMS dip ratio (1 - min/pre):                  {dip_ratio*100:.1f}%")
+    print(f"  post-click RMS (t={run2_t:.2f}-{(run2_t+0.2):.2f}s): {post_rms:.4f}")
+    print(f"  tail RMS       (t={(run2_t+0.5):.2f}-{(run2_t+1.5):.2f}s): {tail_rms:.4f}")
+    print()
+    if dip_ratio > 0.5:
+        print(f"VERDICT: AUDIBLE CUT — RMS drops {dip_ratio*100:.0f}% in the click region")
+        print("        (the pad envelope was killed mid-decay)")
+    elif click_norm > 3.0:
+        print(f"VERDICT: AUDIBLE CLICK — transient peak {click_norm:.1f}× pre-RMS")
+    else:
+        print(f"VERDICT: CONTINUOUS — no significant dip or transient at the Run boundary")
+
+if __name__ == "__main__":
+    main()

--- a/tools/test-fx-orphan-leak.ts
+++ b/tools/test-fx-orphan-leak.ts
@@ -1,0 +1,182 @@
+/**
+ * Reproducer for FX-orphan-leak (applyFx /n_free targets wrong group).
+ *
+ * Latent bug: SuperSonicBridge.applyFxImmediate dispatches /s_new with the
+ * FX synth as a direct child of group 101 (not the container `createFxGroup`).
+ * On hot-swap orphan teardown, freeGroup(state.groups[i]) sends /n_free for
+ * the empty container — the FX synth in group 101 keeps rendering.
+ *
+ * For scope-PRESERVING edits (same scopeId pre/post), no orphan teardown
+ * fires, so the bug is invisible. To force orphan teardown we mutate an FX
+ * opt (here: room: 0.95 → 0.05). Since scopeId fingerprint includes opts
+ * (SonicPiEngine.ts:835-838), the new program produces a different scopeId
+ * → old persistentFx entry is orphaned → freeGroup runs → bug fires.
+ *
+ *   npx tsx tools/test-fx-orphan-leak.ts
+ *
+ * Output: .captures/fx-orphan-leak/<TRIAL_LABEL>.wav
+ *
+ * Symptom pre-fix: After hot-swap, the OLD `:reverb room:0.95` synth keeps
+ * running in group 101 and processes whatever the freed bus happens to carry
+ * (often still master bus 0 or a reallocated bus), producing audible reverb
+ * tail content that the new `room:0.05` synth alone shouldn't produce.
+ * Post-fix: the OLD reverb synth is /n_free'd correctly.
+ *
+ * The decisive observation is the OSC trace (logged separately) — we just
+ * need a WAV capture that lets us A/B audibly + numerically.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/fx-orphan-leak')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'baseline'
+
+// Snippet A — huge reverb (room: 0.95). 4 hits per 4 beats, very wet tail.
+const SNIPPET_A = `use_bpm 120
+
+live_loop :met1 do
+  sleep 1
+end
+
+with_fx :reverb, mix: 0.9, room: 0.95 do
+  live_loop :pulse, sync: :met1 do
+    sample :bd_tek, amp: 1.5
+    sleep 1
+  end
+end
+`
+
+// Snippet B — same loop, reverb room changed (room: 0.05 = nearly dry).
+// scopeId fingerprint differs → orphan teardown fires on hot-swap.
+const SNIPPET_B = SNIPPET_A.replace('room: 0.95', 'room: 0.05')
+
+if (SNIPPET_A === SNIPPET_B) {
+  console.error('[fx-orphan-leak] FATAL: edit pattern did not match; aborting')
+  process.exit(1)
+}
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function fetchCapturedWav(page: import('@playwright/test').Page): Promise<Buffer | null> {
+  for (let i = 0; i < 60; i++) {
+    const len = await page.evaluate(async () => {
+      const b = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+      if (!b) return -1
+      const buf = await b.arrayBuffer()
+      ;(window as unknown as { __wavBytes: Uint8Array }).__wavBytes = new Uint8Array(buf)
+      return buf.byteLength
+    })
+    if (len > 0) {
+      const bytes = await page.evaluate(() => {
+        const u8 = (window as unknown as { __wavBytes: Uint8Array }).__wavBytes
+        return Array.from(u8)
+      })
+      return Buffer.from(bytes)
+    }
+    await page.waitForTimeout(100)
+  }
+  return null
+}
+
+async function main() {
+  console.log('[fx-orphan-leak] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext({ permissions: ['microphone'] })
+  const page = await ctx.newPage()
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET_A)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  console.log('[fx-orphan-leak] Run #1 (room:0.95)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(2000)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  console.log('[fx-orphan-leak] click Rec...')
+  await recBtn.click()
+  await page.waitForTimeout(200)
+
+  // 4 seconds of Run #1 (room:0.95 — wet reverb)
+  console.log('[fx-orphan-leak] recording 4s of room:0.95...')
+  await page.waitForTimeout(4000)
+
+  // Hot-swap to dry reverb — forces scope orphan + recreate
+  console.log('[fx-orphan-leak] editing room:0.95 → 0.05 (scope orphan)...')
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET_B)
+  await page.waitForTimeout(200)
+
+  console.log('[fx-orphan-leak] click Update...')
+  await runBtn.click()
+
+  // 8 seconds post-hot-swap to capture sustained behavior
+  console.log('[fx-orphan-leak] recording 8s post-hot-swap...')
+  await page.waitForTimeout(8000)
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  console.log('[fx-orphan-leak] click Save...')
+  await saveBtn.click()
+
+  const wav = await fetchCapturedWav(page)
+  if (!wav) {
+    console.error('[fx-orphan-leak] no WAV captured')
+    process.exit(1)
+  }
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[fx-orphan-leak] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  await stopBtn.click().catch(() => {})
+
+  await browser.close()
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/tools/test-hhc2-sleep-edit.ts
+++ b/tools/test-hhc2-sleep-edit.ts
@@ -1,0 +1,260 @@
+/**
+ * Reproducer for user-reported case: edit `sleep 0.5` → `sleep 1.5` inside
+ * the top-level :hhc2 loop in the dj_dave snippet. :hhc2 is NOT inside any
+ * with_fx wrapping, so under SP86 A3-strict body-aware reconcile every
+ * FX scope's body fingerprint is unchanged → every FX scope preserved →
+ * reverb/echo tails keep compounding across runs. This is the SP11
+ * residual the user is hearing.
+ *
+ *   npx tsx tools/test-hhc2-sleep-edit.ts
+ *
+ * Output: .captures/hhc2-edit/<TRIAL_LABEL>.wav (16s capture, 2s init +
+ * 6s Run #1 + edit + 8s Run #2 tail). Run analyze-rerun-chunks.py on it
+ * to read per-chunk band-energy progression.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/hhc2-edit')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'after_a3'
+
+const SNIPPET_A = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+// Single targeted edit: change the first `sleep 0.5` inside :hhc2 (immediately
+// after `a = 1.25`) to `sleep 1.5`. This is a real body change to a
+// top-level (no with_fx wrapping) live_loop. Under SP86 A3-strict, no FX
+// scope's body fingerprint changes — all reverbs preserved.
+const SNIPPET_B = SNIPPET_A.replace(
+  /(live_loop :hhc2, sync: :met1 do\n  a = 1\.25\n)  sleep 0\.5\n/,
+  '$1  sleep 1.5\n',
+)
+if (SNIPPET_A === SNIPPET_B) {
+  console.error('[hhc2-edit] FATAL: edit pattern did not match; aborting')
+  process.exit(1)
+}
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function fetchCapturedWav(page: import('@playwright/test').Page): Promise<Buffer | null> {
+  for (let i = 0; i < 60; i++) {
+    const len = await page.evaluate(async () => {
+      const b = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+      if (!b) return -1
+      const buf = await b.arrayBuffer()
+      ;(window as unknown as { __wavBytes: Uint8Array }).__wavBytes = new Uint8Array(buf)
+      return buf.byteLength
+    })
+    if (len > 0) {
+      const bytes = await page.evaluate(() => {
+        const u8 = (window as unknown as { __wavBytes: Uint8Array }).__wavBytes
+        return Array.from(u8)
+      })
+      return Buffer.from(bytes)
+    }
+    await page.waitForTimeout(100)
+  }
+  return null
+}
+
+async function main() {
+  console.log('[hhc2-edit] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext({ permissions: ['microphone'] })
+  const page = await ctx.newPage()
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET_A)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  console.log('[hhc2-edit] Run #1 (initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(2000)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  console.log('[hhc2-edit] click Rec...')
+  await recBtn.click()
+  await page.waitForTimeout(200)
+
+  // 6 seconds of Run #1 with original snippet
+  console.log('[hhc2-edit] recording Run #1 for 6s before edit...')
+  await page.waitForTimeout(6000)
+
+  // Make the real edit
+  console.log('[hhc2-edit] editing :hhc2 sleep 0.5 → 1.5...')
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET_B)
+  await page.waitForTimeout(200)
+
+  console.log('[hhc2-edit] click Update (hot-swap)...')
+  await runBtn.click()
+
+  // 16 seconds of Run #2 tail — long enough to capture the linger window
+  // (~7s for reverb default room=0.6) AND the post-linger steady state.
+  console.log('[hhc2-edit] recording Run #2 for 16s (linger + steady state)...')
+  await page.waitForTimeout(16000)
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  console.log('[hhc2-edit] click Save (stop Rec, download WAV)...')
+  await saveBtn.click()
+
+  const wav = await fetchCapturedWav(page)
+  if (!wav) {
+    console.error('[hhc2-edit] no WAV captured')
+    process.exit(1)
+  }
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[hhc2-edit] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  await stopBtn.click().catch(() => {})
+
+  await browser.close()
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/tools/test-hot-swap-tail.ts
+++ b/tools/test-hot-swap-tail.ts
@@ -1,0 +1,163 @@
+/**
+ * Reproducer for #296 — captures the click-on-Run artifact.
+ *
+ * Snippet: a single live_loop holding a long-sustain :prophet pad inside a
+ * persistent :reverb FX. We click Run, wait 2s while the pad is mid-envelope,
+ * then click Run again with IDENTICAL code (still triggers hot-swap because
+ * the engine doesn't know it's identical until the SV35 short-circuit — and
+ * even then we want to verify we don't break anything on real changes).
+ *
+ * Pre-fix: /g_freeAll 100 kills the pad mid-envelope → audible click at the
+ * Run boundary, then a fresh pad onset.
+ * Post-fix: pad finishes its envelope; new iteration triggers fresh pad
+ * underneath; no click.
+ *
+ * Usage:
+ *   npx tsx tools/test-hot-swap-tail.ts [--swap-changed]
+ *
+ * --swap-changed: instead of identical re-run (SV35 no-op), modify one byte
+ *                 to force the changed-code hot-swap path.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/hot-swap-tail')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const SWAP_CHANGED = process.argv.includes('--swap-changed')
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? (SWAP_CHANGED ? 'changed' : 'identical')
+const PRE_RUN_MS = 2500  // time playing before the Run-during-pad
+const POST_RUN_MS = 3500 // time after Run to capture the tail behavior
+const SETTLE_MS = 1500
+
+// A held pad that runs ONCE per iteration. The iteration length is long
+// (sleep 8) so when we click Run during the iteration, the pad note is
+// mid-envelope. The reverb wraps it so we also exercise FX preservation.
+const SNIPPET_A = `# hot-swap-tail repro
+use_bpm 60
+
+with_fx :reverb, mix: 0.6, room: 0.8 do
+  live_loop :pad do
+    use_synth :saw
+    play :c3, sustain: 6, release: 1, amp: 0.4, cutoff: 90
+    sleep 8
+  end
+end
+
+live_loop :tick_clock do
+  sleep 1
+end
+`
+
+// Identical to SNIPPET_A except for a comment marker — SV35 short-circuit
+// will see currentCode !== code and run the full hot-swap path.
+const SNIPPET_B = SNIPPET_A.replace('# hot-swap-tail repro', '# hot-swap-tail repro (mutated)')
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    if (m.type() === 'error') console.error(`[console error] ${m.text()}`)
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await editor.fill(SNIPPET_A)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  const stopBtnLocator = page.locator('button').filter({ hasText: 'Stop' }).first()
+
+  console.log('[tail] priming Run to warm engine...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+  await stopBtnLocator.click()
+  await page.waitForTimeout(800)
+
+  // Start continuous Rec — the same button flips label Rec ↔ Save when armed,
+  // so we lock onto it via the stable title attribute.
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button[title="Record to WAV"]').first()
+  await recBtn.click()
+
+  // First Run — pad starts
+  console.log(`[tail] Run #1 — pad starts (recording for ${PRE_RUN_MS}ms before hot-swap)`)
+  await runBtn.click()
+  await page.waitForTimeout(PRE_RUN_MS)
+
+  // Mid-envelope: do the hot-swap
+  if (SWAP_CHANGED) {
+    console.log('[tail] mutating snippet for changed-code hot-swap')
+    await editor.click()
+    await page.keyboard.press('Meta+a')
+    await page.keyboard.press('Backspace')
+    await editor.fill(SNIPPET_B)
+    await page.waitForTimeout(100)
+  }
+  console.log('[tail] Run #2 — hot-swap during pad')
+  await runBtn.click()
+  await page.waitForTimeout(POST_RUN_MS)
+
+  // Stop Rec — same button (title="Record to WAV") now labeled Save and
+  // clicking it triggers the WAV download which the interceptor catches.
+  await recBtn.click()
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[tail] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(2)}s float32 stereo @48k)`)
+  console.log(`[tail] Run #2 click happened around t=${(SETTLE_MS / 1000).toFixed(2)}s + ${(PRE_RUN_MS / 1000).toFixed(2)}s into capture`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/tools/test-longrun-no-edit.ts
+++ b/tools/test-longrun-no-edit.ts
@@ -1,0 +1,222 @@
+/**
+ * Control test: load dj_dave, click Run once, record 22 seconds of audio
+ * with NO hot-swap. If gain grows over the same window we observed in
+ * test-hhc2-sleep-edit.ts, the growth is intrinsic to the snippet's
+ * persistent-FX architecture (SP11), not caused by the hot-swap path.
+ *
+ *   npx tsx tools/test-longrun-no-edit.ts
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/hhc2-edit')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'no_edit_control'
+
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function fetchCapturedWav(page: import('@playwright/test').Page): Promise<Buffer | null> {
+  for (let i = 0; i < 60; i++) {
+    const len = await page.evaluate(async () => {
+      const b = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+      if (!b) return -1
+      const buf = await b.arrayBuffer()
+      ;(window as unknown as { __wavBytes: Uint8Array }).__wavBytes = new Uint8Array(buf)
+      return buf.byteLength
+    })
+    if (len > 0) {
+      const bytes = await page.evaluate(() => {
+        const u8 = (window as unknown as { __wavBytes: Uint8Array }).__wavBytes
+        return Array.from(u8)
+      })
+      return Buffer.from(bytes)
+    }
+    await page.waitForTimeout(100)
+  }
+  return null
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext({ permissions: ['microphone'] })
+  const page = await ctx.newPage()
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  console.log('[long-run] Run (single click, no hot-swap)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(2000)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  console.log('[long-run] click Rec...')
+  await recBtn.click()
+  await page.waitForTimeout(200)
+
+  console.log('[long-run] recording 22s with NO hot-swap...')
+  await page.waitForTimeout(22000)
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  console.log('[long-run] click Save...')
+  await saveBtn.click()
+
+  const wav = await fetchCapturedWav(page)
+  if (!wav) {
+    console.error('[long-run] no WAV captured')
+    process.exit(1)
+  }
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[long-run] wrote ${wavPath} (${wav.length} bytes)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  await stopBtn.click().catch(() => {})
+
+  await browser.close()
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/tools/test-rerun-rapid-changed.ts
+++ b/tools/test-rerun-rapid-changed.ts
@@ -1,0 +1,267 @@
+/**
+ * Playwright reproducer for user-reported "tracks drop on Run-while-playing".
+ *
+ * Pastes the full DJ_Dave sketch, clicks Run, then re-Runs every 4 seconds
+ * 3 times while a single continuous in-app Rec captures everything.
+ *
+ * Output: one 16s WAV split into 4 chunks of ~4s each. The companion analyzer
+ * (analyze-rerun-chunks.py) reports per-chunk band energy + onsets so a missing
+ * kick / clap / cymbal track is visible as a band-energy dropout in chunk N.
+ *
+ * Why one continuous Rec (not 4 separate Recs):
+ *   The user reported the bug across a SINGLE recording session — they want
+ *   to see whether the AudioWorklet / scsynth state survives Update without
+ *   disturbing the recorder boundary. Splitting into 4 Recs would re-attach
+ *   the analyser between captures and hide stream-level discontinuities.
+ *
+ * Usage:
+ *   npx tsx tools/test-rerun-track-loss.ts          # headless
+ *   npx tsx tools/test-rerun-track-loss.ts --headed
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { spawnSync } from 'child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/rerun-rapid-changed')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const RAPID_MS = Number(process.env.RAPID_MS ?? 1000)   // ms between rapid hot-swaps
+const NUM_RAPID = Number(process.env.NUM_RAPID ?? 10)   // rapid re-runs after initial Run
+const TAIL_MS = Number(process.env.TAIL_MS ?? 5000)     // free playback after last swap
+const SETTLE_MS = 2000
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'rapid'
+
+// Full DJ_Dave sketch from the user's report. Eight live_loops total:
+//   met1, kick (unwrapped), clap (echo→reverb), hhc1 (reverb→panslicer),
+//   hhc2 (unwrapped), crash (reverb), arp (reverb→echo dynamic), synthbass
+//   (panslicer→reverb).
+const SNIPPET = `# Coded by DJ_Dave
+
+use_bpm 130
+
+live_loop :met1 do
+  sleep 1
+end
+
+cmaster1 = 130
+cmaster2 = 130
+
+define :pattern do |pattern|
+  return pattern.ring.tick == "x"
+end
+
+live_loop :kick, sync: :met1 do
+  a = 1.5
+  sample :bd_tek, amp: a, cutoff: cmaster1 if pattern "x--x--x---x--x--"
+  sleep 0.25
+end
+
+with_fx :echo, mix: 0.2 do
+  with_fx :reverb, mix: 0.2, room: 0.5 do
+    live_loop :clap, sync: :met1 do
+      a = 0.75
+      sleep 1
+      sample :drum_snare_hard, rate: 2.5, cutoff: cmaster1, amp: a
+      sample :drum_snare_hard, rate: 2.2, start: 0.02, cutoff: cmaster1, pan: 0.2, amp: a
+      sample :drum_snare_hard, rate: 2, start: 0.04, cutoff: cmaster1, pan: -0.2, amp: a
+      sleep 1
+    end
+  end
+end
+
+with_fx :reverb, mix: 0.2 do
+  with_fx :panslicer, mix: 0.2 do
+    live_loop :hhc1, sync: :met1 do
+      a = 0.75
+      p = [-0.3, 0.3].choose
+      sample :drum_cymbal_closed, amp: a, rate: 2.5, finish: 0.5, pan: p, cutoff: cmaster2 if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-x-x-x-"
+      sleep 0.125
+    end
+  end
+end
+
+live_loop :hhc2, sync: :met1 do
+  a = 1.25
+  sleep 0.5
+  sample :drum_cymbal_closed, cutoff: cmaster2, rate: 1.2, start: 0.01, finish: 0.5, amp: a
+  sleep 0.5
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :crash, sync: :met1 do
+    a = 0.1
+    c = cmaster2-10
+    r = 1.5
+    f = 0.25
+    crash = :drum_splash_soft
+    sleep 14.5
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 1
+    sample crash, amp: a, cutoff: c, rate: r, finish: f
+    sample crash, amp: a, cutoff: c, rate: r-0.2, finish: f
+    sleep 0.5
+  end
+end
+
+with_fx :reverb, mix: 0.7 do
+  live_loop :arp, sync: :met1 do
+    with_fx :echo, phase: 1, mix: (line 0.1, 1, steps: 128).mirror.tick do
+      a = 0.6
+      r = 0.25
+      c = 130
+      p = (line -0.7, 0.7, steps: 64).mirror.tick
+      at = 0.01
+      use_synth :beep
+      tick
+      notes = (scale :g4, :major_pentatonic).shuffle
+      play notes.look, amp: a, release: r, cutoff: c, pan: p, attack: at
+      sleep 0.75
+    end
+  end
+end
+
+with_fx :panslicer, mix: 0.4 do
+  with_fx :reverb, mix: 0.75 do
+    live_loop :synthbass, sync: :met1 do
+      use_synth :tech_saws
+      play :g3, sustain: 6, cutoff: 60, amp: 0.75, attack: 0
+      sleep 6
+      play :d3, sustain: 2, cutoff: 60, amp: 0.75, attack: 0
+      sleep 2
+      play :e3, sustain: 8, cutoff: 60, amp: 0.75, attack: 0
+      sleep 8
+    end
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function main() {
+  console.log('[rerun-track-loss] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+
+  page.on('pageerror', err => console.error('[page error]', err.message))
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error' || t === 'warning') console.error(`[console ${t}]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  // Paste snippet
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+
+  // First Run — initial play
+  console.log('[rerun-track-loss] click Run (#1, initial)...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(SETTLE_MS)
+
+  // Start continuous Rec
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  await recBtn.click()
+  console.log(`[rerun-rapid] Rec started — ${NUM_RAPID}× hot-swap @ ${RAPID_MS}ms then ${TAIL_MS}ms tail`)
+
+  for (let i = 1; i <= NUM_RAPID; i++) {
+    await page.waitForTimeout(RAPID_MS)
+    // Mutate the snippet so SonicPiEngine.ts:289-291 (SV35 no-op short-circuit)
+    // doesn't fire. Trailing comment differs each iteration, body identical.
+    // This forces the real changed-code hot-swap path (the one #296 targets).
+    const mutated = SNIPPET + `\n# rapid-changed iter ${i}\n`
+    await editor.click()
+    await page.keyboard.press('Meta+a')
+    await page.keyboard.press('Backspace')
+    await editor.fill(mutated)
+    await page.waitForTimeout(30)
+    console.log(`[rerun-rapid-changed] click Run (#${i + 1}, CHANGED-code hot-swap)...`)
+    await runBtn.click()
+  }
+  console.log(`[rerun-rapid] last hot-swap done — letting it play ${TAIL_MS}ms`)
+  await page.waitForTimeout(TAIL_MS)
+
+  // Stop Rec by clicking Save (Toolbar replaces Rec with Save when armed)
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  if (await saveBtn.count() > 0) {
+    await saveBtn.click()
+  } else {
+    await recBtn.click()
+  }
+  await page.waitForTimeout(2500)
+
+  const b64 = await page.evaluate(async () => {
+    const blob = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+    if (!blob) return null
+    const buf = await blob.arrayBuffer()
+    const bytes = new Uint8Array(buf)
+    let s = ''
+    const cs = 8192
+    for (let i = 0; i < bytes.length; i += cs) {
+      s += String.fromCharCode(...bytes.subarray(i, Math.min(i + cs, bytes.length)))
+    }
+    return btoa(s)
+  })
+  if (!b64) throw new Error('no WAV blob captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[rerun-track-loss] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s float32 stereo @48k)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  if (await stopBtn.count() > 0) await stopBtn.click()
+  await browser.close()
+
+  // Boundary scan resolution matters here per feedback_boundary_scan_distinguishes_bug_classes
+  // (chunk-RMS would smear rapid swaps together — 200ms resolution separates them).
+  console.log('\n[rerun-rapid] running boundary scan around click moments...\n')
+  // Click moments at t=2 (initial settle) + RAPID_MS, +2*RAPID_MS, +3*RAPID_MS — but
+  // Rec t=0 is at start of Rec, which is right after the first Run completed and we
+  // settled SETTLE_MS. So rapid clicks occur at relative t = RAPID_MS, 2*RAPID_MS, 3*RAPID_MS.
+  const py = spawnSync('python3', [
+    resolve(__dirname, 'analyze-rerun-boundaries.py'),
+    wavPath,
+    String(RAPID_MS / 1000),
+  ], { stdio: 'inherit' })
+  process.exit(py.status ?? 0)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tools/test-slow-inner-fx.ts
+++ b/tools/test-slow-inner-fx.ts
@@ -1,0 +1,156 @@
+/**
+ * SV41 edge case — inner with_fx iter GENUINELY exceeds kill_delay=1.0s.
+ *
+ * Snippet:
+ *   live_loop :a do
+ *     with_fx :echo do
+ *       play 60
+ *       sleep 3   # iter (3s) > kill_delay (1s) → kill SHOULD fire each iter
+ *     end
+ *   end
+ *
+ * With SV41 (virtual-time-scheduled kill via queueMicrotask):
+ *   - Iter k starts at virtualTime=3k. Reuse branch cancels existing killTimer.
+ *   - Iter k finally schedules killTimer at 3k+1.0 (audio time).
+ *   - Iter k+1 starts at virtualTime=3(k+1). Since 3k+1 < 3k+3, the killTimer
+ *     in iter k SHOULD have fired before iter k+1 takes the reuse branch.
+ *   - Net: each iter creates a fresh FX (CREATE branch), runs ~3s, gets killed
+ *     ~1s after iter body ends. Audio: echo decay window for ~1s after each
+ *     `play 60`, then ~2s of silence, repeat.
+ *
+ * If SV41 broken (kill doesn't fire / leaks resources):
+ *   - Old FX nodes accumulate, bus/group/node IDs leak.
+ *   - WAV shows continuous tail (everything still rendering into bus 0).
+ *
+ *   npx tsx tools/test-slow-inner-fx.ts
+ *
+ * Output: .captures/slow-inner-fx/<TRIAL_LABEL>.wav
+ *
+ * Verification:
+ *   1. WAV character: pulse then ~2s near-silence, repeated.
+ *   2. RMS of "silent" windows should be much smaller than RMS at hits.
+ */
+import { chromium } from '@playwright/test'
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const OUT_DIR = resolve(ROOT, '.captures/slow-inner-fx')
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const HEADED = process.argv.includes('--headed')
+const TRIAL_LABEL = process.env.TRIAL_LABEL ?? 'baseline'
+const REC_MS = Number(process.env.REC_MS ?? 14000)
+
+const SNIPPET = `use_bpm 60
+
+live_loop :a do
+  with_fx :echo do
+    play 60, amp: 0.8, release: 0.4
+    sleep 3
+  end
+end
+`
+
+mkdirSync(OUT_DIR, { recursive: true })
+
+async function installWavInterceptor(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    ;(window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob = null
+    const origClick = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __capturedWavBlob: Blob }).__capturedWavBlob = b
+        })
+      } else {
+        origClick.call(this)
+      }
+    }
+  })
+}
+
+async function fetchCapturedWav(page: import('@playwright/test').Page): Promise<Buffer | null> {
+  for (let i = 0; i < 60; i++) {
+    const len = await page.evaluate(async () => {
+      const b = (window as unknown as { __capturedWavBlob: Blob | null }).__capturedWavBlob
+      if (!b) return -1
+      const buf = await b.arrayBuffer()
+      ;(window as unknown as { __wavBytes: Uint8Array }).__wavBytes = new Uint8Array(buf)
+      return buf.byteLength
+    })
+    if (len > 0) {
+      const bytes = await page.evaluate(() => {
+        const u8 = (window as unknown as { __wavBytes: Uint8Array }).__wavBytes
+        return Array.from(u8)
+      })
+      return Buffer.from(bytes)
+    }
+    await page.waitForTimeout(100)
+  }
+  return null
+}
+
+async function main() {
+  console.log('[slow-inner-fx] launching chromium', HEADED ? '(headed)' : '(headless)')
+  const browser = await chromium.launch({ headless: !HEADED })
+  const ctx = await browser.newContext({ permissions: ['microphone'] })
+  const page = await ctx.newPage()
+  page.on('console', m => {
+    const t = m.type()
+    if (t === 'error') console.error(`[console error]`, m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill(SNIPPET)
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  console.log('[slow-inner-fx] Run...')
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(1500)
+
+  await installWavInterceptor(page)
+  const recBtn = page.locator('button').filter({ hasText: 'Rec' }).first()
+  console.log('[slow-inner-fx] click Rec...')
+  await recBtn.click()
+  await page.waitForTimeout(200)
+
+  console.log(`[slow-inner-fx] recording ${REC_MS}ms (~${REC_MS / 3000} iters at 3s/iter)...`)
+  await page.waitForTimeout(REC_MS)
+
+  const saveBtn = page.locator('button').filter({ hasText: 'Save' }).first()
+  console.log('[slow-inner-fx] click Save...')
+  await saveBtn.click()
+
+  const wav = await fetchCapturedWav(page)
+  if (!wav) {
+    console.error('[slow-inner-fx] no WAV captured')
+    process.exit(1)
+  }
+  const wavPath = resolve(OUT_DIR, `${TRIAL_LABEL}.wav`)
+  writeFileSync(wavPath, wav)
+  console.log(`[slow-inner-fx] wrote ${wavPath} (${wav.length} bytes, ~${(wav.length / 4 / 48000).toFixed(1)}s)`)
+
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  await stopBtn.click().catch(() => {})
+
+  await browser.close()
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
Three-part fix for hot-swap audio reliability. End-to-end residual elimination.

**Stacked on #297 (SP85 bus pool fix) — merge that first.**

### SP86 (commits `33ba2bc`, `c58812c`) — loop-based hot-swap reconciliation
- Replace nuclear `freeAllNodes()` on hot-swap with content-addressed scope reconciliation.
- New `bridge.purgePendingBundles()` drains WASM scheduler queue without killing rendering synths.
- Held synths survive Run mid-envelope.
- New invariants: SV39 (reconcile by identity, not nuke), SV40 (purge queue, not running graph).

### SP87 (commit `ccad2b9`) — reusableFx kill_delay race
- `reusableFx` killTimer used `setTimeout` (real-time). SV40 purge exposed iter-pacing dependency: post-purge real-time-paced iters caused killTimer to fire BEFORE next reuse-iter could cancel it. Inner echo on `:arp` was being recreated every ~1.4s.
- Fix: `VirtualTimeScheduler.scheduleAtVirtualTime(audioTime, cb): { cancel }` fires via `queueMicrotask` so iter cancellation always lands before kill body. `ReusableFxState.killTimer` type changed to `{ cancel }`. Stale-existing guard on reuse-branch finally.
- New invariant: SV41 (inner-FX kill_delay must be virtual-time-scheduled).

### SP88 (commit `ccad2b9`) — applyFx nodeId leak (latent, found during SP87 diagnosis)
- `applyFxImmediate` dispatches `/s_new` with the FX synth as a direct child of root group 101, NOT inside the engine's `createFxGroup` container. Orphan teardown's `freeGroup(state.groupId)` was freeing empty containers while FX synths kept rendering.
- Fix: capture nodeId at applyFx, `/n_free` it before `freeGroup` on orphan teardown / kill_delay / hot-swap.
- Was masked pre-SP86 by nuclear `freeAllNodes()` (`/g_freeAll 101` caught everything). SP86 unmasked it; SP87's timing race produced the louder symptom that drowned this out until per-FX-scope RMS instrumentation isolated it.
- New invariant: SV42 (FX synths created via applyFx must be `/n_free`'d explicitly).

### Regression net (commit `556d915`)
- `tools/test-slow-inner-fx.ts` — SV41 edge case where iter genuinely exceeds `kill_delay=1s`. Asserts kill fires and frees cleanly on the slow-iter path.

## WAV verification
- Pre-all-fixes (HEAD `347dfd7`): snare chunks 7–10 = 121–217 (unbounded growth)
- Post-fix (HEAD `ccad2b9`): snare chunks 7–10 = 30–50 (matches no-edit baseline 27–46)
- Per-FX-scope `AnalyserNode` RMS taps confirmed `:arp` outer reverb at baseline post-fix.

## Full regression suite (this PR HEAD `556d915`, run 2026-05-14)
- `tools/test-run-stop-cycle.ts` (10×) — kick/snare stable, no FX accumulation, no bus pool leak
- `tools/test-rerun-rapid-changed.ts` — all tracks survive 15+ rapid hot-swaps
- `tools/test-rerun-track-loss.ts` — VERDICT: no >60% band drop across chunks
- `tools/test-hhc2-sleep-edit.ts` — snare chunks 7–10 = 30.5/35.4/39.0/49.8 ✓
- `tools/test-slow-inner-fx.ts` — 5 iters identical (peak 0.1106, RMS 0.0547), kill fires cleanly
- `npx vitest run` — 929/929 pass
- `npx tsc --noEmit` — clean

## Test plan
- [ ] Reviewer runs `tools/test-hhc2-sleep-edit.ts` and confirms snare 7–10 in [25, 55]
- [ ] Reviewer runs `tools/test-fx-orphan-leak.ts` audibly clean post-hot-swap
- [ ] Reviewer runs `tools/test-rerun-rapid-changed.ts` — all tracks survive
- [ ] Reviewer runs `tools/test-run-stop-cycle.ts` 10× — no degradation
- [ ] 929/929 vitest, tsc clean

Closes #296. Depends on #297 (SP85 bus pool fix — merge first).