### PR TITLE
✨ feat(app): default to "Solar Flare" with a slim header — closes #334

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -21,17 +21,8 @@ import { decodeShareCode, buildShareURL, pickInitialBuffer } from './ShareLink'
 import { theme } from './theme'
 import { track, EVENTS, errorClass, detectBrowserFamily } from './Analytics'
 
-// Welcome buffer — the Blade Runner Ecstasy Edit
-const WELCOME_CODE = `# =====================================================
-#   ____              _        ____  _  __        __   _
-#  / ___|  ___  _ __ (_) ___  |  _ \\(_) \\ \\      / /__| |__
-#  \\___ \\ / _ \\| '_ \\| |/ __| | |_) | |  \\ \\ /\\ / / _ \\ '_ \\
-#   ___) | (_) | | | | | (__  |  __/| |   \\ V  V /  __/ |_) |
-#  |____/ \\___/|_| |_|_|\\___| |_|   |_|    \\_/\\_/ \\___|_.__/
-#
-#  Your Sonic Pi code, now portable.
-# =====================================================
-#
+// Welcome buffer — "Solar Flare" (progressive trance) is the default piece
+const WELCOME_CODE = `#
 #  Press Run (Ctrl+Enter or Alt+R) to hear this piece.
 #  Press Stop (Esc or Alt+S) to silence everything.
 #  Edit the code while it plays — changes apply instantly!
