### PR TITLE
🐛 fix(engine): consolidate 3 drifted sub-builder copies into forkBuilder(mode) — closes #343

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -296,29 +296,10 @@ export class ProgramBuilder {
     // Assign a nodeRef so the FX can be targeted by control()
     const fxRef = this.nextRef++
     this._lastRef = fxRef
-    const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-    inner.currentSynth = this.currentSynth
-    inner.densityFactor = this.densityFactor
-    inner._argBpmScaling = this._argBpmScaling
-    inner._transpose = this._transpose
-    inner._synthDefaults = { ...this._synthDefaults }
-    inner._sampleDefaults = { ...this._sampleDefaults }
-    // Inherit iteration introspection state so current_time / current_beat
-    // inside with_fx / in_thread / at blocks return the outer's values (#226).
-    inner._iterationStartAudioTime = this._iterationStartAudioTime
-    inner._currentBuildSeconds = this._currentBuildSeconds
-    inner._currentBeat = this._currentBeat
-    inner._schedAheadTime = this._schedAheadTime
-    // Share the SAME tick map (by reference, not a copy). `with_fx` does NOT
-    // fork a thread (unlike in_thread / at, which push {tag:'thread'} and
-    // correctly get an independent tick scope) — it is a synchronous FX
-    // wrapper in the same thread, so `.tick`/`.look` inside it must advance
-    // the live_loop's persistent counter. Without this, every iteration's
-    // `inner` got a fresh empty tick map that was discarded after build(),
-    // so the engine's per-loop loopTicks never saw the advance → `play
-    // notes.tick` inside a per-iteration with_fx was frozen on index 0
-    // (Solar Flare :arp stuck on one note). #340.
-    inner.ticks = this.ticks
+    // with_fx is a synchronous same-thread FX wrapper — tick map AND random
+    // stream continue through it (#340/#341 + #343 Defect C). forkBuilder is
+    // the single source of truth for sub-builder state threading.
+    const inner = this.forkBuilder('same-thread')
     fn(inner, fxRef)
     const fxOpts = !this._argBpmScaling ? { ...opts, _argBpmScaling: 0 } : opts
     this.steps.push({ tag: 'fx', name, opts: fxOpts, body: inner.build(), nodeRef: fxRef })
@@ -326,19 +307,10 @@ export class ProgramBuilder {
   }
 
   in_thread(buildFn: (b: ProgramBuilder) => void): this {
-    const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-    inner.currentSynth = this.currentSynth
-    inner.densityFactor = this.densityFactor
-    inner._argBpmScaling = this._argBpmScaling
-    inner._transpose = this._transpose
-    inner._synthDefaults = { ...this._synthDefaults }
-    inner._sampleDefaults = { ...this._sampleDefaults }
-    // Inherit iteration introspection state so current_time / current_beat
-    // inside with_fx / in_thread / at blocks return the outer's values (#226).
-    inner._iterationStartAudioTime = this._iterationStartAudioTime
-    inner._currentBuildSeconds = this._currentBuildSeconds
-    inner._currentBeat = this._currentBeat
-    inner._schedAheadTime = this._schedAheadTime
+    // in_thread forks a thread → fresh tick scope + re-seeded rng, but
+    // inherits a snapshot of thread-locals (synth/bpm/transpose/density/
+    // defaults/iteration introspection). #343 Defect: _currentBpm now threads.
+    const inner = this.forkBuilder('forked')
     buildFn(inner)
     this.steps.push({ tag: 'thread', body: inner.build() })
     return this
@@ -348,18 +320,61 @@ export class ProgramBuilder {
     for (let i = 0; i < times.length; i++) {
       const offset = times[i]
       const val = values ? values[i % values.length] : i
-      const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-      inner.currentSynth = this.currentSynth
-      inner.densityFactor = this.densityFactor
-      inner._argBpmScaling = this._argBpmScaling
-      inner._transpose = this._transpose
-      inner._synthDefaults = { ...this._synthDefaults }
-      inner._sampleDefaults = { ...this._sampleDefaults }
+      // `at` forks a thread per time like in_thread. forkBuilder also threads
+      // iteration introspection (#226 Defect B — `at` used to drop it) and
+      // _currentBpm (#343 Defect A).
+      const inner = this.forkBuilder('forked')
       if (offset > 0) inner.sleep(offset)
       buildFn(inner, val)
       this.steps.push({ tag: 'thread', body: inner.build() })
     }
     return this
+  }
+
+  /**
+   * Single source of truth for which per-thread / per-build state threads into
+   * a nested block's sub-builder. Replaces three hand-maintained copies that
+   * had drifted (#343). Desktop SP semantics (ref/sources/desktop-sp):
+   *  - 'same-thread' (with_fx): no thread fork → ALL thread-locals continue,
+   *    including the tick map and the random STREAM, shared by reference.
+   *  - 'forked' (in_thread / at): forks a thread → inherits a SNAPSHOT of
+   *    thread-locals but gets a FRESH tick scope and a RE-SEEDED rng
+   *    (runtime.rb:1062-1067 only re-seeds on a new thread).
+   */
+  private forkBuilder(mode: 'same-thread' | 'forked'): ProgramBuilder {
+    // 'forked' re-seeds the rng from the parent stream (deterministic fork);
+    // 'same-thread' shares the parent rng instance (set below) so the seed
+    // here is irrelevant and must NOT consume from the parent stream.
+    const inner = mode === 'forked'
+      ? new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
+      : new ProgramBuilder()
+    // Common — inherited by every sub-builder regardless of mode.
+    inner.currentSynth = this.currentSynth
+    inner.densityFactor = this.densityFactor
+    inner._argBpmScaling = this._argBpmScaling
+    inner._transpose = this._transpose
+    inner._synthDefaults = { ...this._synthDefaults }
+    inner._sampleDefaults = { ...this._sampleDefaults }
+    // #343 Defect A: use_bpm is thread-local in desktop SP (runtime.rb:155).
+    // with_fx (same thread) continues it; in_thread/at snapshot it at fork.
+    // Previously NO sub-builder inherited it → silent 2× tempo error.
+    inner._currentBpm = this._currentBpm
+    // Iteration introspection (#226) so current_time / current_beat inside
+    // with_fx / in_thread / at return the outer's values. #343 Defect B:
+    // `at` used to drop these.
+    inner._iterationStartAudioTime = this._iterationStartAudioTime
+    inner._currentBuildSeconds = this._currentBuildSeconds
+    inner._currentBeat = this._currentBeat
+    inner._schedAheadTime = this._schedAheadTime
+    if (mode === 'same-thread') {
+      // with_fx forks no thread: tick map AND random stream continue. Sharing
+      // the tick Map by reference is the #340/#341 fix; sharing the rng
+      // instance is its seed-fork analog (#343 Defect C). 'forked' leaves
+      // inner.ticks a fresh Map and inner.rng the re-seeded generator.
+      inner.ticks = this.ticks
+      inner.rng = this.rng
+    }
+    return inner
   }
 
   live_audio(name: string, optsOrStop?: Record<string, number> | 'stop', maybeOpts?: Record<string, number>): this {

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -716,4 +716,92 @@ describe('ProgramBuilder', () => {
       expect(b.getTicks().get('__default')).toBe(0)
     })
   })
+
+  describe('sub-builder state threading — forkBuilder(mode) (#343)', () => {
+    // Desktop SP: with_fx forks no thread → random STREAM continues (the
+    // seed-fork analog of the #340 tick fix). in_thread/at fork → re-seeded.
+    // `rng` is private — read it through a structural cast (same pattern the
+    // #340 block uses for _currentBuildSeconds).
+    const rngOf = (b: ProgramBuilder) => (b as unknown as { rng: { next(): number } }).rng
+
+    it('Defect C: with_fx continues the parent random stream (does not re-fork)', () => {
+      const flat = new ProgramBuilder()
+      flat.use_random_seed(42)
+      const baseline = [rngOf(flat).next(), rngOf(flat).next(), rngOf(flat).next(), rngOf(flat).next()]
+
+      const b = new ProgramBuilder()
+      b.use_random_seed(42)
+      const seq: number[] = [rngOf(b).next()]
+      b.with_fx('reverb', {}, (inner) => {
+        seq.push(rngOf(inner).next())
+        seq.push(rngOf(inner).next())
+        return inner
+      })
+      seq.push(rngOf(b).next())
+      expect(seq).toEqual(baseline)
+    })
+
+    it('in_thread re-forks the rng (forked thread = independent stream)', () => {
+      const flat = new ProgramBuilder()
+      flat.use_random_seed(42)
+      const baseline = [rngOf(flat).next(), rngOf(flat).next()]
+
+      const b = new ProgramBuilder()
+      b.use_random_seed(42)
+      rngOf(b).next()                            // parent pos0
+      let innerFirst = -1
+      b.in_thread((inner) => { innerFirst = rngOf(inner).next() })
+      // Forked: inner's first draw is NOT the parent's next stream position.
+      expect(innerFirst).not.toBeCloseTo(baseline[1], 9)
+    })
+
+    it('Defect A: use_bpm threads into with_fx (same-thread tempo continues)', () => {
+      const b = new ProgramBuilder()
+      b.use_bpm(120)
+      let beatSecs = -1
+      b.with_fx('reverb', {}, (inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        beatSecs = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+        return inner
+      })
+      expect(beatSecs).toBeCloseTo(0.5, 9)       // 1 beat @ bpm120, not 1.0s @ bpm60
+    })
+
+    it('Defect A: use_bpm snapshots into in_thread/at at fork', () => {
+      const bt = new ProgramBuilder()
+      bt.use_bpm(120)
+      let inThreadBeat = -1
+      bt.in_thread((inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        inThreadBeat = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+      })
+      expect(inThreadBeat).toBeCloseTo(0.5, 9)
+
+      const ba = new ProgramBuilder()
+      ba.use_bpm(120)
+      let atBeat = -1
+      ba.at([0], null, (inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        atBeat = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+      })
+      expect(atBeat).toBeCloseTo(0.5, 9)
+    })
+
+    it('Defect B: at inherits iteration introspection (#226), like with_fx/in_thread', () => {
+      const b = new ProgramBuilder()
+      ;(b as unknown as { _currentBuildSeconds: number })._currentBuildSeconds = 9.5
+      ;(b as unknown as { _currentBeat: number })._currentBeat = 3
+      let seenSecs = -1
+      let seenBeat = -1
+      b.at([0], null, (inner) => {
+        seenSecs = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        seenBeat = (inner as unknown as { _currentBeat: number })._currentBeat
+      })
+      expect(seenSecs).toBe(9.5)
+      expect(seenBeat).toBe(3)
+    })
+  })
 })


