### PR TITLE
🐛 fix(engine): Time State persists across Stop, matching desktop SP — closes #336

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1736,7 +1736,14 @@ export class SonicPiEngine {
     this.loopTicks.clear()
     this.loopBeats.clear()
     this.loopSynced.clear()
-    this.globalStore.clear()
+    // Time State (set/get) intentionally NOT cleared on Stop. Desktop Sonic
+    // Pi creates @event_history once per session (runtime.rb:1450) and never
+    // clears it on Stop — `get` is documented "deterministic across Runs".
+    // The core live-coding workflow (Run a piece that `set`s state → Stop →
+    // Run a fragment that `get`s it) relies on this. Clearing here was an
+    // inception-time "clean slate" assumption (517bf7b), not a debugged
+    // invariant, and diverged from the reference. Cleared only on dispose()
+    // (full engine teardown ≈ Sonic Pi app restart). #336.
     this.definedFns.clear()
     this.defonceCache.clear()
     // SP85 (#294): return persistentFx bus indices to the bridge pool BEFORE

--- a/src/engine/__tests__/SonicPiEngine.test.ts
+++ b/src/engine/__tests__/SonicPiEngine.test.ts
@@ -731,4 +731,53 @@ end
 
     engine.dispose()
   })
+
+  it('Time State (set/get) persists across Stop, matching desktop Sonic Pi (#336)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    // Run 1: a piece that sets shared state (the :director role in Solar Flare).
+    await engine.evaluate('set :section, 41')
+
+    // Stop — desktop SP does NOT clear @event_history on Stop; `get` is
+    // documented deterministic across Runs. Our engine used to wipe it here.
+    engine.stop()
+
+    // Run 2: a fragment that only READS the state (the extracted :arp role).
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+    await engine.evaluate('play get[:section]')
+
+    const scheduler = (engine as unknown as { scheduler: { tick: (t: number) => void } }).scheduler
+    scheduler.tick(100)
+    await new Promise((r) => setTimeout(r, 50))
+
+    // get[:section] must still be 41 (survived Stop) → play emits midiNote 41.
+    // Pre-fix: globalStore.clear() in stop() wiped it → get[:section] === null
+    // → play(null) → no 41 note → :arp-class silence.
+    expect(events.some((e) => e.midiNote === 41)).toBe(true)
+
+    engine.dispose()
+  })
+
+  it('Time State IS cleared on dispose (session end ≈ Sonic Pi app restart) (#336)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate('set :section, 41')
+    engine.dispose()
+
+    // Fresh engine after dispose: state must NOT leak in.
+    const engine2 = new SonicPiEngine()
+    await engine2.init()
+    const events: SoundEvent[] = []
+    engine2.components.streaming!.eventStream.on((e) => events.push(e))
+    await engine2.evaluate('play (get[:section] || 99)')
+    const scheduler = (engine2 as unknown as { scheduler: { tick: (t: number) => void } }).scheduler
+    scheduler.tick(100)
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(events.some((e) => e.midiNote === 99)).toBe(true)
+    expect(events.some((e) => e.midiNote === 41)).toBe(false)
+    engine2.dispose()
+  })
 })