@@ -44,268 +35,110 @@ const WELCOME_CODE = `# =====================================================
 #    SuperCollider          — supercollider.github.io
 #    Sonic Pi community     — in-thread.sonic-pi.net
 #
-# =====================================================
-#  BLADE RUNNER x TECHNO
-#  10 synced loops: percussion + harmonic engine + synthbass
-#  Techniques: define, line().mirror.tick, panslicer, sync
-# =====================================================
+# "Solar Flare" — Progressive Trance
+# Inspired by the Sonic Pi community
+# Technique: line() filter sweeps, building arpeggios, layered pads
 
-use_bpm 115
+use_bpm 138
 
-amp_master = 1.0
-c_blade    = 72
-c_perc     = 115
-
-define :pattern do |p|
-  p.ring.tick == "x"
+live_loop :director do
+  set :section, 0  # intro: kick + rising filter arp
+  sleep 32
+  set :section, 1  # build: pads enter, arp intensifies
+  sleep 32
+  set :section, 2  # drop: full euphoric chords + bass
+  sleep 64
+  set :section, 3  # breakdown: pad solo, no drums
+  sleep 16
+  set :section, 4  # climax: everything, peak energy
+  sleep 48
+  stop
 end
 
-live_loop :met1 do
+live_loop :kick do
+  s = get[:section]
+  vol = 0
+  vol = 1.5 if s == 0 or s == 1
+  vol = 2.0 if s == 2 or s == 4
+  sample :bd_haus, amp: vol
   sleep 1
 end
 
-# KICK
-live_loop :kick, sync: :met1 do
-  sample :bd_haus, amp: 1.5 * amp_master, cutoff: c_perc      if pattern "x-----------x---"
-  sample :bd_tek,  amp: 0.5 * amp_master, cutoff: c_perc + 12 if pattern "x-----------x---"
-  sleep 0.25
+live_loop :offbeat_hat do
+  s = get[:section]
+  vol = 0
+  vol = 0.4 if s == 0 or s == 1
+  vol = 0.6 if s == 2 or s == 4
+  sleep 0.5
+  sample :drum_cymbal_closed, amp: vol
+  sleep 0.5
 end
 
-# SNARE
-with_fx :reverb, mix: 0.3, room: 0.72 do
-  live_loop :snare, sync: :met1 do
-    sleep 1
-    sample :drum_snare_hard, rate: 1.8, cutoff: c_perc, amp: 0.65 * amp_master
-    sample :drum_snare_hard, rate: 1.6, start: 0.03, cutoff: c_perc, pan: 0.25, amp: 0.65 * amp_master
-    sample :drum_snare_hard, rate: 1.5, start: 0.06, cutoff: c_perc, pan: -0.25, amp: 0.65 * amp_master
-    sleep 1
-  end
+live_loop :clap do
+  s = get[:section]
+  vol = 0
+  vol = 0.8 if s == 1
+  vol = 1.2 if s == 2 or s == 4
+  sleep 1
+  sample :sn_dub, amp: vol
+  sleep 1
 end
 
-# HI-HATS
-with_fx :panslicer, mix: 0.22 do
-  with_fx :reverb, mix: 0.15 do
-    live_loop :hats, sync: :met1 do
-      a = rrand(0.38, 0.72) * amp_master
-      sample :drum_cymbal_closed, amp: a, rate: 2.2, finish: 0.5, pan: [-0.4, 0.4].choose, cutoff: c_perc if pattern "x-x-x-x-x-x-x-x-xxx-x-x-x-"
-      sleep 0.125
-    end
-  end
-end
-
-# CRASH
-with_fx :reverb, mix: 0.75 do
-  live_loop :crash, sync: :met1 do
-    sleep 15.5
-    sample :drum_splash_soft, amp: 0.07 * amp_master, cutoff: c_perc - 12, rate: 1.4, finish: 0.3
-    sleep 0.5
-  end
-end
-
-# HARMONIC ENGINE
-with_fx :panslicer, mix: 0.18, phase: 8 do
-  with_fx :reverb, room: 0.97, mix: 0.78, damp: 0.4 do
-
-    # PADS
-    live_loop :pads, sync: :met1 do
-      use_synth :blade
-      sweep = (line c_blade - 16, c_blade + 16, steps: 16).mirror.tick
-
-      [:c3, :eb3, :g3, :b3].each do |n|
-        play n, attack: 3.0, sustain: 5.0, release: 4.0, amp: 1.3 * amp_master, cutoff: sweep, vibrato_rate: 4.5, vibrato_depth: 0.10, vibrato_delay: 1.5, vibrato_onset: 0.8
-      end
-      sleep 12
-
-      [:eb3, :g3, :bb3, :d4, :f4].each do |n|
-        play n, attack: 3.0, sustain: 5.0, release: 4.0, amp: 1.3 * amp_master, cutoff: sweep + 8, vibrato_rate: 5.0, vibrato_depth: 0.12, vibrato_delay: 1.2, vibrato_onset: 0.7
-      end
-      sleep 12
-
-      [:ab2, :c3, :eb3, :g3].each do |n|
-        play n, attack: 3.0, sustain: 5.0, release: 4.0, amp: 1.4 * amp_master, cutoff: sweep + 14, vibrato_rate: 5.5, vibrato_depth: 0.15, vibrato_delay: 1.0, vibrato_onset: 0.6
-      end
-      sleep 12
-
-      [:g2, :b2, :d3, :f3, :a3].each do |n|
-        play n, attack: 3.5, sustain: 5.0, release: 4.5, amp: 1.4 * amp_master, cutoff: sweep + 20, vibrato_rate: 6.0, vibrato_depth: 0.18, vibrato_delay: 0.8, vibrato_onset: 0.5
-      end
-      sleep 12
-    end
-
-    # MELODY
-    live_loop :melody, sync: :pads do
-      use_synth :blade
-      vib = (line 0.10, 0.30, steps: 48).mirror.tick
-
-      play :c5, attack: 1.5, sustain: 2.5, release: 2.5, amp: 0.58 * amp_master, cutoff: c_blade + 6, vibrato_rate: 5.5, vibrato_depth: vib, vibrato_delay: 0.8, vibrato_onset: 0.5
-      sleep 5
-      play :eb5, attack: 0.8, sustain: 1.5, release: 1.8, amp: 0.52 * amp_master, cutoff: c_blade + 4, vibrato_rate: 5.2, vibrato_depth: vib + 0.02, vibrato_delay: 0.6, vibrato_onset: 0.4
-      sleep 4
-      play :g5, attack: 0.6, sustain: 1.2, release: 1.5, amp: 0.50 * amp_master, cutoff: c_blade + 8, vibrato_rate: 5.8, vibrato_depth: vib + 0.02, vibrato_delay: 0.5, vibrato_onset: 0.3
-      sleep 3
-
-      play :bb5, attack: 2.0, sustain: 3.5, release: 2.5, amp: 0.64 * amp_master, cutoff: c_blade + 12, vibrato_rate: 6.0, vibrato_depth: vib + 0.04, vibrato_delay: 0.9, vibrato_onset: 0.5
-      sleep 6
-      play :g5, attack: 0.8, sustain: 2.0, release: 2.0, amp: 0.56 * amp_master, cutoff: c_blade + 10, vibrato_rate: 5.8, vibrato_depth: vib + 0.02, vibrato_delay: 0.7, vibrato_onset: 0.4
-      sleep 6
-
-      play :c6, attack: 2.5, sustain: 5.5, release: 3.0, amp: 0.68 * amp_master, cutoff: c_blade + 20, vibrato_rate: 6.5, vibrato_depth: vib + 0.08, vibrato_delay: 1.2, vibrato_onset: 0.6
-      sleep 12
-
-      play :d6, attack: 3.0, sustain: 4.5, release: 3.5, amp: 0.66 * amp_master, cutoff: c_blade + 24, vibrato_rate: 7.0, vibrato_depth: vib + 0.10, vibrato_delay: 1.0, vibrato_onset: 0.7
-      sleep 8
-      play :b5, attack: 1.2, sustain: 1.8, release: 2.2, amp: 0.55 * amp_master, cutoff: c_blade + 18, vibrato_rate: 6.5, vibrato_depth: vib + 0.05, vibrato_delay: 0.6, vibrato_onset: 0.4
-      sleep 4
-    end
-
-    # ECSTASY ARPEGGIOS
-    live_loop :ecstasy, sync: :pads do
-      use_synth :blade
-      arp_chords = [
-        [:c4, :eb4, :g4, :b4, :c5, :g4],
-        [:eb4, :g4, :bb4, :d5, :f5, :bb4],
-        [:ab4, :c5, :eb5, :g5, :ab5, :eb5],
-        [:g4, :b4, :d5, :f5, :a5, :d5],
-      ]
-      4.times do |i|
-        arp = arp_chords[i]
-        spd = 1.2 - (i * 0.05)
-        breath = 12.0 - (arp.length * spd)
-        with_fx :echo, phase: 0.75, mix: (line 0.08, 0.72, steps: 128).mirror.tick do
-          arp.each do |n|
-            play n, attack: 0.04, sustain: spd * 0.32, release: spd * 0.58, amp: rrand(0.18, 0.32) * amp_master, cutoff: c_blade + (i * 6) + rrand(-4, 8), vibrato_rate: rrand(6, 9), vibrato_depth: rrand(0.08, 0.16), vibrato_delay: 0.12, vibrato_onset: 0.06
-            sleep spd
-          end
-        end
-        sleep [breath, 0.25].max
-      end
-    end
-
-    # TEARS
-    live_loop :tears, sync: :pads do
-      use_synth :blade
-      tear_data = [[:eb6, 12], [:g6, 12], [:c7, 12], [:b6, 12]]
-      tear_data.each do |td|
-        if one_in(2)
-          play td[0], attack: rrand(2.5, 4.5), sustain: rrand(3.0, 5.5), release: rrand(4.0, 7.0), amp: rrand(0.12, 0.22) * amp_master, cutoff: rrand(92, 108), vibrato_rate: rrand(4.5, 7.0), vibrato_depth: rrand(0.18, 0.34), vibrato_delay: rrand(1.2, 2.5), vibrato_onset: rrand(0.5, 1.0)
-        end
-        sleep td[1]
-      end
-    end
-
-    # SHIMMER
-    live_loop :shimmer, sync: :pads do
-      use_synth :blade
-      pool = [:c6, :eb6, :g6, :bb6, :d7, :c7, :g6, :eb6, :ab6, :f6, :b6, :d6]
-      pool.each do |n|
-        unless one_in(3)
-          play n, attack: rrand(1.0, 3.0), sustain: rrand(0.5, 2.0), release: rrand(3.5, 6.0), amp: rrand(0.06, 0.16) * amp_master, cutoff: rrand(94, 112), vibrato_rate: rrand(7.0, 10.0), vibrato_depth: rrand(0.14, 0.30), vibrato_delay: rrand(0.3, 0.8), vibrato_onset: rrand(0.2, 0.5)
-        end
-        sleep rrand(1.0, 3.0)
-      end
-    end
-
+live_loop :arp do
+  s = get[:section]
+  use_synth :saw
+  vol = 0
+  vol = 0.2 if s == 0
+  vol = 0.3 if s == 1
+  vol = 0.4 if s == 2 or s == 4
+  vol = 0.15 if s == 3
+  co = 70
+  co = 90 if s == 1
+  co = 110 if s >= 2
+  notes = scale(:a3, :minor_pentatonic, num_octaves: 2)
+  with_fx :echo, phase: 0.25, decay: 4, mix: 0.4 do
+    play notes.tick, release: 0.15, amp: vol, cutoff: co
+    sleep 0.125
   end
 end
 
-# SYNTHBASS
-with_fx :panslicer, mix: 0.28 do
-  with_fx :reverb, mix: 0.28 do
-    live_loop :synthbass, sync: :pads do
-      use_synth :tech_saws
-      bass_data = [[:c2, 56], [:eb2, 60], [:ab2, 65], [:g2, 69]]
-      bass_data.each do |bd|
-        play bd[0], sustain: 8.5, release: 3.0, cutoff: bd[1], amp: 0.78 * amp_master, attack: 0.1
-        sleep 12
-      end
-    end
+live_loop :pad do
+  s = get[:section]
+  use_synth :prophet
+  vol = 0
+  vol = 0.3 if s == 1
+  vol = 0.5 if s == 2
+  vol = 0.6 if s == 3
+  vol = 0.5 if s == 4
+  chords = [chord(:a3, :minor), chord(:f3, :major),
+            chord(:c4, :major), chord(:g3, :major)]
+  with_fx :reverb, room: 0.8, mix: 0.5 do
+    play chords.tick, attack: 1, release: 6, amp: vol, cutoff: 90
+    sleep 4
   end
 end
 
-# ============================================================
-#  CHRISSENDO — the cyberpunk beat drop
-#  Fires every 48 beats (4 chord cycles). Long hold → rising
-#  noise sweep → accelerating snare roll → sub-kick + acid stab.
-#  Mood: BR2049 at 2AM, rain on neon, synths through distortion.
-# ============================================================
-live_loop :chrissendo, sync: :pads do
-  sleep 32
+live_loop :bass do
+  s = get[:section]
+  use_synth :sine
+  vol = 0
+  vol = 0.6 if s == 2
+  vol = 0.8 if s == 4
+  notes = ring(:a1, :a1, :f1, :f1, :c2, :c2, :g1, :g1)
+  play notes.tick, release: 0.4, amp: vol
+  sleep 0.5
+end
 
-  # RISER — 8 beats of rising noise; cutoff on each play opens the filter
-  with_fx :reverb, mix: 0.6 do
-    use_synth :cnoise
-    riser_amps = line 0.04, 0.32, steps: 32
-    32.times do |i|
-      play 60, attack: 0, release: 0.12, amp: riser_amps.tick * amp_master, cutoff: 60 + (i * 2), pan: rrand(-0.4, 0.4)
-      sleep 0.25
-    end
+live_loop :riser do
+  s = get[:section]
+  use_synth :cnoise
+  vol = 0
+  vol = 0.06 if s == 1
+  vol = 0.08 if s == 3
+  with_fx :hpf, cutoff: rrand(70, 100) do
+    play :c4, release: 4, amp: vol
   end
-
-  # SNARE ROLL — 4 beats, doubling every bar, building tension
-  roll_rates = [0.5, 0.5, 0.5, 0.5, 0.25, 0.25, 0.25, 0.25, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125]
-  roll_amps  = line 0.22, 0.6, steps: 16
-  16.times do
-    sample :drum_snare_hard, rate: 1.8, cutoff: c_perc, amp: roll_amps.tick * amp_master, pan: rrand(-0.3, 0.3)
-    sleep roll_rates.tick
-  end
-
-  # IMPACT — sub-kick + distorted TB303 acid stab, Blade pad shimmer
-  with_fx :distortion, distort: 0.55, mix: 0.75 do
-    sample :bd_klub, amp: 2.8 * amp_master, rate: 0.55
-    use_synth :tb303
-    play :c2, attack: 0.005, release: 3.2, cutoff: 98, res: 0.88, amp: 0.95 * amp_master
-    play :c3, attack: 0.005, release: 1.8, cutoff: 92, res: 0.80, amp: 0.45 * amp_master
-  end
-
-  # Echoed aftershock stab — locks the drop back into the pad palette
-  with_fx :echo, phase: 0.5, decay: 4, mix: 0.35 do
-    use_synth :blade
-    play :c5, attack: 0.02, sustain: 1.5, release: 2.5, amp: 0.5 * amp_master, cutoff: c_blade + 18, vibrato_rate: 6.0, vibrato_depth: 0.12
-  end
-
   sleep 4
-end
-
-# ============================================================
-#  FINALE — the fade into the rain
-#  Fires once, 144 beats in (3 chrissendo cycles). Sheds the
-#  rhythmic layers first, lets the pads breathe one last chord,
-#  then lands on a sustained Cm9 that dissolves into deep reverb.
-# ============================================================
-live_loop :finale, sync: :pads do
-  sleep 144
-
-  # First wave: shed percussion, bass, and the drop itself
-  stop_loop :kick
-  stop_loop :snare
-  stop_loop :hats
-  stop_loop :crash
-  stop_loop :synthbass
-  stop_loop :chrissendo
-
-  # One last chord cycle with only pads / melody / ecstasy / tears / shimmer
-  sleep 12
-
-  # Second wave: shed the melodic layers
-  stop_loop :pads
-  stop_loop :melody
-  stop_loop :ecstasy
-  stop_loop :tears
-  stop_loop :shimmer
-
-  # THE FINAL CHORD — Cm9 drifting into deep reverb + slow echo
-  with_fx :reverb, mix: 0.95, room: 0.99, damp: 0.3 do
-    with_fx :echo, phase: 2.0, decay: 10, mix: 0.45 do
-      use_synth :blade
-      [:c3, :eb3, :g3, :bb3, :d4, :g4, :c5, :eb5].each do |n|
-        play n, attack: 2.5, sustain: 10.0, release: 14.0, amp: 0.55 * amp_master, cutoff: c_blade + 14, vibrato_rate: 4.5, vibrato_depth: 0.09, vibrato_delay: 1.0
-      end
-    end
-  end
-
-  sleep 24           # let the reverb tail bloom
-  stop_loop :met1    # the metronome goes last
-  stop               # finale itself ends — song complete
 end`
 
 // Welcome log — credits and shortcuts


