### PR TITLE
🐛 fix(engine): cap pre-Run preflight with a timeout — closes #330

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -22,6 +22,11 @@ import { initTreeSitter } from './TreeSitterTranspiler'
  * to surface each unique line once per evaluation (issue #202, G4).
  */
 const CLAMP_WARN_RE = /clamped to .+ \((min|max)\)$/
+/** #330: cap the pre-Run component preflight so a hung/slow CDN fetch
+ *  can't hang Run-start. On timeout the engine proceeds (lazy-load +
+ *  SV43 self-heal), it does not refuse — a timeout is not a definitive
+ *  miss. 5s is well past a healthy unpkg fetch, short enough to feel. */
+const PREFLIGHT_TIMEOUT_MS = 5000
 import { friendlyError, formatFriendlyError, type FriendlyError } from './FriendlyErrors'
 import { scanComponentNames } from './ComponentScan'
 import { resolveComponentManifest } from './ComponentResolver'
@@ -310,21 +315,46 @@ export class SonicPiEngine {
         // literal names only; runtime-computed names still lazy-load.
         if (this.bridge) {
           const manifest = scanComponentNames(code)
-          const { hardMisses, warnings } = await resolveComponentManifest(manifest, {
-            sample: (n) => this.bridge!.preloadSample(n),
-            synth: (n) => this.bridge!.preloadSynth(n),
-            fx: (n) => this.bridge!.preloadFx(n),
+          // #330: a hung / very slow CDN fetch must not hang Run-start
+          // forever. Race the preflight against a bounded timeout. A
+          // timeout is NOT a definitive "missing" — so on timeout we
+          // PROCEED with a warning and let playback lazy-load (post-#320
+          // self-heal covers transient failures). Block ONLY on a
+          // definitive hard miss, which a timeout is not. Refusing Run on
+          // a slow network would be worse UX than the silent-drop #318
+          // fixed.
+          let timer: ReturnType<typeof setTimeout> | undefined
+          const timeout = new Promise<'timeout'>((resolve) => {
+            timer = setTimeout(() => resolve('timeout'), PREFLIGHT_TIMEOUT_MS)
           })
-          for (const w of warnings) {
+          const resolved = await Promise.race([
+            resolveComponentManifest(manifest, {
+              sample: (n) => this.bridge!.preloadSample(n),
+              synth: (n) => this.bridge!.preloadSynth(n),
+              fx: (n) => this.bridge!.preloadFx(n),
+            }),
+            timeout,
+          ])
+          if (timer) clearTimeout(timer)
+          if (resolved === 'timeout') {
             if (this.printHandler) {
               this.printHandler(
-                `[Warning] sample :${w} isn't loaded yet — it will play once registered`,
+                '[Warning] component preflight timed out — starting anyway; any missing sounds will load when available',
               )
             }
-          }
-          if (hardMisses.length > 0) {
-            const list = hardMisses.map((n) => `:${n}`).join(', ')
-            return { error: new Error(`Couldn't load: ${list}`) }
+          } else {
+            const { hardMisses, warnings } = resolved
+            for (const w of warnings) {
+              if (this.printHandler) {
+                this.printHandler(
+                  `[Warning] sample :${w} isn't loaded yet — it will play once registered`,
+                )
+              }
+            }
+            if (hardMisses.length > 0) {
+              const list = hardMisses.map((n) => `:${n}`).join(', ')
+              return { error: new Error(`Couldn't load: ${list}`) }
+            }
           }
         }
 

--- a/src/engine/__tests__/PreRunGate.test.ts
+++ b/src/engine/__tests__/PreRunGate.test.ts
@@ -9,7 +9,11 @@ import { SonicPiEngine } from '../SonicPiEngine'
  * cases don't regress.
  */
 
-function mockSuperSonic(failSynthDefs: Set<string>, failSamples: Set<string>) {
+function mockSuperSonic(
+  failSynthDefs: Set<string>,
+  failSamples: Set<string>,
+  hangSamples: Set<string> = new Set(),
+) {
   const mockSonic = {
     init: vi.fn().mockResolvedValue(undefined),
     send: vi.fn(),
@@ -19,7 +23,11 @@ function mockSuperSonic(failSynthDefs: Set<string>, failSamples: Set<string>) {
     ),
     loadSynthDefs: vi.fn().mockResolvedValue(undefined),
     loadSample: vi.fn((_b: number, path: string) =>
-      failSamples.has(path) ? Promise.reject(new Error('CORS/404')) : Promise.resolve(undefined),
+      hangSamples.has(path)
+        ? new Promise<undefined>(() => { /* never settles — simulates a hung CDN fetch */ })
+        : failSamples.has(path)
+          ? Promise.reject(new Error('CORS/404'))
+          : Promise.resolve(undefined),
     ),
     sync: vi.fn().mockResolvedValue(undefined),
     nextNodeId: (() => { let i = 1000; return vi.fn(() => i++) })(),
@@ -94,5 +102,27 @@ describe('pre-Run component gate (#318.3 / #323)', () => {
     const r = await engine.evaluate('# use_synth :hollow\nplay 60')
     expect(r.error).toBeUndefined()
     engine.dispose()
+  })
+
+  it('#330: a hung CDN fetch does not hang Run-start — preflight times out, proceeds with a warning', async () => {
+    mockSuperSonic(new Set(), new Set(), new Set(['hang_sample.flac']))
+    const engine = new SonicPiEngine()
+    await engine.init() // init under real timers (only mock-promise awaits)
+
+    const prints: string[] = []
+    engine.setPrintHandler((m) => prints.push(m))
+
+    vi.useFakeTimers()
+    try {
+      const p = engine.evaluate('sample :hang_sample')
+      // Past PREFLIGHT_TIMEOUT_MS (5000) — the race resolves to 'timeout'.
+      await vi.advanceTimersByTimeAsync(5001)
+      const r = await p
+      expect(r.error).toBeUndefined() // proceeded, did NOT refuse on a timeout
+      expect(prints.some((m) => m.includes('preflight timed out'))).toBe(true)
+    } finally {
+      vi.useRealTimers()
+      engine.dispose()
+    }
   })
 })


### PR DESCRIPTION
Self-review follow-up of #329 (EPIC #318).

## Problem

The pre-Run gate `await`ed `resolveComponentManifest` (Promise.all of the loaders) with **no timeout**. A hung/slow CDN fetch hung Run-start indefinitely — click Run, nothing happens, no error, no sound. #318 made this pre-existing lazy-load exposure more visible by turning it into a hard gate.

## Fix

Race the preflight against `PREFLIGHT_TIMEOUT_MS` (5s). **A timeout is not a definitive "missing"** → on timeout the engine **proceeds with a `[Warning]`** and lets playback lazy-load (post-#320 SV43 self-heal covers transient failures). It does **not** refuse — refusing Run on a slow network would be worse UX than the silent-drop #318 fixed. A definitive `hardMiss` still blocks as before; only the indeterminate timeout case proceeds. Timer cleared on the resolve path (no dangling timer).

This is the **decision embedded in #330** (proceed-vs-refuse on timeout), taken as proceed-with-warning per the rationale above — flagged as my recommendation in the prior session.

## Test plan / observation

- New integration test: a `loadSample` that never settles → preflight times out at 5s (fake timers) → `evaluate` resolves with **no error** + the timeout warning printed. **Real detector:** without the timeout logic `evaluate` would hang forever and the test would itself time out.
- `npx vitest run` → **981/981** (+1). `npx tsc --noEmit` clean.
- Catalogue: SV44 honest-bound updated to record timeout→proceed.

Closes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)