### PR TITLE
✨ feat(engine): Program-walk component manifest — closes #321

### DIFF
--- a/src/engine/ComponentManifest.ts
+++ b/src/engine/ComponentManifest.ts
@@ -1,0 +1,66 @@
+/**
+ * Component manifest — the set of sample / FX / synth names a built
+ * Program references. First child of the pre-Run preflight EPIC (#318,
+ * child #318.1 / #321).
+ *
+ * Why a standalone module (not inlined in the engine): the preflight is
+ * one domain concern that spans walk → resolve → gate. Each piece gets
+ * its own auditable surface so the cluster (SP5/SP84/SP89/SP90) is
+ * consolidated, not scattered — same rationale as SoundLayer mirroring
+ * sound.rb. This file owns *only* the walk; #318.2 resolves the names
+ * and #318.3 gates Run on the result.
+ *
+ * Names are resolved at BUILD time and stamped onto their steps by
+ * ProgramBuilder, so this is a pure structural walk — no use_synth
+ * state-tracking needed:
+ *   - `play`   → `step.synth` (ProgramBuilder sets `synth ?? currentSynth`
+ *                at push time, ProgramBuilder.ts; the `useSynth` step is
+ *                NOT collected — it would over-report a synth that may
+ *                never actually play).
+ *   - `sample` → `step.name`.
+ *   - `fx`     → `step.name`, then recurse `step.body`.
+ *   - `thread` → recurse `step.body` (in_thread / nested bodies carry
+ *                their own play/sample/fx).
+ * All other tags carry no CDN-loadable component and are ignored.
+ */
+
+import type { Program } from './Program'
+
+export interface ComponentManifest {
+  samples: Set<string>
+  fx: Set<string>
+  synths: Set<string>
+}
+
+/**
+ * Walk a built Program (and its nested fx/thread bodies) and collect every
+ * referenced sample, FX, and synth name. Pure: no I/O, no engine refs —
+ * unit-testable without a DOM or audio context.
+ */
+export function collectComponentManifest(
+  program: Program,
+  into: ComponentManifest = { samples: new Set(), fx: new Set(), synths: new Set() },
+): ComponentManifest {
+  for (const step of program) {
+    switch (step.tag) {
+      case 'play':
+        // `synth` is optional on the type but ProgramBuilder always stamps
+        // it; guard defensively rather than assume.
+        if (step.synth) into.synths.add(step.synth)
+        break
+      case 'sample':
+        into.samples.add(step.name)
+        break
+      case 'fx':
+        into.fx.add(step.name)
+        collectComponentManifest(step.body, into)
+        break
+      case 'thread':
+        collectComponentManifest(step.body, into)
+        break
+      // Every other tag (sleep, cue, control, useSynth, midiOut, liveAudio,
+      // recording*, …) references no CDN-loadable component — ignored.
+    }
+  }
+  return into
+}

