### PR TITLE
🐛 fix(engine): resolve synth aliases in preflight scanners — closes #337

### DIFF
--- a/src/engine/ComponentManifest.ts
+++ b/src/engine/ComponentManifest.ts
@@ -25,6 +25,7 @@
  */
 
 import type { Program } from './Program'
+import { resolveSynthName } from './SoundLayer'
 
 export interface ComponentManifest {
   samples: Set<string>
@@ -46,7 +47,15 @@ export function collectComponentManifest(
       case 'play':
         // `synth` is optional on the type but ProgramBuilder always stamps
         // it; guard defensively rather than assume.
-        if (step.synth) into.synths.add(step.synth)
+        //
+        // Resolve the alias (`:sine`→`beep`, `:mod_beep`→`mod_sine`) HERE so
+        // the manifest reports the synthdef the runtime will actually load.
+        // AudioInterpreter applies resolveSynthName at /s_new time
+        // (AudioInterpreter.ts:110); the preflight resolver must agree or it
+        // fetches `sonic-pi-sine.scsyndef` — a name the CDN package never
+        // ships → 404 (SP89, the CORS-masquerade) + a spurious preflight
+        // timeout. SV14: symbol references resolve before normalization.
+        if (step.synth) into.synths.add(resolveSynthName(step.synth))
         break
       case 'sample':
         into.samples.add(step.name)

--- a/src/engine/ComponentScan.ts
+++ b/src/engine/ComponentScan.ts
@@ -27,6 +27,7 @@
  */
 
 import type { ComponentManifest } from './ComponentManifest'
+import { resolveSynthName } from './SoundLayer'
 
 /**
  * Strip Ruby comments so a commented-out `sample :typo` cannot false-block
@@ -77,7 +78,16 @@ export function scanComponentNames(code: string): ComponentManifest {
   for (const [bucket, re] of PATTERNS) {
     re.lastIndex = 0
     let m: RegExpExecArray | null
-    while ((m = re.exec(src)) !== null) manifest[bucket].add(m[1])
+    while ((m = re.exec(src)) !== null) {
+      // SV14: resolve the synth alias (`:sine`→`beep`, `:mod_beep`→`mod_sine`)
+      // at scan time so the preflight loads the synthdef the runtime will
+      // actually /s_new (AudioInterpreter.ts:110 resolves identically). The
+      // CDN package ships no `sonic-pi-sine.scsyndef`; without this the
+      // preflight resolver fetches a 404 (SP89 CORS-masquerade) and the
+      // 5s preflight spuriously times out on every `:sine` Run. Samples/FX
+      // have no alias layer — pass through unchanged.
+      manifest[bucket].add(bucket === 'synths' ? resolveSynthName(m[1]) : m[1])
+    }
   }
   return manifest
 }

--- a/src/engine/__tests__/ComponentManifest.test.ts
+++ b/src/engine/__tests__/ComponentManifest.test.ts
@@ -105,6 +105,22 @@ describe('collectComponentManifest (#318.1 / #321)', () => {
     expect(m.samples.size + m.fx.size + m.synths.size).toBe(0)
   })
 
+  it('resolves synth aliases so the preflight loads the real synthdef (SP89 / #337)', () => {
+    // `:sine` has no `sonic-pi-sine.scsyndef` in the CDN package — it aliases
+    // to `beep` (SoundLayer.resolveSynthName, applied at /s_new time in
+    // AudioInterpreter). The manifest must agree or the preflight resolver
+    // fetches a 404 (SP89 CORS-masquerade) + spuriously times out.
+    const p: Program = [
+      { tag: 'play', note: 57, opts: {}, synth: 'sine' },
+      { tag: 'play', note: 60, opts: {}, synth: 'mod_beep' },
+      { tag: 'play', note: 62, opts: {}, synth: 'prophet' },
+    ]
+    const m = collectComponentManifest(p)
+    expect([...m.synths].sort()).toEqual(['beep', 'mod_sine', 'prophet'])
+    expect(m.synths.has('sine')).toBe(false)
+    expect(m.synths.has('mod_beep')).toBe(false)
+  })
+
   it('accumulates into a caller-provided manifest (multi-loop aggregation)', () => {
     const acc = { samples: new Set<string>(), fx: new Set<string>(), synths: new Set<string>() }
     collectComponentManifest([{ tag: 'play', note: 60, opts: {}, synth: 'beep' }], acc)

--- a/src/engine/__tests__/ComponentScan.test.ts
+++ b/src/engine/__tests__/ComponentScan.test.ts
@@ -76,6 +76,20 @@ describe('scanComponentNames (#318.3 / #323 static extractor)', () => {
     })
   })
 
+  it('resolves synth aliases so the preflight loads the real synthdef (SP89 / #337)', () => {
+    // `:sine` has no `sonic-pi-sine.scsyndef` in the CDN package — it aliases
+    // to `beep`. The preflight resolver consumes this scan; keeping the raw
+    // name fetches a 404 (SP89 CORS-masquerade) and the 5s preflight
+    // spuriously times out on every `:sine` Run. SV14.
+    expect(s('use_synth :sine\nplay :a3')).toMatchObject({ synths: ['beep'] })
+    expect(s('synth :mod_beep, note: 60')).toMatchObject({ synths: ['mod_sine'] })
+    // Non-aliased synths pass through; samples/FX have no alias layer.
+    expect(s('use_synth :prophet\nwith_fx :reverb do\nend')).toMatchObject({
+      synths: ['prophet'],
+      fx: ['reverb'],
+    })
+  })
+
   it('empty / component-free code yields empty sets', () => {
     expect(s('play 60\nsleep 1')).toEqual({ samples: [], fx: [], synths: [] })
     expect(s('')).toEqual({ samples: [], fx: [], synths: [] })


### PR DESCRIPTION
Closes #337. SP89-class (CORS-404 masquerade). Branched off merged main — independent of #335/#332.

## Root cause (grounded)
`resolveSynthName` (`SoundLayer.ts:32`: `:sine→beep`, `:mod_beep→mod_sine`) is applied on the **runtime** path (`interpreters/AudioInterpreter.ts:110,194`) but not on the **pre-Run preflight** path. The preflight (`SonicPiEngine.ts:331`) consumes `ComponentScan.scanComponentNames` (#328), which collected the raw `sine` → `preloadSynth('sine')` → fetch `…/sonic-pi-sine.scsyndef` → **HTTP 404** (verified: package ships `sonic-pi-beep`, never `sonic-pi-sine`) → surfaced as CORS (SP89 masquerade). Every `:sine` Run spammed 404s + the 5s preflight spuriously timed out.

First fix attempt patched only `collectComponentManifest` (#321) — the unit test passed but the **WAV observation contradicted it**: the preflight uses the *other* scanner (#328). Followed observation, not inference; fixed both.

## Fix
Apply `resolveSynthName` to the synths bucket at scan time in **both** scanners — `ComponentScan` (#328, preflight-consumed) and `collectComponentManifest` (#321, sibling). SV14: symbol references resolve consistently at every name-translation boundary. Samples/FX unchanged (no alias layer).

## Test plan / observation
- New regression tests in `ComponentScan.test.ts` + `ComponentManifest.test.ts` (`:sine`→`beep`, `:mod_beep`→`mod_sine`, non-aliased pass-through).
- `npx tsc --noEmit` clean; `npx vitest run` **983/983**.
- **Level 3 (clean dev server, orphan-vite killed):** `use_synth :sine` capture — `sonic-pi-sine` 404 count **10→0**, preflight-timeout warning **present→NONE**, "No errors detected", audio plays `/s_new "sonic-pi-beep"` at **t:2.3s** (was ~7s — preflight no longer blocks on the doomed fetch).

## Catalogue
SP89 now grounded with the second-scanner span; SV14 span extended (runtime + #321 + #328). Follow-up to update `.anvi` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)