### PR TITLE
🐛 fix(engine): share tick map across with_fx — arp no longer frozen on note 0 — closes #340

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -309,6 +309,16 @@ export class ProgramBuilder {
     inner._currentBuildSeconds = this._currentBuildSeconds
     inner._currentBeat = this._currentBeat
     inner._schedAheadTime = this._schedAheadTime
+    // Share the SAME tick map (by reference, not a copy). `with_fx` does NOT
+    // fork a thread (unlike in_thread / at, which push {tag:'thread'} and
+    // correctly get an independent tick scope) — it is a synchronous FX
+    // wrapper in the same thread, so `.tick`/`.look` inside it must advance
+    // the live_loop's persistent counter. Without this, every iteration's
+    // `inner` got a fresh empty tick map that was discarded after build(),
+    // so the engine's per-loop loopTicks never saw the advance → `play
+    // notes.tick` inside a per-iteration with_fx was frozen on index 0
+    // (Solar Flare :arp stuck on one note). #340.
+    inner.ticks = this.ticks
     fn(inner, fxRef)
     const fxOpts = !this._argBpmScaling ? { ...opts, _argBpmScaling: 0 } : opts
     this.steps.push({ tag: 'fx', name, opts: fxOpts, body: inner.build(), nodeRef: fxRef })

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -679,4 +679,41 @@ describe('ProgramBuilder', () => {
       expect(step.stop).toBeUndefined()
     })
   })
+
+  describe('tick state across block boundaries (#340)', () => {
+    it('with_fx shares the parent tick map — .tick inside advances the live_loop counter', () => {
+      // with_fx is a synchronous same-thread FX wrapper, NOT a forked thread.
+      // .tick inside it must mutate the SAME counter the engine persists via
+      // loopTicks between iterations. Pre-fix the inner builder got a fresh
+      // empty tick map that was discarded → `play notes.tick` inside a
+      // per-iteration with_fx was frozen on index 0 (Solar Flare :arp).
+      const b = new ProgramBuilder()
+      b.with_fx('echo', {}, (inner) => {
+        inner.tick()       // → 0
+        inner.tick()       // → 1
+        return inner
+      })
+      expect(b.getTicks().get('__default')).toBe(1)
+    })
+
+    it('a tick before with_fx continues (not resets) inside it', () => {
+      const b = new ProgramBuilder()
+      b.tick()                                   // outer → 0
+      b.with_fx('reverb', {}, (inner) => {
+        inner.tick()                             // must be 1, not a reset to 0
+        return inner
+      })
+      expect(b.getTicks().get('__default')).toBe(1)
+    })
+
+    it('in_thread does NOT share the tick map (forked thread = independent tick, Sonic Pi semantics)', () => {
+      const b = new ProgramBuilder()
+      b.tick()                                   // outer → 0  (ticks.__default = 0)
+      b.in_thread((inner) => {
+        inner.tick()                             // independent scope
+      })
+      // Outer counter unchanged by the forked thread's tick.
+      expect(b.getTicks().get('__default')).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
Closes #340. Branched off merged main — independent of #335/#338/#339.

## Symptom (user-found, via pitch-track of the desktop↔web A/B)
Solar Flare's `:arp` plays **one note forever** on web; desktop arpeggiates. `play <ring>.tick` inside a per-iteration `with_fx` is frozen on index 0.

## Root cause (grounded)
`.tick` uses the engine's **persistent per-live_loop counter** (`SonicPiEngine.loopTicks`, seeded into each iteration's builder at `:719`, saved back at `:762`) — *not* `Ring._tick`. That's why bare `notes = scale(...); play notes.tick` ticks fine despite rebuilding the ring each iteration. But `with_fx` (`ProgramBuilder.ts:299`) created its `inner` builder with a **fresh empty tick map**; `inner.tick()` advanced that, `inner` was discarded after `build()`, so the outer's `getTicks()` (→ `loopTicks`) never saw it → reset to 0 every iteration → every note = index 0.

Isolation: bare ✅ · `with_fx` OUTSIDE loop ✅ · `with_fx` INSIDE loop ❌ → the per-iteration sub-builder is the culprit.

## Fix
`with_fx`'s inner shares the **same tick Map by reference** (`inner.ticks = this.ticks`). `with_fx` is a synchronous same-thread FX wrapper — unlike `in_thread`/`at`, which push `{tag:'thread'}` and *correctly* keep an independent tick scope (Sonic Pi: tick is per-thread; `with_fx` does not fork a thread). One line.

## Test plan / observation
- 3 regression tests in `ProgramBuilder.test.ts`: with_fx shares tick · tick-before-with_fx continues · **in_thread does NOT share** (asserts forked-thread isolation is preserved — guards against over-reaching the fix).
- `npx tsc --noEmit` clean; `npx vitest run` **986/986** (+3).
- **Level-3 reproducer:** `scale(:a3,:minor_pentatonic,2).tick` inside per-iteration `with_fx :echo` → emits `57,60,62,64,67,69,72,74,76,79,81,57…` (was `57,57,57…`).
- **Level-3 desktop↔web A/B (pitch-track):** web now ascends the minor-pentatonic matching desktop's melodic contour (was frozen `[57]`). MFCC distance 154→121 as the wrong-notes confound cleared. Level still ~0.51× — the separate, known gain-staging family, not this bug.

## Relation to the thread
This is the actual `:arp` defect. #339 (Time State persist across Stop) and the gain-staging observations were real but adjacent — the headline "arp not working / notes not scaling" is this tick-ownership bug at the per-iteration `with_fx` boundary (SP11 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)