### PR TITLE
✨ feat(engine): pre-Run component gate — refuse Run on missing components — closes #323, closes #318

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -23,6 +23,8 @@ import { initTreeSitter } from './TreeSitterTranspiler'
  */
 const CLAMP_WARN_RE = /clamped to .+ \((min|max)\)$/
 import { friendlyError, formatFriendlyError, type FriendlyError } from './FriendlyErrors'
+import { scanComponentNames } from './ComponentScan'
+import { resolveComponentManifest } from './ComponentResolver'
 import { detectStratum, Stratum } from './Stratum'
 import { SoundEventStream } from './SoundEventStream'
 import { ring, knit, range, line, doubles, halves, Ring } from './Ring'
@@ -297,6 +299,35 @@ export class SonicPiEngine {
 
       // First run or after stop: create fresh scheduler
       if (!isReEvaluate) {
+        // Pre-Run component preflight (#318 / #323). Statically-named
+        // samples/synths/FX are loaded NOW; if any genuinely-missing one
+        // can't load, refuse Run with a clear message instead of starting
+        // and silently dropping it (the SP5/SP84/SP89/SP90 cluster).
+        // Fresh Run only — a hot-swap must NOT re-block a held performance
+        // (it lazy-loads and, post-#320, self-heals on transient failure).
+        // `user_` custom samples are exempt (warning, not block): the host
+        // may registerCustomSample around/after Run. Static scan catches
+        // literal names only; runtime-computed names still lazy-load.
+        if (this.bridge) {
+          const manifest = scanComponentNames(code)
+          const { hardMisses, warnings } = await resolveComponentManifest(manifest, {
+            sample: (n) => this.bridge!.preloadSample(n),
+            synth: (n) => this.bridge!.preloadSynth(n),
+            fx: (n) => this.bridge!.preloadFx(n),
+          })
+          for (const w of warnings) {
+            if (this.printHandler) {
+              this.printHandler(
+                `[Warning] sample :${w} isn't loaded yet — it will play once registered`,
+              )
+            }
+          }
+          if (hardMisses.length > 0) {
+            const list = hardMisses.map((n) => `:${n}`).join(', ')
+            return { error: new Error(`Couldn't load: ${list}`) }
+          }
+        }
+
         if (this.scheduler) {
           this.scheduler.dispose()
         }

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -560,6 +560,28 @@ export class SuperSonicBridge {
     )
   }
 
+  /**
+   * Preload ONE synth synthdef binary, REJECTING on failure. The
+   * non-swallowing counterpart to `preloadFxSynthDefs` — the #318/#323
+   * pre-Run preflight needs a truthful per-name pass/fail so it can block
+   * Run (or surface it) instead of the SP5 silent-drop-at-/s_new. Pass the
+   * synth name WITHOUT prefix ('saw', 'prophet'); `ensureSynthDefLoaded`
+   * adds `sonic-pi-`. Safe only because #320 fixed the reject-leak — a
+   * failed preflight no longer poisons the later real /s_new.
+   */
+  preloadSynth(name: string): Promise<void> {
+    return this.ensureSynthDefLoaded(name)
+  }
+
+  /**
+   * Preload ONE FX synthdef binary, REJECTING on failure (see
+   * `preloadSynth`). Pass the FX name WITHOUT prefix ('reverb', 'echo') —
+   * `sonic-pi-fx_` is added here to match `preloadFxSynthDefs`'s contract.
+   */
+  preloadFx(name: string): Promise<void> {
+    return this.ensureSynthDefLoaded(`sonic-pi-fx_${name}`)
+  }
+
   private ensureSynthDefLoaded(name: string): Promise<void> {
     const fullName = name.startsWith('sonic-pi-') ? name : `sonic-pi-${name}`
     if (this.loadedSynthDefs.has(fullName)) return Promise.resolve()

--- a/src/engine/__tests__/PreRunGate.test.ts
+++ b/src/engine/__tests__/PreRunGate.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+/**
+ * #318.3 / #323 — pre-Run component preflight gate (integration:
+ * engine + real SuperSonicBridge + mock scsynth). Verifies a
+ * genuinely-missing statically-named component refuses Run with a
+ * clear message, custom (user_) samples are exempt, and the no-op
+ * cases don't regress.
+ */
+
+function mockSuperSonic(failSynthDefs: Set<string>, failSamples: Set<string>) {
+  const mockSonic = {
+    init: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn(),
+    sendOSC: vi.fn(),
+    loadSynthDef: vi.fn((full: string) =>
+      failSynthDefs.has(full) ? Promise.reject(new Error('CORS/404')) : Promise.resolve(undefined),
+    ),
+    loadSynthDefs: vi.fn().mockResolvedValue(undefined),
+    loadSample: vi.fn((_b: number, path: string) =>
+      failSamples.has(path) ? Promise.reject(new Error('CORS/404')) : Promise.resolve(undefined),
+    ),
+    sync: vi.fn().mockResolvedValue(undefined),
+    nextNodeId: (() => { let i = 1000; return vi.fn(() => i++) })(),
+    destroy: vi.fn(),
+    node: { connect: vi.fn() },
+    audioContext: {
+      currentTime: 0,
+      sampleRate: 44100,
+      destination: { connect: vi.fn() },
+      createAnalyser: vi.fn(() => ({ fftSize: 2048, smoothingTimeConstant: 0.8, connect: vi.fn(), disconnect: vi.fn() })),
+      createChannelSplitter: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+      createChannelMerger: vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() })),
+      createGain: vi.fn(() => ({ gain: { value: 1, setTargetAtTime: vi.fn() }, connect: vi.fn(), disconnect: vi.fn() })),
+    },
+  }
+  ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+  return mockSonic
+}
+
+describe('pre-Run component gate (#318.3 / #323)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('refuses Run with a clear message when a statically-named synth cannot load', async () => {
+    // `hollow` is not in COMMON_SYNTHDEFS → slow path → loadSynthDef called.
+    mockSuperSonic(new Set(['sonic-pi-hollow']), new Set())
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const r = await engine.evaluate('use_synth :hollow\nplay 60')
+    expect(r.error).toBeDefined()
+    expect(r.error!.message).toBe('Couldn\'t load: :hollow')
+    engine.dispose()
+  })
+
+  it('refuses Run when a built-in sample 404s, listing it', async () => {
+    mockSuperSonic(new Set(), new Set(['bd_typo.flac']))
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const r = await engine.evaluate('sample :bd_typo')
+    expect(r.error?.message).toBe('Couldn\'t load: :bd_typo')
+    engine.dispose()
+  })
+
+  it('does NOT block on a failed user_ custom sample (exempt — may register late)', async () => {
+    mockSuperSonic(new Set(), new Set(['user_kick.flac']))
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const r = await engine.evaluate('sample :user_kick')
+    expect(r.error).toBeUndefined() // warning, not a hard miss
+    engine.dispose()
+  })
+
+  it('proceeds normally when every statically-named component resolves', async () => {
+    mockSuperSonic(new Set(), new Set())
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const r = await engine.evaluate('use_synth :saw\nsample :bd_haus\nplay 60')
+    expect(r.error).toBeUndefined()
+    engine.dispose()
+  })
+
+  it('a commented-out missing name does not block (scanner strips comments)', async () => {
+    mockSuperSonic(new Set(['sonic-pi-hollow']), new Set())
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const r = await engine.evaluate('# use_synth :hollow\nplay 60')
+    expect(r.error).toBeUndefined()
+    engine.dispose()
+  })
+})


