### PR TITLE
🔗 Share a track via permalink (#306)

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -17,6 +17,7 @@ import { CueLog } from './CueLog'
 import { SampleBrowser } from './SampleBrowser'
 import { HelpPanel } from './HelpPanel'
 import { APP_VERSION } from './version'
+import { decodeShareCode, buildShareURL } from './ShareLink'
 import { theme } from './theme'
 import { track, EVENTS, errorClass, detectBrowserFamily } from './Analytics'
 
@@ -469,6 +470,18 @@ export class App {
 
   /** Load buffers from localStorage, falling back to welcome code. */
   private loadBuffers(): void {
+    // A share link takes precedence over everything: you clicked someone's
+    // permalink, you want their track — not your stale localStorage buffer.
+    // Strip the hash afterwards so a refresh / unload-save behaves normally
+    // (the shared code is now just the active buffer).
+    const shared = decodeShareCode()
+    if (shared !== null) {
+      this.buffers[0] = shared
+      try {
+        history.replaceState(null, '', location.pathname + location.search)
+      } catch { /* history API unavailable — harmless, hash just lingers */ }
+      return
+    }
     try {
       const saved = localStorage.getItem('spw-buffers')
       if (saved) {
@@ -583,6 +596,7 @@ export class App {
       onFontSizeChange: (delta) => this.editor.changeFontSize(delta),
       onSave: () => this.handleSave(),
       onLoad: () => this.handleLoad(),
+      onShare: () => this.handleShare(),
       onZen: () => this.toggleZen(),
     })
 
@@ -1222,6 +1236,41 @@ export class App {
       this.console.logSystem(`  Loaded: ${file.name}`)
     }
     input.click()
+  }
+
+  private async handleShare(): Promise<void> {
+    const url = buildShareURL(this.editor.getValue())
+    let copied = false
+    try {
+      await navigator.clipboard.writeText(url)
+      copied = true
+    } catch {
+      // Clipboard blocked (insecure context / permission). Fall back to a
+      // prompt so the link is still recoverable — never silently fail.
+      try { window.prompt('Copy this share link:', url) } catch { /* headless */ }
+    }
+    this.console.logSystem(copied ? '  Share link copied to clipboard.' : '  Share link ready.')
+    this.flashToast(copied ? 'Share link copied' : 'Share link ready')
+  }
+
+  /** Transient bottom-center toast — feedback when the Console panel is hidden. */
+  private flashToast(msg: string): void {
+    const el = document.createElement('div')
+    el.textContent = msg
+    el.style.cssText = `
+      position: fixed; left: 50%; bottom: 2.5rem; transform: translateX(-50%);
+      background: ${theme.bgDark}; color: ${theme.fg};
+      border: 1px solid ${theme.comment}; border-radius: 6px;
+      padding: 0.5rem 1rem; font-size: 0.8rem; font-family: inherit;
+      z-index: 99999; pointer-events: none; opacity: 0;
+      transition: opacity 0.15s;
+    `
+    this.root.appendChild(el)
+    requestAnimationFrame(() => { el.style.opacity = '1' })
+    setTimeout(() => {
+      el.style.opacity = '0'
+      setTimeout(() => el.remove(), 200)
+    }, 1800)
   }
 
   private toggleZen(): void {

--- a/src/app/ShareLink.ts
+++ b/src/app/ShareLink.ts
@@ -1,0 +1,72 @@
+/**
+ * Share-link (permalink) encoding for the editor buffer.
+ *
+ * Option B from issue #306: encode the track into the URL fragment so a
+ * single link fully reconstructs it. No backend, no dependencies — the
+ * code rides in the hash as UTF-8-safe base64url.
+ *
+ * The fragment key is versioned (`c=` → "code, v1"). Future formats
+ * (compressed, multi-buffer) can claim a new key without breaking old
+ * links: `decodeShareCode` simply returns null for keys it does not know.
+ */
+
+/** Fragment key: `#c=<base64url>`. `c` = code, version 1. */
+const PREFIX = 'c='
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  // Chunked to keep String.fromCharCode under the argument-count / stack
+  // limit for large buffers (a few KB of live-coding code is well within,
+  // but a paste of a long track must not throw).
+  let bin = ''
+  const CHUNK = 0x8000
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK))
+  }
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlToBytes(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = b64.length % 4 === 0 ? '' : '='.repeat(4 - (b64.length % 4))
+  const bin = atob(b64 + pad)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+/** Encode code into a URL fragment (including the leading `#`). */
+export function encodeShareCode(code: string): string {
+  const bytes = new TextEncoder().encode(code)
+  return '#' + PREFIX + bytesToBase64Url(bytes)
+}
+
+/**
+ * Build a full shareable URL. `base` defaults to the current
+ * origin+pathname (query and old hash dropped — a share link is a clean
+ * entry point, not the sharer's exact view).
+ */
+export function buildShareURL(code: string, base?: string): string {
+  const origin =
+    base ?? (typeof location !== 'undefined' ? location.origin + location.pathname : '')
+  return origin + encodeShareCode(code)
+}
+
+/**
+ * Decode a share fragment back to code. Returns null when there is no
+ * share payload or it is malformed — callers fall back to their normal
+ * load path (localStorage / welcome).
+ */
+export function decodeShareCode(hash?: string): string | null {
+  const h = (hash ?? (typeof location !== 'undefined' ? location.hash : '')) || ''
+  const raw = h.startsWith('#') ? h.slice(1) : h
+  // A missing `c=` key means "no share payload" (null → caller falls back).
+  // A present-but-empty payload (`#c=`) is a legitimately shared empty
+  // buffer and must round-trip to '' — do not collapse it to null.
+  if (!raw.startsWith(PREFIX)) return null
+  const payload = raw.slice(PREFIX.length)
+  try {
+    return new TextDecoder().decode(base64UrlToBytes(payload))
+  } catch {
+    return null
+  }
+}

--- a/src/app/Toolbar.ts
+++ b/src/app/Toolbar.ts
@@ -27,6 +27,7 @@ export interface ToolbarCallbacks {
   onFontSizeChange?: (delta: number) => void
   onSave?: () => void
   onLoad?: () => void
+  onShare?: () => void
   onZen?: () => void
 }
 
@@ -113,6 +114,16 @@ export class Toolbar {
     loadBtn.title = 'Load file into buffer'
     loadBtn.style.opacity = '0.7'
     topRow.appendChild(loadBtn)
+
+    // Share button — copy a permalink that reconstructs the current buffer
+    const shareBtn = this.iconButton(
+      '\u{1F517}', 'Share',
+      () => this.callbacks.onShare?.(),
+      { bg: theme.comment, hover: theme.fgMuted }
+    )
+    shareBtn.title = 'Copy a shareable link to this track'
+    shareBtn.style.opacity = '0.7'
+    topRow.appendChild(shareBtn)
 
     topRow.appendChild(this.separator())
 

--- a/src/app/__tests__/ShareLink.test.ts
+++ b/src/app/__tests__/ShareLink.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { encodeShareCode, decodeShareCode, buildShareURL } from '../ShareLink'
+
+describe('ShareLink', () => {
+  const roundtrip = (code: string) => decodeShareCode(encodeShareCode(code))
+
+  it('round-trips plain ASCII code', () => {
+    const code = 'live_loop :drums do\n  sample :bd_haus\n  sleep 1\nend'
+    expect(roundtrip(code)).toBe(code)
+  })
+
+  it('round-trips unicode and emoji', () => {
+    const code = '# ♯ こんにちは 🎹🥁\nuse_synth :prophet'
+    expect(roundtrip(code)).toBe(code)
+  })
+
+  it('round-trips empty string', () => {
+    expect(roundtrip('')).toBe('')
+  })
+
+  it('round-trips a large buffer (~12KB)', () => {
+    const code = 'play 60\nsleep 0.25\n'.repeat(700)
+    expect(roundtrip(code)).toBe(code)
+  })
+
+  it('produces a url-safe fragment (no +, /, =, or spaces)', () => {
+    const frag = encodeShareCode('a/b+c=d e\nf?g#h')
+    expect(frag.startsWith('#c=')).toBe(true)
+    // The base64url payload (after the `#c=` key) must be url-safe.
+    expect(frag.slice(3)).not.toMatch(/[+/= ]/)
+  })
+
+  it('returns null when the c= key is absent', () => {
+    expect(decodeShareCode('')).toBeNull()
+    expect(decodeShareCode('#')).toBeNull()
+    expect(decodeShareCode('#foo=bar')).toBeNull()
+  })
+
+  it('treats #c= (key present, empty payload) as a shared empty buffer', () => {
+    expect(decodeShareCode('#c=')).toBe('')
+    expect(decodeShareCode(encodeShareCode(''))).toBe('')
+  })
+
+  it('returns null for a malformed payload instead of throwing', () => {
+    expect(decodeShareCode('#c=@@@not base64@@@')).toBeNull()
+  })
+
+  it('accepts the fragment with or without a leading #', () => {
+    const frag = encodeShareCode('hi')
+    expect(decodeShareCode(frag)).toBe('hi')
+    expect(decodeShareCode(frag.slice(1))).toBe('hi')
+  })
+
+  it('buildShareURL appends the fragment to an explicit base', () => {
+    const url = buildShareURL('play 72', 'https://sonicpi.cc/')
+    expect(url).toBe('https://sonicpi.cc/' + encodeShareCode('play 72'))
+    expect(decodeShareCode(new URL(url).hash)).toBe('play 72')
+  })
+})

--- a/tools/observe-share-link.ts
+++ b/tools/observe-share-link.ts
@@ -1,0 +1,67 @@
+/**
+ * Level-3 observation for the share-permalink feature (#306).
+ *
+ * Tests + tsc are inference ("the code I expected ran"). This loads a
+ * REAL browser and observes what actually happens:
+ *   1. Navigate to BASE_URL#c=<encoded>  → CodeMirror shows the decoded code.
+ *   2. Click Share with fresh code        → clipboard holds a URL that
+ *                                            decodes back to that code.
+ *
+ * Usage: npm run dev (other terminal), then `npx tsx tools/observe-share-link.ts`
+ */
+import { chromium } from '@playwright/test'
+import { encodeShareCode, decodeShareCode } from '../src/app/ShareLink'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const SHARED = 'live_loop :obs do\n  sample :bd_haus\n  sleep 0.5\nend  # ♯🎹 #306'
+const TYPED = 'play 72\nsleep 0.25\nplay 76  # share-button observation'
+
+let failed = false
+const ok = (label: string, cond: boolean, detail = '') => {
+  console.log(`${cond ? '[PASS]' : '[FAIL]'} ${label}${detail ? ' — ' + detail : ''}`)
+  if (!cond) failed = true
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true })
+  const ctx = await browser.newContext({ permissions: ['clipboard-read', 'clipboard-write'] })
+  const page = await ctx.newPage()
+
+  // --- 1. Inbound: a share URL reconstructs the buffer ---
+  await page.goto(BASE_URL + encodeShareCode(SHARED))
+  await page.waitForSelector('.cm-content', { timeout: 15000 })
+  await page.waitForTimeout(800)
+  const shown = (await page.locator('.cm-content').first().innerText()).replace(/ /g, ' ')
+  // CodeMirror may soft-wrap/strip; compare on a distinctive line.
+  ok('share URL populates editor', shown.includes('live_loop :obs do'), JSON.stringify(shown.slice(0, 60)))
+  ok('unicode survived round-trip', shown.includes('♯') && shown.includes('🎹'))
+
+  // Hash must be stripped so refresh/persistence behave normally.
+  const hashAfter = await page.evaluate(() => location.hash)
+  ok('hash stripped after load', hashAfter === '', `hash=${JSON.stringify(hashAfter)}`)
+
+  // --- 2. Outbound: Share button copies a working link ---
+  const editor = page.locator('.cm-content').first()
+  await editor.click()
+  await page.keyboard.press('Meta+A')
+  await page.keyboard.press('Backspace')
+  await editor.fill(TYPED)
+  await page.waitForTimeout(200)
+
+  await page.locator('.spw-btn-label:has-text("Share")').click()
+  await page.waitForTimeout(300)
+
+  const clip = await page.evaluate(() => navigator.clipboard.readText())
+  const decoded = clip ? decodeShareCode(new URL(clip).hash) : null
+  ok('Share button copied a URL', !!clip && clip.includes('#c='), clip.slice(0, 50))
+  ok('copied link decodes to typed code', decoded === TYPED, JSON.stringify(decoded))
+
+  const toastVisible = await page.locator('text=Share link copied').count()
+  ok('toast shown', toastVisible > 0)
+
+  await browser.close()
+  console.log(failed ? '\nOBSERVATION FAILED' : '\nOBSERVATION CLEAN')
+  process.exit(failed ? 1 : 0)
+}
+
+main().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
Closes #306.

## Problem
No way to share a Sonic Pi Web track. The engine ships an unwired `CollaborationSession` but there's no snapshot/permalink path — write a track, and there's no "copy link".

## Solution (Option B — no backend, no deps)
- **`src/app/ShareLink.ts`** — pure `encodeShareCode`/`decodeShareCode`/`buildShareURL`. UTF-8-safe base64url under a versioned `#c=` key (chunked to survive large pastes).
- **`App.loadBuffers`** — a share link takes precedence over localStorage (you clicked someone's link, you want their track), then the hash is stripped via `history.replaceState` so refresh/unload-save behave normally.
- **Toolbar** — 🔗 Share button next to Save/Load: builds the URL, copies to clipboard (`window.prompt` fallback when clipboard is blocked — never silently fails), transient toast feedback.

**Contract decision:** `#c=` (key present, empty payload) round-trips to `''` — a deliberately shared empty buffer. Only a *missing* `c=` key or malformed base64 returns `null` (caller falls back to localStorage/welcome). This keeps the encode→decode round-trip invariant total.

## Out of scope (future)
LZ compression / paste backend for very long buffers; live co-editing (Option A — `CollaborationSession` wiring).

## Test plan
- **Verify:** 10 `ShareLink` unit tests (ASCII, unicode/emoji, empty, ~12KB, malformed → null, url-safety, leading-# tolerance, explicit base). `939/939` vitest, `tsc --noEmit` clean.
- **Observe (Level 3):** `tools/observe-share-link.ts` drives real Chromium — confirms a `#c=` URL reconstructs the buffer (unicode intact), the hash is stripped, and the Share button copies a link that decodes back to the typed code + toast shows. All 6 observations PASS.

## Self-review (next pass)
Will audit: clipboard-permission UX on insecure origins, very-long-URL behavior vs browser limits, interaction with the 10-buffer system (currently only buffer 0 is shared), and whether the stripped-hash precedence surprises users who *want* to keep editing then reshare.