### PR TITLE
🐛 fix(engine): clear pendingSampleLoads on reject, not only on resolve — closes #304

### DIFF
--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -585,10 +585,24 @@ export class SuperSonicBridge {
     const bufNum = this.nextBufNum++
     const p = this.sonic.loadSample(bufNum, `${name}.flac`).then(() => {
       this.loadedSamples.set(name, bufNum)
-      this.pendingSampleLoads.delete(name)
       this.fetchSampleDuration(name).catch(err =>
         console.warn(`[SonicPi] Could not determine duration for ${name}: ${err.message}`))
       return bufNum
+    }).finally(() => {
+      // SV43: clear the in-flight dedup entry whether the load RESOLVES OR
+      // REJECTS. The old code deleted only inside .then(), so a failed load
+      // (CORS/404 for a typo'd name, or `sample :user_x` before
+      // registerCustomSample) left a permanently-rejecting promise cached
+      // here — every later sample :name returned that rejection and was
+      // silent forever, no error surfaced (SP90 / #304). Clearing on reject
+      // lets a later retry (typo fixed, or sample now registered) re-attempt
+      // the load instead of replaying the dead rejection.
+      //
+      // The consumed bufNum is intentionally NOT recycled on reject: this
+      // matches the existing freeSample design decision (~line 1142) — slot
+      // recycling would require ref-tracking, and the cost of a skipped int
+      // on a failed load is the same accepted one-int cost.
+      this.pendingSampleLoads.delete(name)
     })
     this.pendingSampleLoads.set(name, p)
     return p

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -144,6 +144,33 @@ describe('SuperSonicBridge', () => {
     expect(bundleStr).toContain('sonic-pi-basic_stereo_player')
   })
 
+  it('SV43: a rejected sample load does not poison subsequent retries (SP90 / #304)', async () => {
+    const { mockSonic } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    // First load rejects — CORS/404 for a typo'd name, or `sample :user_x`
+    // used before registerCustomSample. Every subsequent load resolves
+    // (user fixed the typo, or the sample is now registered).
+    mockSonic.loadSample.mockReset()
+    mockSonic.loadSample
+      .mockRejectedValueOnce(new Error('CORS/404'))
+      .mockResolvedValue(undefined)
+
+    // The failed load must SURFACE as an error, not resolve silently.
+    await expect(bridge.preloadSample('user_typo')).rejects.toThrow()
+
+    // Pre-fix (delete only in .then()): pendingSampleLoads still holds the
+    // rejected promise, so this returns the cached rejection and loadSample
+    // is never called again — silent forever. Post-fix (.finally clears the
+    // entry): the retry re-attempts the load and succeeds.
+    const buf = await bridge.preloadSample('user_typo')
+    expect(typeof buf).toBe('number')
+    expect(mockSonic.loadSample).toHaveBeenCalledTimes(2)
+  })
+
   it('caches loaded SynthDefs', async () => {
     const { mockSonic } = createMockSuperSonic()
     ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)


### PR DESCRIPTION
## Problem

`ensureSampleLoaded` (`SuperSonicBridge.ts`) deleted the `pendingSampleLoads` dedup entry **only inside `.then()`**. When `loadSample` *rejects* — a CORS/404 for any name not in the CDN package (a user typo, or `sample :user_x` used before `registerCustomSample`) — the rejected promise stayed cached under that name **forever**. Every later `sample :name` that reached the pending check returned that cached rejection: the sample was **silent permanently, with no error surfaced** (SP90 / SV43).

#304's documented `rms=0.0002` numeric symptom was a **stale test-ordering artifact** (same class as #302) — it does not reproduce; the committed `tools/test-custom-sample-workflow.ts` passes 5/5. The real defect is this latent reject-leak, found by source-grounding the boundary, not by chasing the issue narrative (whose hypotheses 1–4 about teardown/hot-swap were wrong).

## Fix

Move `pendingSampleLoads.delete(name)` into a `.finally()` so the in-flight entry clears whether the load **resolves OR rejects**. A later retry (typo fixed, or sample now registered) re-attempts the load instead of replaying the dead rejection, and the failed load now surfaces as an error instead of silence.

The consumed `bufNum` is intentionally **not** recycled on reject — consistent with the existing `freeSample` design decision (`SuperSonicBridge.ts` ~:1142): slot recycling needs ref-tracking, and a skipped int on a failed load is the same accepted one-int cost already documented there.

## Test plan / observation

- New unit test `SuperSonicBridge.test.ts` → *"SV43: a rejected sample load does not poison subsequent retries"*. **Verified as a real detector:** `git stash` the source fix → the test **fails**; restore → it **passes**.
- `npx vitest run` → **940/940** green (was 939, +1). `npx tsc --noEmit` clean.
- This bug is **structurally invisible to WAV/Level-3** (the symptom is the *absence* of a never-loaded sound, and the rms harness's `registerCustomSample` masks the poisoned entry). The unit test at the `ensureSampleLoaded` level is the correct observation surface — called out explicitly so this isn't read as skipping the audio gate.

## Known gap (not in this PR, by design)

`ensureSynthDefLoaded` / `pendingSynthDefLoads` has the **identical** `.then()`-only delete — same silent-load shape as SP89. Left out to keep this PR's surface minimal; captured in `vyapti.md` SV43 and folded into the proposed pre-Run component-load preflight follow-up.

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)