### PR DESCRIPTION
**Completes EPIC #318** (pre-Run component-load preflight). Off clean `main`, not stacked (SP91 discipline). Builds on merged #325/#327/#328.

## Problem

The silent-drop cluster **SP5/SP84/SP89/SP90**: a referenced sample/synth/FX that can't load → engine starts anyway, drops the sound, no error, user has no idea which name was wrong. Every loader swallowed its own failure.

## Fix (the last #323 slice)

Wires the merged scanner (#328) + resolver (#322/#327) into a **pre-Run gate**:

- **Bridge:** new `preloadSynth(name)` / `preloadFx(name)` — the single-name, **rejecting**, non-swallowing counterpart to `preloadFxSynthDefs`'s empty `.catch` (`preloadSample` already existed).
- **`SonicPiEngine.evaluate`, fresh-Run path only** (`!isReEvaluate`): `scanComponentNames(code)` → `resolveComponentManifest` over the real bridge loaders →
  - `hardMisses` → `return { error: "Couldn't load: :a, :b" }`, scheduler never created/started (mirrors the existing parse-error refuse path).
  - `user_` custom samples → non-blocking `[Warning]` (host may `registerCustomSample` late) — **never** blocks.
- **Hot-swap untouched** — a held performance is not re-blocked (lazy-load + #320 self-heal). Static scan is literal-only by design; runtime-computed names lazy-load (no false-block, no regression). Sound only because #317/#320 fixed the dedup reject-leak.

## Verification

- **Level 1:** 5 integration tests (engine + real `SuperSonicBridge` + mock scsynth) — missing synth/sample blocks with the exact message, `user_` exempt, all-resolve proceeds, commented-out name doesn't block. 980/980 vitest, `tsc` clean.
- **Level 3 (real Chromium, `tools/capture.ts`):**
  - valid `sample :bd_haus` track → plays through the gate, **RMS 0.034**, `/s_new` firing, no false-block.
  - typo'd `:bd_typoooo` → **Peak 0 / RMS 0, no `/s_new`** — Run refused.
  - Honest scope: the WAV proves the *behavioural* block (silence + no dispatch); the exact message string is verified at the `evaluate()` API level by the integration test (the capture report logs console/CORS noise, not `printHandler` text).

## Catalogue

New invariant **SV44** (statically-named components must load or Run is refused) — records the cluster consolidation, the precondition (SV43), and the honest bounds (presence-only, literal-only, fresh-Run-only).

Closes #323. Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)