--- a/tools/test-timestate-across-stop.ts
+++ b/tools/test-timestate-across-stop.ts
@@ -1,0 +1,164 @@
+/**
+ * Level-3 reproducer for #336 / PR #339 — Time State must persist across Stop.
+ *
+ * Exactly the user's reported workflow, with one continuous Rec spanning
+ * phase 2 only:
+ *   Phase 1: a "director" piece that `set :section, 2`, Run, play, STOP.
+ *   Phase 2: the EXTRACTED `:arp` loop (reads `get[:section]`), Run, record.
+ *
+ * Pre-fix (globalStore.clear() in stop()): phase-2 `get[:section]` → nil →
+ *   every `vol = X if s == N` false → amp 0 → SILENT WAV (RMS ~0).
+ * Post-fix: :section survives Stop → vol 0.4 → AUDIBLE WAV (RMS > 0).
+ *
+ * The WAV is the observation; RMS/peak is the verdict.
+ */
+import { chromium } from 'playwright'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173/'
+const OUT_DIR = resolve(process.cwd(), '.captures', 'timestate-across-stop')
+
+const DIRECTOR = `live_loop :director do
+  set :section, 2
+  sleep 4
+end`
+
+const ARP_ONLY = `live_loop :arp do
+  s = get[:section]
+  use_synth :saw
+  vol = 0
+  vol = 0.2 if s == 0
+  vol = 0.3 if s == 1
+  vol = 0.4 if s == 2 or s == 4
+  vol = 0.15 if s == 3
+  co = 70
+  co = 90 if s == 1
+  co = 110 if s >= 2
+  notes = scale(:a3, :minor_pentatonic, num_octaves: 2)
+  with_fx :echo, phase: 0.25, decay: 4, mix: 0.4 do
+    play notes.tick, release: 0.15, amp: vol, cutoff: co
+    sleep 0.125
+  end
+end`
+
+function wavRms(buf: Buffer): { rms: number; peak: number; durSec: number } {
+  // Find 'data' chunk; samples are float32 LE (Recorder.ts raw float32 WAV).
+  let off = 12
+  let dataOff = -1
+  let dataLen = 0
+  while (off + 8 <= buf.length) {
+    const id = buf.toString('ascii', off, off + 4)
+    const sz = buf.readUInt32LE(off + 4)
+    if (id === 'data') { dataOff = off + 8; dataLen = sz; break }
+    off += 8 + sz + (sz & 1)
+  }
+  if (dataOff < 0) return { rms: 0, peak: 0, durSec: 0 }
+  // Recorder.ts emits PCM 16-bit LE stereo @48k (audioFormat=1).
+  const n = Math.floor(Math.min(dataLen, buf.length - dataOff) / 2)
+  let sumSq = 0
+  let peak = 0
+  for (let i = 0; i < n; i++) {
+    const s = buf.readInt16LE(dataOff + i * 2) / 32768
+    sumSq += s * s
+    const a = Math.abs(s)
+    if (a > peak) peak = a
+  }
+  return { rms: Math.sqrt(sumSq / n), peak, durSec: n / 2 / 48000 }
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+  const browser = await chromium.launch({ headless: false })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', e => console.error('[page error]', e.message))
+  page.on('console', m => {
+    if (m.type() === 'error') console.error('[console error]', m.text())
+  })
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(2000)
+
+  await page.evaluate(() => {
+    ;(window as unknown as { __wav: Blob | null }).__wav = null
+    const oc = HTMLAnchorElement.prototype.click
+    HTMLAnchorElement.prototype.click = function () {
+      if (this.href?.startsWith('blob:') && this.download?.endsWith('.wav')) {
+        fetch(this.href).then(r => r.blob()).then(b => {
+          ;(window as unknown as { __wav: Blob }).__wav = b
+        })
+      } else { oc.call(this) }
+    }
+  })
+
+  const editor = page.locator('.cm-content, textarea').first()
+  const runBtn = page.locator('.spw-btn-label').filter({ hasText: /^(Run|Update)$/ }).first()
+  const stopBtn = page.locator('button').filter({ hasText: 'Stop' }).first()
+  const recBtn = page.getByTitle('Record to WAV').first()
+
+  const paste = async (code: string) => {
+    await editor.click()
+    await page.keyboard.press('Meta+a')
+    await page.keyboard.press('Backspace')
+    await page.waitForTimeout(100)
+    await editor.fill(code)
+    await page.waitForTimeout(200)
+  }
+
+  // ── Phase 1: director sets :section, then STOP ──
+  console.log('[ts] Phase 1: run :director (set :section, 2)…')
+  await paste(DIRECTOR)
+  await runBtn.click()
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 15000 },
+  ).catch(() => {})
+  await page.waitForTimeout(3000)            // let :director run + set state
+  console.log('[ts] Phase 1: STOP (pre-fix this wipes Time State)')
+  await stopBtn.click()
+  await page.waitForTimeout(1000)
+
+  // ── Phase 2: extracted :arp only, record the result ──
+  // Run FIRST (engine live → stratum S1 → Rec available; Stop had dropped
+  // it to S3). The state read happens at this Run, AFTER the phase-1 Stop —
+  // that is precisely what the fix must make survive.
+  console.log('[ts] Phase 2: paste :arp-only, Run…')
+  await paste(ARP_ONLY)
+  await runBtn.click()
+  await page.waitForTimeout(1200)
+  const btns = (await page.locator('button').allTextContents()).filter(t => t.trim())
+  console.log('[ts] toolbar buttons after phase-2 Run:', btns.join(' | '))
+  console.log('[ts] Phase 2: Rec ON, observe 7s…')
+  await recBtn.waitFor({ timeout: 10000 })
+  await recBtn.click()
+  await page.waitForTimeout(7000)
+
+  // Toggle the same recording button OFF — this fires the .wav blob download
+  // (intercepted above). The 💾 toolbar button saves the CODE buffer, not the WAV.
+  await recBtn.click()
+  await page.waitForTimeout(3000)
+
+  const b64 = await page.evaluate(async () => {
+    const b = (window as unknown as { __wav: Blob | null }).__wav
+    if (!b) return null
+    const u = new Uint8Array(await b.arrayBuffer())
+    let s = ''
+    for (let i = 0; i < u.length; i += 8192) s += String.fromCharCode(...u.subarray(i, Math.min(i + 8192, u.length)))
+    return btoa(s)
+  })
+  await page.locator('button').filter({ hasText: 'Stop' }).first().click().catch(() => {})
+  await browser.close()
+
+  if (!b64) throw new Error('no WAV captured')
+  const wav = Buffer.from(b64, 'base64')
+  const wavPath = resolve(OUT_DIR, 'arp-after-stop.wav')
+  writeFileSync(wavPath, wav)
+  const { rms, peak, durSec } = wavRms(wav)
+  console.log(`\n[ts] WAV: ${wavPath} (${(wav.length / 1e6).toFixed(2)} MB, ~${durSec.toFixed(1)}s)`)
+  console.log(`[ts] RMS=${rms.toFixed(5)}  Peak=${peak.toFixed(4)}`)
+  const PASS = rms > 0.002
+  console.log(`[ts] VERDICT: ${PASS ? 'PASS — :arp AUDIBLE after Stop (Time State survived)' : 'FAIL — silent (state wiped on Stop)'}`)
+  process.exit(PASS ? 0 : 1)
+}
+
+main()


