### PR TITLE
🐛 fix(engine): clear pendingSynthDefLoads on reject — SV43 synthdef twin — closes #320

### DIFF
--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -569,6 +569,16 @@ export class SuperSonicBridge {
     if (!this.sonic) throw new Error('SuperSonic not initialized')
     const p = this.sonic.loadSynthDef(fullName).then(() => {
       this.loadedSynthDefs.add(fullName)
+    }).finally(() => {
+      // SV43 (synthdef twin of the #317 sample fix): clear the in-flight
+      // dedup entry whether the load RESOLVES OR REJECTS. The old code
+      // deleted only inside .then(), so a failed synthdef load (SP89-class:
+      // an inventory name the CDN package never shipped, or a transient
+      // fetch failure) left a permanently-rejecting promise cached here —
+      // every later ensureSynthDefLoaded(name) returned that rejection and
+      // the synth/FX was silent forever, no error. Clearing on reject lets
+      // a later retry re-attempt the load instead of replaying the dead
+      // rejection (and unblocks the #318 preflight resolver).
       this.pendingSynthDefLoads.delete(fullName)
     })
     this.pendingSynthDefLoads.set(fullName, p)

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -171,6 +171,32 @@ describe('SuperSonicBridge', () => {
     expect(mockSonic.loadSample).toHaveBeenCalledTimes(2)
   })
 
+  it('SV43 twin: a rejected synthdef load does not poison subsequent retries (#318.4)', async () => {
+    const { mockSonic } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    // First synthdef load rejects — SP89-class: an inventory name the CDN
+    // package never shipped, or a transient fetch failure. Subsequent loads
+    // resolve (transient recovered, or a retry path).
+    mockSonic.loadSynthDef.mockReset()
+    mockSonic.loadSynthDef
+      .mockRejectedValueOnce(new Error('CORS/404'))
+      .mockResolvedValue(undefined)
+
+    // The failed load must SURFACE as an error, not resolve silently.
+    await expect(bridge.triggerSynth('hollow', 0, { note: 60 })).rejects.toThrow()
+
+    // Pre-fix (delete only in .then()): pendingSynthDefLoads still holds the
+    // rejected promise, so this returns the cached rejection and loadSynthDef
+    // is never called again — that synth silent forever. Post-fix (.finally
+    // clears the entry): the retry re-attempts the load and succeeds.
+    await bridge.triggerSynth('hollow', 0, { note: 60 })
+    expect(mockSonic.loadSynthDef).toHaveBeenCalledTimes(2)
+  })
+
   it('caches loaded SynthDefs', async () => {
     const { mockSonic } = createMockSuperSonic()
     ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)


### PR DESCRIPTION
First child of EPIC #318 (#318.4). Mechanical mirror of the merged #317.

## Problem

`ensureSynthDefLoaded` (`SuperSonicBridge.ts`) had the **identical** defect SV43/SP90 fixed for samples in #317: `pendingSynthDefLoads.delete(fullName)` lived only inside `.then()`. A failed synthdef load — SP89-class (an inventory name the CDN package never shipped) or a transient fetch failure — left a permanently-rejecting promise cached forever. Every later `ensureSynthDefLoaded(name)` returned that cached rejection: the synth/FX was **silent forever, no error**, and the #318 preflight resolver (#322) would replay the dead rejection.

## Fix

Mirror #317 exactly — move `pendingSynthDefLoads.delete(fullName)` into a `.finally()` so the in-flight entry clears whether the load resolves OR rejects. A later retry re-attempts the load; the failure surfaces as an error instead of silence. SV43 now holds on **both** in-flight dedup maps (`pendingSampleLoads` + `pendingSynthDefLoads`).

## Test plan / observation

- New unit test `SuperSonicBridge.test.ts` → *"SV43 twin: a rejected synthdef load does not poison subsequent retries"* (the SV43-sample test's twin). Uses a synth **not** in `COMMON_SYNTHDEFS` (`hollow`) to force the `ensureSynthDefLoaded` slow path rather than the preloaded fast path.
- **Verified as a real detector:** `git stash` the source fix → test **fails**; restore → **passes**.
- `npx vitest run` → **946/946** (was 945, +1). `npx tsc --noEmit` clean.
- Invisible to WAV by nature (absence of a never-loaded synth) — the unit test is the correct observation surface, mirroring #317's rationale.

Catalogues: vyapti SV43 + hetvabhasa SP90 updated — synthdef twin now FIXED, invariant holds on both maps.

Closes #320. Unblocks #322 (#318.2 preflight resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)