### PR TITLE
🐛 fix(app): a shared empty buffer opens blank, not the welcome track — closes #308

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -17,7 +17,7 @@ import { CueLog } from './CueLog'
 import { SampleBrowser } from './SampleBrowser'
 import { HelpPanel } from './HelpPanel'
 import { APP_VERSION } from './version'
-import { decodeShareCode, buildShareURL } from './ShareLink'
+import { decodeShareCode, buildShareURL, pickInitialBuffer } from './ShareLink'
 import { theme } from './theme'
 import { track, EVENTS, errorClass, detectBrowserFamily } from './Analytics'
 
@@ -349,6 +349,11 @@ export class App {
   // Buffer management — 10 buffers like Sonic Pi
   private buffers: string[] = Array(BUFFER_COUNT).fill('')
   private activeBuffer = 0
+  /** True when buffer[0] came from a share link (incl. an intentionally
+   *  empty `#c=` payload). Lets init() honor a shared blank buffer instead
+   *  of falling through `|| WELCOME_CODE`. Contract: ShareLink round-trips
+   *  '' → '' (#306/#308). */
+  private loadedFromShare = false
   private eventStreamHandler: ((event: unknown) => void) | null = null
   private recorder: Recorder | null = null
   private isRecording = false
@@ -477,6 +482,7 @@ export class App {
     const shared = decodeShareCode()
     if (shared !== null) {
       this.buffers[0] = shared
+      this.loadedFromShare = true
       try {
         history.replaceState(null, '', location.pathname + location.search)
       } catch { /* history API unavailable — harmless, hash just lingers */ }
@@ -515,7 +521,9 @@ export class App {
   }
 
   async init(): Promise<void> {
-    await this.editor.init(this.buffers[0] || WELCOME_CODE)
+    await this.editor.init(
+      pickInitialBuffer(this.buffers[0], this.loadedFromShare, WELCOME_CODE),
+    )
     this.editor.onRun(() => this.handlePlay())
     this.editor.onStop(() => this.handleStop())
     this.editor.onZen(() => this.toggleZen())

--- a/src/app/ShareLink.ts
+++ b/src/app/ShareLink.ts
@@ -52,6 +52,29 @@ export function buildShareURL(code: string, base?: string): string {
 }
 
 /**
+ * Choose what the editor should open with, given the (already-decoded)
+ * first buffer and whether it came from a share link.
+ *
+ * This is the consumer side of the `#c=` → `''` round-trip contract: a
+ * shared buffer — *including an intentionally empty one* — must open
+ * verbatim. Only the non-share path may fall through to the welcome
+ * track. Kept here (not inlined in App) because the empty-buffer
+ * invariant spans encode → decode → this selection: one auditable place
+ * for the whole contract (#306 / #308).
+ *
+ * The bug this guards: `'' || welcome` is truthy-falsy, so an inline
+ * `buffer || welcome` silently replaces a shared blank track with the
+ * welcome code, contradicting `decodeShareCode('#c=') === ''`.
+ */
+export function pickInitialBuffer(
+  buffer: string,
+  fromShare: boolean,
+  welcome: string,
+): string {
+  return fromShare ? buffer : buffer || welcome
+}
+
+/**
  * Decode a share fragment back to code. Returns null when there is no
  * share payload or it is malformed — callers fall back to their normal
  * load path (localStorage / welcome).

--- a/src/app/__tests__/ShareLink.test.ts
+++ b/src/app/__tests__/ShareLink.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { encodeShareCode, decodeShareCode, buildShareURL } from '../ShareLink'
+import {
+  encodeShareCode,
+  decodeShareCode,
+  buildShareURL,
+  pickInitialBuffer,
+} from '../ShareLink'
 
 describe('ShareLink', () => {
   const roundtrip = (code: string) => decodeShareCode(encodeShareCode(code))
@@ -55,5 +60,32 @@ describe('ShareLink', () => {
     const url = buildShareURL('play 72', 'https://sonicpi.cc/')
     expect(url).toBe('https://sonicpi.cc/' + encodeShareCode('play 72'))
     expect(decodeShareCode(new URL(url).hash)).toBe('play 72')
+  })
+
+  describe('pickInitialBuffer (#308)', () => {
+    const WELCOME = '# welcome track'
+
+    it('a shared EMPTY buffer opens blank, NOT the welcome track', () => {
+      // The whole point of #308: '' || WELCOME would wrongly pick WELCOME.
+      expect(pickInitialBuffer('', true, WELCOME)).toBe('')
+    })
+
+    it('a shared non-empty buffer opens verbatim', () => {
+      expect(pickInitialBuffer('play 60', true, WELCOME)).toBe('play 60')
+    })
+
+    it('non-share empty first run falls through to the welcome track', () => {
+      expect(pickInitialBuffer('', false, WELCOME)).toBe(WELCOME)
+    })
+
+    it('non-share restored buffer opens verbatim (no welcome override)', () => {
+      expect(pickInitialBuffer('live_loop :a {}', false, WELCOME)).toBe('live_loop :a {}')
+    })
+
+    it('round-trips an empty share through decode → pick', () => {
+      const shared = decodeShareCode('#c=')
+      expect(shared).toBe('')
+      expect(pickInitialBuffer(shared as string, shared !== null, WELCOME)).toBe('')
+    })
   })
 })


### PR DESCRIPTION
Follow-up from #306 / PR #307 self-review.

## Problem

`ShareLink` deliberately round-trips `#c=` (empty payload) to `''` — a shared empty buffer (`decodeShareCode('#c=') === ''`, tested since #307). But `App.init` did:

```ts
await this.editor.init(this.buffers[0] || WELCOME_CODE)
```

`'' || WELCOME_CODE` is truthy-falsy → an intentionally-shared empty track rendered the welcome code instead of a blank editor. The `ShareLink` contract and the `App` behavior disagreed at the consumer side. P4 (degenerate, but a tracked contract inconsistency).

## Fix

Extract the selection into a pure, exported **`pickInitialBuffer(buffer, fromShare, welcome)`** in `ShareLink.ts` — the module that already owns and tests the `''` round-trip contract. The empty-buffer invariant spans encode → decode → selection, so it belongs in one auditable place rather than inlined in `App` (domain-aligned boundary, not smallest diff).

`loadBuffers` sets a `loadedFromShare` flag when a share payload is present; `init` passes it to `pickInitialBuffer`, so a shared buffer (including an empty one) opens verbatim and **only the non-share path** falls through to `WELCOME_CODE`. Non-share localStorage/empty behavior is unchanged.

## Test plan / observation

- 5 new unit tests under `ShareLink.test.ts` → `pickInitialBuffer (#308)`, including the `decodeShareCode('#c=') → '' → pickInitialBuffer` round-trip.
- **Verified as real detectors:** simulating the original bug (`return buffer || welcome`) fails exactly the 2 contract tests; restored → all pass.
- `npx vitest run` → **945/945** (was 940, +5). `npx tsc --noEmit` clean.
- No audio surface (editor-content selection only) — the pure-function + round-trip test is the correct observation level; called out so it isn't read as skipping the WAV gate.

Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)