### PR TITLE
🐛 fix(fx): remove unshipped :delay and :chorus from FX inventory

### DIFF
--- a/src/app/helpData.ts
+++ b/src/app/helpData.ts
@@ -799,7 +799,6 @@ const SYNTH_DESCRIPTIONS: Record<string, string> = {
 const FX_DESCRIPTIONS: Record<string, string> = {
   reverb: 'Room reverb — adds space and depth.',
   echo: 'Echo/delay with feedback and decay.',
-  delay: 'Simple delay line.',
   distortion: 'Waveshaping distortion — gritty, overdriven.',
   slicer: 'Amplitude slicer — rhythmic gating.',
   wobble: 'Wobble bass filter — LFO-controlled cutoff.',
@@ -816,7 +815,6 @@ const FX_DESCRIPTIONS: Record<string, string> = {
   krush: 'Lo-fi crusher with filter.',
   bitcrusher: 'Bit depth and sample rate reducer.',
   ring_mod: 'Ring modulation — metallic, bell-like.',
-  chorus: 'Chorus — thickens with modulated delay.',
   octaver: 'Octave doubler — adds sub and super octaves.',
   vowel: 'Vowel formant filter.',
   tanh: 'Hyperbolic tangent distortion — warm saturation.',

--- a/src/engine/FriendlyErrors.ts
+++ b/src/engine/FriendlyErrors.ts
@@ -36,11 +36,15 @@ export const KNOWN_SAMPLES = [
   'perc_bell', 'perc_snap', 'perc_swoosh',
 ]
 
+// `delay` and `chorus` omitted — not shipped in the SuperSonic CDN package
+// (verified 404 across v0.57.0–v0.66.0). See FxNames.ts ALL_FX_NAMES for the
+// canonical list and rationale. Suggesting these names to a user with a typo
+// would lead them to a "FX not found" failure at /s_new dispatch (issue #301).
 export const KNOWN_FX = [
-  'reverb', 'echo', 'delay', 'distortion', 'slicer',
+  'reverb', 'echo', 'distortion', 'slicer',
   'wobble', 'ixi_techno', 'compressor', 'rlpf', 'rhpf',
   'hpf', 'lpf', 'normaliser', 'pan', 'band_eq',
-  'flanger', 'krush', 'bitcrusher', 'ring_mod', 'chorus',
+  'flanger', 'krush', 'bitcrusher', 'ring_mod',
   'octaver', 'vowel', 'tanh', 'gverb', 'pitch_shift',
   'whammy', 'tremolo', 'record', 'sound_out', 'sound_out_stereo',
   'level', 'mono', 'autotuner',

--- a/src/engine/FxNames.ts
+++ b/src/engine/FxNames.ts
@@ -10,10 +10,21 @@
  * (`SonicPiEngine.ts:fx_names_fn`) AND the bridge preloader. Adding an FX here
  * makes it both queryable AND eagerly loaded on engine init.
  */
+// NOTE on omissions (issue #301):
+// `delay` and `chorus` exist in desktop Sonic Pi's synthinfo.rb FX classes
+// but are NOT shipped in the `supersonic-scsynth-synthdefs` CDN package —
+// verified 404 across versions 0.57.0 through 0.66.0 (latest). Including them
+// here would make `with_fx :delay` / `with_fx :chorus` fail at /s_new dispatch
+// with a 404 + CORS console error and silent FX skip. Until the upstream
+// package ships them:
+//   - users wanting delay should use `:echo` (similar character, different params)
+//   - users wanting chorus can approximate via `:flanger` or `:ring_mod`
+// FriendlyErrors.KNOWN_FX is kept in sync (same omissions) so the
+// "did-you-mean" suggester won't recommend names that won't resolve.
 export const ALL_FX_NAMES: readonly string[] = [
-  'reverb','echo','delay','distortion','slicer','wobble','ixi_techno',
+  'reverb','echo','distortion','slicer','wobble','ixi_techno',
   'compressor','rlpf','rhpf','hpf','lpf','normaliser','pan','band_eq',
-  'flanger','krush','bitcrusher','ring_mod','chorus','octaver','vowel',
+  'flanger','krush','bitcrusher','ring_mod','octaver','vowel',
   'tanh','gverb','pitch_shift','whammy','tremolo','level','mono',
   'ping_pong','panslicer',
   // Filter variants — from synthinfo.rb FX classes


### PR DESCRIPTION
## Summary

Closes #301. Removes `:delay` and `:chorus` from our FX inventory because the upstream `supersonic-scsynth-synthdefs` package does not actually ship those synthdef binaries.

## Investigation

Tested every FX in `ALL_FX_NAMES` against the CDN. 29 of 31 return 200; only these two return 404:

```
fx_delay:  404
fx_chorus: 404
```

Verified across **all** package versions from 0.57.0 (current pin) through 0.66.0 (latest). These FX have **never** been shipped on this CDN.

The "CORS error" framing in #301 was misleading — Cloudflare serves 404 pages without `Access-Control-Allow-Origin` headers, so the browser surfaces `CORS policy` rather than `HTTP 404`. Same outcome: silent FX-load failure.

## Why removal (not preserve)

A user typing `with_fx :delay do ... end`:
- **Before:** console flooded with CORS errors, FX silently no-ops, audio passes through dry — user can't tell what's wrong
- **After (with this PR):** the FX isn't in `KNOWN_FX` so the friendly-errors layer correctly reports "FX `:delay` not found. Did you mean `:echo`?"

For users who want delay/chorus functionality:
- `:delay` → use `:echo` (similar character, different params)
- `:chorus` → approximate via `:flanger` or `:ring_mod`

## Files changed

| File | Change |
|---|---|
| `src/engine/FxNames.ts` | Remove `delay`+`chorus` from `ALL_FX_NAMES`; add comment with rationale |
| `src/engine/FriendlyErrors.ts` | Remove from `KNOWN_FX` (did-you-mean suggester) |
| `src/app/helpData.ts` | Remove from `FX_DESCRIPTIONS` (help panel + autocomplete) |

3 files, +19/-6 lines.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **929/929 pass**. The one test using `with_fx('delay', ...)` is in `QueryInterpreter.test.ts` which only exercises the JS-side `ProgramBuilder` timing query (no scsynth round-trip) — the FX name string is opaque to it.
- [ ] Manual: open app, click Run on default welcome — no CORS errors for fx_delay/fx_chorus in console
- [ ] Manual: type `with_fx :delay do play 60 end` + Run — friendly error suggests `:echo`

## Follow-up (out of scope for this PR)

File an upstream issue at samaaron/supersonic asking for `fx_delay` and `fx_chorus` to be added to the synthdefs package. When they ship, revert this PR and add them back. The `SV25` invariant (Public DSL Inventory Verified Against Upstream) recommends auditing on each version bump.