### PR DESCRIPTION
## Problem

`ProgramBuilder` had **three** near-identical ~10-line blocks (`with_fx`, `in_thread`, `at`) each hand-enumerating which per-thread/per-build state copies into the inner builder. With no single contract, the three lists **drifted three ways** (dharana §25 organizational fatality). #341 had patched only the `with_fx` tick cell — leaving siblings broken.

The EPIC #342 exhaustive `state × {idiom}` sweep found **3 same-class defects / 5 cells**, all observation-confirmed:

| Defect | Cells | Evidence (pre-fix) |
|---|---|---|
| **A** `_currentBpm` threaded into NO sub-builder → `use_bpm`+`with_fx`/`in_thread`/`at` ran at wrong tempo (silent 2×) | with_fx, in_thread, at | inner `sleep(1)` = 1.0s vs correct 0.5s @ bpm120 |
| **B** `at` dropped iteration introspection (#226) | at | inner `_currentBuildSeconds` 0 vs 9.5 |
| **C** `with_fx` forked the RNG (seed-fork analog of #340) | with_fx | `0.37,0.19,0.17,0.73` re-forked vs continuous `0.37,0.95,0.73,0.60` |

`with_fx` wrapping a `live_loop` body is ubiquitous (Solar Flare itself) → Defect A silently mis-tempos a huge class of real pieces.

## Fix

One private `forkBuilder(mode: 'same-thread' | 'forked')` — the single audited place sub-builder state is classified:

- **Common (all modes):** synth, density, argBpmScaling, transpose, synth/sampleDefaults, iteration introspection (#226), **`_currentBpm`** → fixes A + B.
- **`same-thread` (`with_fx`):** also shares the tick Map (preserves #340/#341) **and the rng instance** → fixes C. `with_fx` forks no thread, so tick + random STREAM continue (grounded: `ref/sources/desktop-sp/runtime.rb:1062-1067` only re-seeds on a new thread).
- **`forked` (`in_thread`/`at`):** fresh tick scope + re-seeded rng (behavior unchanged).

## Verification

- **Level 1:** 998/998 vitest (+5 new sub-builder twins covering A/B/C and the forked-isolation guard), `tsc --noEmit` clean.
- **Level 3 (observation):** web capture of `use_bpm 120` + per-iteration `with_fx :reverb` + seeded `scale.choose` → `/s_new` beep spacing **0.25s** (bpm120 honored; was bpm60) and a **rich evolving seeded note sequence** all within `scale :e3,:minor_pentatonic` (stream continues through `with_fx`; was re-forked). FX routing intact, no errors.

## Catalogues

SV45 → IMPLEMENTED + CONSOLIDATED. New hetvabhasa **SP94** ("hand-maintained per-idiom copies drift → consolidate, don't patch"). dharana **§25 fatality RESOLVED**.

## Scope discipline

Exact forked-seed derivation vs `runtime.rb:1067` (our `this.rng.next()` vs desktop's `new_rand_seed + get_seed`) is explicitly **out of scope** — tracked separately under EPIC #342, not chased here.

Part of EPIC #342. Closes #343.