### PR DESCRIPTION
Closes #334.

## What
- `WELCOME_CODE` (`src/app/App.ts`, the default `buffers[0]`) now opens with the **Solar Flare** progressive-trance piece (verbatim from `src/engine/examples.ts`) instead of *Blade Runner x Techno*.
- Header replaced with a slim comment block (exactly as requested): Run/Stop controls, project + Sonic Tau links, "standing on the shoulders of giants" credits — no ASCII-art banner.
- Stale `// Welcome buffer — the Blade Runner Ecstasy Edit` comment corrected.

## Test plan / observation
- `npx tsc --noEmit` clean; `npx vitest run src/app` 20/20 (no test asserts WELCOME_CODE content).
- **Level 3:** captured the exact new default buffer through the engine — WAV 9.05s, Peak 0.197, RMS 0.040; samples + `fx_echo` + `fx_reverb` fire; audible end-to-end.
- The post-#331 pre-Run preflight **proceeds-with-warning** on the default (verified in the capture), so the swap doesn't regress first-run.

## Observed, out of scope (not introduced here)
`sonic-pi-sine.scsyndef` CORS-fails from `unpkg.com` in the dev-server env (Solar Flare's bass uses `:sine`) — the known **SP89** CDN-CORS pattern, environmental. The preflight degrades gracefully (doesn't block). Raising for visibility; if we want the *default* piece immune to CDN hiccups we could swap the bass synth, but that's a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)