### PR TITLE
📝 docs(roadmap): Tutorial system port EPIC #309 (T0–T5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,6 +104,17 @@ These features are wired and Level-2 verified (events, logs, WAV-free E2E tests)
 - [ ] WebSocket-to-UDP bridge (bundled option, not just hook)
 - [ ] `sync "/osc/..."` path delivery via WebSocket
 
+### Tutorial system port (EPIC #309)
+
+Port the ~90-chapter Desktop Sonic Pi tutorial as a first-class web subsystem — the largest remaining parity item (~98% target, lifts help coverage 311 → ~600 entries). Standalone `TutorialPanel` + structured corpus + ingest/validation tooling; `HelpPanel` (per-symbol reference) stays separate, mirroring desktop's dedicated tutorial pane. Dependency order: **T0 → T1 → {T2 → T3, T4} → T5** (~6.5 wk).
+
+- [ ] **T0 — license & source gate (#310) — 🚧 BLOCKING: T1–T5 do not start until T0 closes GO**
+- [ ] T1 — ingest pipeline + data model (#311)
+- [ ] T2 — code-block validation gate, Level 2/3 (#312)
+- [ ] T3 — web-adaptation overlay + "What's different from Desktop SP" chapter (#313)
+- [ ] T4 — TutorialPanel UI (#314)
+- [ ] T5 — polish (lazy-load, assets, search) + Level-3 observation (#315)
+
 ### Collaboration
 - [ ] Ableton Link via WebRTC DataChannel
 - [ ] Collaborative live coding (CRDT sync via Yjs + WebRTC)


### PR DESCRIPTION
Files the **Tutorial system port** roadmap item as actionable work.

## What this does
- Records the EPIC under `ROADMAP.md` v1.6.0 with the T0–T5 phased breakdown and dependency order.
- Companion to **EPIC #309** + child issues **#310–#315** (no code — planning/tracking only).

## Why
`artifacts/roadmap.md:212` had the tutorial port as a single table cell ("weeks / ~98% / 50+ chapter content + UI") with no breakdown. It's the largest remaining parity gap and biggest discoverability lever (`roadmap.md:154`: currently "1 welcome buffer only"; `:21`: 311 → ~600 help entries).

## Structure
- **T0 #310 — license & source gate — 🚧 BLOCKING.** Sonic Pi tutorial prose is CC-BY-SA in a GPLv3 repo; this is a separate package. Nothing proceeds until license/compliance/scope are resolved with a GO.
- T1 #311 ingest + data model · T2 #312 code-block validation (L2/L3) · T3 #313 web-adaptation overlay + "What's different" chapter (`roadmap.md:333`) · T4 #314 TutorialPanel UI · T5 #315 polish + Level-3 observation.
- Dependency order: **T0 → T1 → {T2 → T3, T4} → T5** (~6.5 wk → ~98% parity).

## Architecture intent (per CLAUDE.md "match the reference")
Standalone `TutorialPanel` + structured corpus, separate from `HelpPanel` (per-symbol reference) — mirrors desktop SP's dedicated tutorial pane rather than bolting chapters into the symbol-lookup panel.

Docs-only; no behavior change. Not for merge until you've reviewed the epic scope (notably the full ~90-chapter vs. curated-essentials decision deferred to T0).