### PR TITLE
✨ feat(engine): static component-name scanner (pre-Run preflight) — part of #323

### DIFF
--- a/src/engine/ComponentScan.ts
+++ b/src/engine/ComponentScan.ts
@@ -1,0 +1,83 @@
+/**
+ * Static component scan — extract the LITERAL sample / FX / synth names a
+ * piece of user code references, without building or running it. The
+ * pre-Run path of the preflight EPIC (#318, child #318.3 / #323).
+ *
+ * Why static (not the #321 Step-walker): loop Programs are built lazily
+ * per-iteration inside the scheduler (`SonicPiEngine.ts:694`); there is no
+ * pre-Run moment where Step[]s exist, and re-running builderFn to get them
+ * is an SP72 build-phase-state-mutation hazard. A textual scan of the user
+ * code is the only side-effect-free pre-Run option. The result feeds the
+ * unchanged `ComponentResolver` (#322) — same `ComponentManifest` shape.
+ *
+ * BOUNDED BY DESIGN: only LITERAL names are found —
+ *   `sample :x` / `sample "x"` / `sample('x')`
+ *   `use_synth :x` · `synth :x` · `with_fx :x`  (and quoted/paren forms)
+ * Runtime-computed names (`sample SAMPS.tick`, a name from a variable) are
+ * deliberately NOT found: they cannot be known pre-Run, so they are not
+ * preflighted and not blocked — they fall back to normal lazy-load (which,
+ * post-#320/#317, self-heals on transient failure). This is the precise,
+ * intended limit, not a gap to paper over. Literal names are exactly the
+ * set that bites users (typos, SP89 never-shipped names are always literal).
+ *
+ * Over-collection is harmless (a real, loadable name just resolves).
+ * Under-collection of a literal, or collecting a name from a COMMENT,
+ * is not: a commented-out `sample :typo` must never block Run — so
+ * comments are stripped before scanning.
+ */
+
+import type { ComponentManifest } from './ComponentManifest'
+
+/**
+ * Strip Ruby comments so a commented-out `sample :typo` cannot false-block
+ * Run. Handles line comments (`#` … EOL) and `=begin`/`=end` block
+ * comments. Known v1 limit: a `#` inside a string literal on a line with
+ * no real comment will truncate that line early — acceptable because the
+ * DSL forms we scan (`sample :x` etc.) do not use `#` in their literal
+ * name, and the failure mode is under-collection of that one line, which
+ * degrades to lazy-load (no false-block, no regression). `#{}`
+ * interpolation is preserved (only `#` NOT followed by `{` starts a
+ * comment here).
+ */
+function stripComments(code: string): string {
+  const withoutBlocks = code.replace(/^=begin\b[\s\S]*?^=end\b.*$/gm, '')
+  return withoutBlocks
+    .split('\n')
+    .map((line) => {
+      for (let i = 0; i < line.length; i++) {
+        if (line[i] === '#' && line[i + 1] !== '{') return line.slice(0, i)
+      }
+      return line
+    })
+    .join('\n')
+}
+
+// `\bsample\s*\(?\s*[:"']([name])` — `\b` before `synth` does NOT match the
+// `synth` inside `use_synth` (`_` is a word char → no boundary), so the two
+// patterns are unambiguous. Name = Ruby ident: letter/underscore start.
+const NAME = '([a-zA-Z_][a-zA-Z0-9_]*)'
+const PATTERNS: ReadonlyArray<[keyof ComponentManifest, RegExp]> = [
+  ['samples', new RegExp(`\\bsample\\s*\\(?\\s*[:"']${NAME}`, 'g')],
+  ['synths', new RegExp(`\\buse_synth\\s*\\(?\\s*[:"']${NAME}`, 'g')],
+  ['synths', new RegExp(`\\bsynth\\s*\\(?\\s*[:"']${NAME}`, 'g')],
+  ['fx', new RegExp(`\\bwith_fx\\s*\\(?\\s*[:"']${NAME}`, 'g')],
+]
+
+/**
+ * Scan user code for literal component references. Pure: input string →
+ * name Sets. Feeds `resolveComponentManifest` (#322) unchanged.
+ */
+export function scanComponentNames(code: string): ComponentManifest {
+  const manifest: ComponentManifest = {
+    samples: new Set(),
+    fx: new Set(),
+    synths: new Set(),
+  }
+  const src = stripComments(code)
+  for (const [bucket, re] of PATTERNS) {
+    re.lastIndex = 0
+    let m: RegExpExecArray | null
+    while ((m = re.exec(src)) !== null) manifest[bucket].add(m[1])
+  }
+  return manifest
+}