### PR DESCRIPTION
Closes #336. Branched off merged main — independent of #332/#335/#338.

## Root cause (grounded both sides)
- **Desktop SP** `runtime.rb:1450`: `@event_history = EventHistory.new` created **once per session**, never cleared on Stop. `core.rb:334` `get` doc: "deterministic across Runs."
- **Ours** `SonicPiEngine.ts` `stop()`: `this.globalStore.clear()` wiped all `set`/`get` Time State on every Stop. `git blame` → added in the same commit that introduced get/set (`517bf7b`), a "clean slate" assumption, not a debugged invariant.

The core live-coding workflow — Run a piece that `set`s state → **Stop** → Run an extracted fragment that `get`s it — works in desktop, was silent in ours. This is what made Solar Flare's `:arp` (reads `get[:section]`, set by `:director`) silent when run alone after Stop.

## Diagnosis path (3 reframes, each evidence-driven — not flailing)
1. #336 hypothesis: per-iteration `with_fx :echo` torn down → **refuted by observation** (1 `fx_echo` /s_new across 67 iterations).
2. Composition-robustness (`get[:section]` nil default) → **refuted by user's desktop ground truth** (exact code plays in desktop).
3. Grounded in `desktop-sp/runtime.rb` + `core.rb` → Time State lifecycle parity bug. ✓

## Fix
Remove `globalStore.clear()` from `stop()`; keep it only in `dispose()` (full teardown ≈ Sonic Pi app restart). One line + rationale comment.

## Test plan / observation
- 2 new real-engine tests in `SonicPiEngine.test.ts`: (a) `set :section,41` → `engine.stop()` → `play get[:section]` emits **midiNote 41** (pre-fix: `null`); (b) dispose still clears — fresh engine gets the `|| 99` default, never stale 41.
- `npx tsc --noEmit` clean; `npx vitest run` **983/983** (+2).
- Earlier Level-3 WAV already showed nonzero `:section` → audible `:arp` (Peak 0.098). The two observations compose to the user scenario.
- **Honest tooling note:** `tools/capture.ts` has no run→stop→run mode, so the single-session browser replay is covered by the real-engine unit test + the prior WAV, not one combined WAV capture.

## Blast radius
`evaluate()` never cleared `globalStore` (Run-after-Run already persisted); only Stop did. This aligns Stop with Run and with desktop. No test asserted state-clears-on-stop. Determinism preserved (desktop's persistence *is* the deterministic contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)