--- a/src/engine/__tests__/ComponentManifest.test.ts
+++ b/src/engine/__tests__/ComponentManifest.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { collectComponentManifest } from '../ComponentManifest'
+import type { Program } from '../Program'
+
+describe('collectComponentManifest (#318.1 / #321)', () => {
+  it('collects the synth name baked onto a play step', () => {
+    const p: Program = [
+      { tag: 'useSynth', name: 'prophet' },
+      { tag: 'play', note: 60, opts: {}, synth: 'prophet' },
+    ]
+    const m = collectComponentManifest(p)
+    expect([...m.synths]).toEqual(['prophet'])
+    // useSynth itself is NOT collected — only what a play step actually uses.
+    expect(m.synths.has('useSynth')).toBe(false)
+  })
+
+  it('collects sample names', () => {
+    const p: Program = [
+      { tag: 'sample', name: 'bd_haus', opts: {} },
+      { tag: 'sample', name: 'user_kick', opts: {} },
+    ]
+    expect([...collectComponentManifest(p).samples].sort()).toEqual([
+      'bd_haus',
+      'user_kick',
+    ])
+  })
+
+  it('collects an FX name AND recurses into its body', () => {
+    const p: Program = [
+      {
+        tag: 'fx',
+        name: 'reverb',
+        opts: {},
+        body: [
+          { tag: 'play', note: 64, opts: {}, synth: 'tb303' },
+          { tag: 'sample', name: 'ambi_choir', opts: {} },
+        ],
+      },
+    ]
+    const m = collectComponentManifest(p)
+    expect([...m.fx]).toEqual(['reverb'])
+    expect([...m.synths]).toEqual(['tb303'])
+    expect([...m.samples]).toEqual(['ambi_choir'])
+  })
+
+  it('recurses into nested fx and thread bodies (in_thread / with_fx)', () => {
+    const p: Program = [
+      {
+        tag: 'thread',
+        body: [
+          {
+            tag: 'fx',
+            name: 'echo',
+            opts: {},
+            body: [
+              {
+                tag: 'fx',
+                name: 'distortion',
+                opts: {},
+                body: [{ tag: 'play', note: 48, opts: {}, synth: 'dsaw' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const m = collectComponentManifest(p)
+    expect([...m.fx].sort()).toEqual(['distortion', 'echo'])
+    expect([...m.synths]).toEqual(['dsaw'])
+  })
+
+  it('deduplicates repeated names (Set semantics)', () => {
+    const p: Program = [
+      { tag: 'play', note: 60, opts: {}, synth: 'beep' },
+      { tag: 'sleep', beats: 1 },
+      { tag: 'play', note: 67, opts: {}, synth: 'beep' },
+      { tag: 'sample', name: 'bd_haus', opts: {} },
+      { tag: 'sample', name: 'bd_haus', opts: {} },
+    ]
+    const m = collectComponentManifest(p)
+    expect(m.synths.size).toBe(1)
+    expect(m.samples.size).toBe(1)
+  })
+
+  it('ignores tags that reference no CDN-loadable component', () => {
+    const p: Program = [
+      { tag: 'sleep', beats: 1 },
+      { tag: 'cue', name: 'tick' },
+      { tag: 'control', nodeRef: 1, params: {} },
+      { tag: 'liveAudio', name: 'sound_in', opts: {} },
+      { tag: 'midiOut', kind: 'noteOn', args: [60, 100, 1] },
+      { tag: 'recordingStart' },
+    ]
+    const m = collectComponentManifest(p)
+    expect(m.synths.size + m.samples.size + m.fx.size).toBe(0)
+  })
+
+  it('a play step missing the optional synth field is skipped, not crashed', () => {
+    const p: Program = [{ tag: 'play', note: 60, opts: {} }]
+    expect(collectComponentManifest(p).synths.size).toBe(0)
+  })
+
+  it('an empty program yields an empty manifest', () => {
+    const m = collectComponentManifest([])
+    expect(m.samples.size + m.fx.size + m.synths.size).toBe(0)
+  })
+
+  it('accumulates into a caller-provided manifest (multi-loop aggregation)', () => {
+    const acc = { samples: new Set<string>(), fx: new Set<string>(), synths: new Set<string>() }
+    collectComponentManifest([{ tag: 'play', note: 60, opts: {}, synth: 'beep' }], acc)
+    collectComponentManifest([{ tag: 'sample', name: 'bd_haus', opts: {} }], acc)
+    expect([...acc.synths]).toEqual(['beep'])
+    expect([...acc.samples]).toEqual(['bd_haus'])
+  })
+})


### PR DESCRIPTION
Child **#318.1** of EPIC #318 (pre-Run component-load preflight). Walker only.

## Problem

The preflight (#318) needs to know, before playback starts, which samples / FX / synths a built program references. No collector exists — every loader independently discovers and silently swallows its own load failure (the SP5/SP84/SP89/SP90 cluster).

## What this adds

New standalone pure module `ComponentManifest.ts`:

```ts
collectComponentManifest(program): { samples: Set, fx: Set, synths: Set }
```

Walks a built `Program` and its nested `fx`/`thread` bodies. Pure — no I/O, no engine refs, unit-testable without DOM/audio.

**Design correction (honest):** I'd earlier scoped synth preflight as "best-effort, needs use_synth state-tracking — materially harder." Reading the source corrected that: `ProgramBuilder` stamps `synth: synth ?? currentSynth` onto every play step at build time, so this is a pure structural walk. `useSynth` steps are **not** collected — the resolved name is already on each `play` step; collecting `useSynth` would over-report a synth that may never play. EPIC #318's scope note updated to match.

Recurses into both `fx.body` **and** `thread.body` (verified from the `Step` type — `thread` carries a body, so `in_thread`/nested components would otherwise be missed).

## Scope boundary

Walker **only**. Does not wire into the engine, resolve loads, or gate Run — that's #322 (#318.2 resolve+classify) and #323 (#318.3 gate+surface). Standalone module, not inlined, so the preflight concern stays one auditable surface (same rationale as `SoundLayer` ↔ `sound.rb`).

## Test plan / observation

- 9 unit tests: fx+thread recursion, `useSynth`-not-collected, dedup (Set), ignored tags, optional-`synth` guard, multi-loop accumulation, empty program.
- `npx vitest run` → **955/955** (was 946, +9). `npx tsc --noEmit` clean.
- Pure function — the unit suite is the complete observation surface; no audio path touched (correctly, by scope).

Closes #321. Next: #322 (#318.2) — depends on this + the merged #320/#324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)