--- a/src/engine/__tests__/ComponentScan.test.ts
+++ b/src/engine/__tests__/ComponentScan.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { scanComponentNames } from '../ComponentScan'
+
+const s = (code: string) => {
+  const m = scanComponentNames(code)
+  return {
+    samples: [...m.samples].sort(),
+    fx: [...m.fx].sort(),
+    synths: [...m.synths].sort(),
+  }
+}
+
+describe('scanComponentNames (#318.3 / #323 static extractor)', () => {
+  it('finds symbol, string, and paren literal forms', () => {
+    expect(s('sample :bd_haus')).toMatchObject({ samples: ['bd_haus'] })
+    expect(s('sample "bd_haus"')).toMatchObject({ samples: ['bd_haus'] })
+    expect(s("sample('bd_haus', amp: 2)")).toMatchObject({ samples: ['bd_haus'] })
+  })
+
+  it('separates use_synth / synth / with_fx into the right buckets', () => {
+    const r = s('use_synth :prophet\nsynth :saw, note: 60\nwith_fx :reverb do\nend')
+    expect(r.synths).toEqual(['prophet', 'saw'])
+    expect(r.fx).toEqual(['reverb'])
+  })
+
+  it('does NOT mistake the synth inside use_synth for a separate synth ref', () => {
+    // \b before `synth` cannot match mid-word in `use_synth` (_ is a word char).
+    expect(s('use_synth :tb303')).toEqual({ samples: [], fx: [], synths: ['tb303'] })
+  })
+
+  it('deduplicates repeated references', () => {
+    expect(s('sample :bd_haus\nsleep 1\nsample :bd_haus').samples).toEqual(['bd_haus'])
+  })
+
+  it('a commented-out reference must NOT be collected (no false-block)', () => {
+    expect(s('# sample :typo_should_not_block\nsample :bd_haus').samples).toEqual([
+      'bd_haus',
+    ])
+    expect(s('sample :bd_haus  # with_fx :ghost').fx).toEqual([])
+  })
+
+  it('strips =begin/=end block comments', () => {
+    const code = '=begin\nsample :commented_out\n=end\nsample :real'
+    expect(s(code).samples).toEqual(['real'])
+  })
+
+  it('preserves #{} interpolation (only # not followed by { is a comment)', () => {
+    // The `#{i}` must not truncate the line; the literal name is still found.
+    expect(s('with_fx :echo do\n  play "#{note}"\nend').fx).toEqual(['echo'])
+  })
+
+  it('does NOT collect runtime-computed names (bounded by design)', () => {
+    const r = s('use_synth SYNTHS.tick\nsample samps.choose\nwith_fx fx_name')
+    expect(r).toEqual({ samples: [], fx: [], synths: [] })
+  })
+
+  it('collects user_ custom sample names (resolver applies the exemption, not the scanner)', () => {
+    expect(s('sample :user_mykick').samples).toEqual(['user_mykick'])
+  })
+
+  it('handles a realistic multi-component snippet', () => {
+    const code = `
+      use_synth :tb303
+      live_loop :bass do
+        with_fx :reverb do
+          synth :saw, note: 40
+          sample :bd_haus
+        end
+        sleep 1
+      end
+    `
+    expect(s(code)).toEqual({
+      samples: ['bd_haus'],
+      fx: ['reverb'],
+      synths: ['saw', 'tb303'],
+    })
+  })
+
+  it('empty / component-free code yields empty sets', () => {
+    expect(s('play 60\nsleep 1')).toEqual({ samples: [], fx: [], synths: [] })
+    expect(s('')).toEqual({ samples: [], fx: [], synths: [] })
+  })
+})


### PR DESCRIPTION
First slice of **#318.3 / #323**. Independent of `ComponentResolver` — imports only the merged `ComponentManifest` type, so it lands on `main` directly (NOT stacked — SP91 lesson).

## Why static scan (replan)

The issue's original "walk built Programs at a pre-Run gate" is **architecturally infeasible**: loop Programs are built lazily per-iteration *inside* the scheduler (`SonicPiEngine.ts:694`); no pre-Run moment has Step[]s, and re-running `builderFn` to get them is an SP72 build-phase-state hazard. Full replan rationale on #323 / #318. `ComponentManifest`'s Step-walker (#321) stays valid for query/at-build use — it's just not the pre-Run mechanism.

## What this adds

`ComponentScan.ts` — `scanComponentNames(code): ComponentManifest`. Pure textual extraction of **literal** `sample` / `use_synth` / `synth` / `with_fx` names (symbol, string, paren forms) → feeds the unchanged `ComponentResolver` (#322).

- **Comments stripped first** (`#`-line + `=begin/=end`) so a commented-out `sample :typo` cannot false-block Run. `#{}` interpolation preserved.
- `\b` before `synth` cannot match inside `use_synth` (`_` is a word char) — verified by a dedicated test.
- **Bounded by design (stated, not hidden):** runtime-computed names (`sample SAMPS.tick`) are deliberately *not* found — they lazy-load (post-#320 self-healing), no false-block, no regression. Literal names are exactly the set that bites (typos, SP89 never-shipped).

## Scope boundary

Scanner **only**. The bridge `preloadSynth`/`preloadFx` surface, the run-path gate before `scheduler.start()`, and the FriendlyErrors message are the remaining #323 slices — **serialized behind #327** (resolver re-land) per SP91, off clean `main`, not stacked.

## Test plan / observation

- 11 unit tests: literal forms, bucket separation, `use_synth`/`synth` boundary, dedup, line+block comment strip (incl. the false-block guard), interpolation, dynamic-name omission, `user_` passthrough, realistic snippet, empty.
- `npx vitest run` → **966/966** (+11). `npx tsc --noEmit` clean.
- Pure function — unit suite is the complete observation surface (the Level-3 audio gate applies to the *gate-wiring* slice of #323, not this extractor).

Part of #323 (does not close it). Next slices wait on #327 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)