### PR TITLE
✨ feat(engine): re-land component resolver on main (#322 stranded by stacked squash-merge)

### DIFF
--- a/src/engine/ComponentResolver.ts
+++ b/src/engine/ComponentResolver.ts
@@ -1,0 +1,88 @@
+/**
+ * Component resolver — drives the loaders for a ComponentManifest and
+ * partitions the failures. Child #318.2 / #322 of the pre-Run preflight
+ * EPIC (#318).
+ *
+ * This is the inverse of `SuperSonicBridge.preloadFxSynthDefs`'s empty
+ * `.catch(() => {})` (SP84): failures are *collected*, not swallowed, so
+ * #318.3 (#323) can block Run and surface them.
+ *
+ * Decoupled from the bridge by design: it takes injected loaders, so it
+ * is pure-testable without a DOM / audio context / real scsynth. #323
+ * wires the actual `ensureSampleLoaded` / `ensureSynthDefLoaded` calls.
+ *
+ * HARD CONSTRAINT (EPIC #318): a `user_`-prefixed sample is a custom
+ * sample (the `CustomSampleStore` convention) — the host may
+ * `registerCustomSample` around or after Run ("late registration"). A
+ * failed custom-sample load is therefore a non-blocking *warning*, never
+ * a hard miss. This is the false-block guard that makes the block-Run
+ * decision viable; it is not optional. The exemption is scoped to
+ * samples only — there is no custom-FX / custom-synth registration path.
+ */
+
+import type { ComponentManifest } from './ComponentManifest'
+
+export interface ResolveResult {
+  /** Names that must block Run (#318.3 surfaces these). */
+  hardMisses: string[]
+  /** Non-blocking — custom samples that may still arrive via registerCustomSample. */
+  warnings: string[]
+}
+
+/** Resolves if the component is available, rejects otherwise. */
+export type ComponentLoader = (name: string) => Promise<unknown>
+
+export interface ComponentLoaders {
+  sample: ComponentLoader
+  fx: ComponentLoader
+  synth: ComponentLoader
+}
+
+/**
+ * `user_`-prefixed = custom sample (`CustomSampleStore` convention, see
+ * CustomSampleStore.ts). A failed load is exempt from hard-blocking
+ * because the host may register it late.
+ */
+export function isCustomSampleName(name: string): boolean {
+  return name.startsWith('user_')
+}
+
+/**
+ * Drive every loader for the manifest, collecting failures. A failed
+ * custom sample (`user_*`) → `warnings`; every other failure →
+ * `hardMisses`. Successes produce nothing. Output is sorted for stable
+ * messages and deterministic tests.
+ */
+export async function resolveComponentManifest(
+  manifest: ComponentManifest,
+  loaders: ComponentLoaders,
+): Promise<ResolveResult> {
+  const hardMisses: string[] = []
+  const warnings: string[] = []
+
+  const settle = async (
+    name: string,
+    loader: ComponentLoader,
+    kind: 'sample' | 'fx' | 'synth',
+  ): Promise<void> => {
+    try {
+      await loader(name)
+    } catch {
+      if (kind === 'sample' && isCustomSampleName(name)) {
+        warnings.push(name)
+      } else {
+        hardMisses.push(name)
+      }
+    }
+  }
+
+  await Promise.all([
+    ...[...manifest.samples].map((n) => settle(n, loaders.sample, 'sample')),
+    ...[...manifest.fx].map((n) => settle(n, loaders.fx, 'fx')),
+    ...[...manifest.synths].map((n) => settle(n, loaders.synth, 'synth')),
+  ])
+
+  hardMisses.sort()
+  warnings.sort()
+  return { hardMisses, warnings }
+}

--- a/src/engine/__tests__/ComponentResolver.test.ts
+++ b/src/engine/__tests__/ComponentResolver.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  resolveComponentManifest,
+  isCustomSampleName,
+  type ComponentLoaders,
+} from '../ComponentResolver'
+import type { ComponentManifest } from '../ComponentManifest'
+
+const manifest = (
+  m: Partial<Record<keyof ComponentManifest, string[]>>,
+): ComponentManifest => ({
+  samples: new Set(m.samples ?? []),
+  fx: new Set(m.fx ?? []),
+  synths: new Set(m.synths ?? []),
+})
+
+/** Loaders that resolve unless the name is in `fail`. */
+const loaders = (fail: Set<string>): ComponentLoaders => {
+  const mk = () =>
+    vi.fn((n: string) =>
+      fail.has(n) ? Promise.reject(new Error('CORS/404')) : Promise.resolve(undefined),
+    )
+  return { sample: mk(), fx: mk(), synth: mk() }
+}
+
+describe('isCustomSampleName', () => {
+  it('treats user_-prefixed names as custom (CustomSampleStore convention)', () => {
+    expect(isCustomSampleName('user_kick')).toBe(true)
+    expect(isCustomSampleName('bd_haus')).toBe(false)
+  })
+})
+
+describe('resolveComponentManifest (#318.2 / #322)', () => {
+  it('all components resolve → no misses, no warnings', async () => {
+    const r = await resolveComponentManifest(
+      manifest({ samples: ['bd_haus'], fx: ['reverb'], synths: ['beep'] }),
+      loaders(new Set()),
+    )
+    expect(r).toEqual({ hardMisses: [], warnings: [] })
+  })
+
+  it('a failed built-in sample is a hard miss', async () => {
+    const r = await resolveComponentManifest(
+      manifest({ samples: ['bd_typo'] }),
+      loaders(new Set(['bd_typo'])),
+    )
+    expect(r.hardMisses).toEqual(['bd_typo'])
+    expect(r.warnings).toEqual([])
+  })
+
+  it('HARD CONSTRAINT: a failed user_ sample is a WARNING, never a hard miss', async () => {
+    const r = await resolveComponentManifest(
+      manifest({ samples: ['user_kick'] }),
+      loaders(new Set(['user_kick'])),
+    )
+    expect(r.hardMisses).toEqual([])
+    expect(r.warnings).toEqual(['user_kick'])
+  })
+
+  it('failed FX and synth are hard misses', async () => {
+    const r = await resolveComponentManifest(
+      manifest({ fx: ['nofx'], synths: ['nosynth'] }),
+      loaders(new Set(['nofx', 'nosynth'])),
+    )
+    expect(r.hardMisses).toEqual(['nofx', 'nosynth'])
+  })
+
+  it('the user_ exemption is sample-only — a user_-named synth still hard-misses', async () => {
+    const r = await resolveComponentManifest(
+      manifest({ synths: ['user_synth'] }),
+      loaders(new Set(['user_synth'])),
+    )
+    expect(r.hardMisses).toEqual(['user_synth'])
+    expect(r.warnings).toEqual([])
+  })
+
+  it('partitions a mixed program correctly and sorts output deterministically', async () => {
+    const r = await resolveComponentManifest(
+      manifest({
+        samples: ['bd_haus', 'zz_typo', 'user_late'],
+        fx: ['reverb', 'aa_badfx'],
+        synths: ['beep'],
+      }),
+      loaders(new Set(['zz_typo', 'user_late', 'aa_badfx'])),
+    )
+    expect(r.hardMisses).toEqual(['aa_badfx', 'zz_typo']) // sorted
+    expect(r.warnings).toEqual(['user_late'])
+  })
+
+  it('an empty manifest resolves to an empty result', async () => {
+    expect(await resolveComponentManifest(manifest({}), loaders(new Set()))).toEqual({
+      hardMisses: [],
+      warnings: [],
+    })
+  })
+
+  it('drives every loader exactly once per referenced name', async () => {
+    const l = loaders(new Set())
+    await resolveComponentManifest(
+      manifest({ samples: ['a'], fx: ['b'], synths: ['c'] }),
+      l,
+    )
+    expect(l.sample).toHaveBeenCalledTimes(1)
+    expect(l.fx).toHaveBeenCalledTimes(1)
+    expect(l.synth).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Why this PR exists

#322 (PR #326) is marked **MERGED**, but its code is **not on `main`**.

#326 was stacked on #325's branch (`feat/issue-321-component-manifest`). #325 was **squash-merged** to `main` (`14acc3b`), which left #326's base branch orphaned. #326 then merged into that now-dead base (`8c792be`), reachable from no path to `main`. `gh` reports MERGED; `git` shows `ComponentResolver.ts` never reached `main`. Classic stacked-PR + squash hazard.

## What this does

Cherry-picks `8c792be` (the reviewed #322 content — `ComponentResolver.ts` + its 9 tests, 195 insertions, no other files) onto a fresh branch off current `main`. No code changes vs. what was reviewed in #326 — pure re-land.

## Verification

- Cherry-pick applied with **zero conflicts** (manifest from #321 is already on `main` via #325's squash).
- `npx tsc --noEmit` clean. `npx vitest run` → **964/964** (resolver suite 9/9).

## Process note (for the catalogue)

Stacked PRs whose base is **squash-merged** strand the upper PR: the squash creates a new commit, the upper PR's base branch is deleted, and its own merge lands on the dead branch. Future EPIC children should either (a) not stack, or (b) rebase-merge the chain, or (c) re-target the upper PR to `main` *before* merging the lower. Recording under EPIC #318 lessons.

Re-lands #322 / supersedes the stranded #326. Unblocks #323 (#318.3), which consumes `resolveComponentManifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)