### PR TITLE
✅ test(audio): 6-tier audio-analysis standard — pitch-track verdict + Tier-0 gates — closes #346

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,42 +97,37 @@ Global AnviDev workflow applies. These are the project-specific additions:
 
 ## Testing Protocol — This Project's Observation Hierarchy
 
-There are THREE levels of observation. Each level catches bugs the previous cannot.
-**You must reach Level 3 before declaring anything "works."**
+Levels 1–2 are INFERENCE; Level 3 (audio) is OBSERVATION. **You must reach Level 3 before declaring anything "works."** Never say "verified ✓" from the event log alone — the event log is a plan, not proof.
+
+- **Level 1 — Unit tests:** `npx vitest run` (all pass) + `npx tsc --noEmit` (zero errors).
+- **Level 2 — Event log:** `npx tsx tools/capture.ts --file x.rb --duration 15000` (Chromium; `--firefox` = headless, no audio).
+- **Level 3 — Audio:** `npx tsx tools/compare-desktop-vs-web.ts --file x.rb` (desktop SP via OSC + web + analysis) or `tools/capture.ts` for web-only WAV. **Diagnostic tools:** `tools/pitchtrack.py <wav>` (Tier-1 sequence), `tools/diagnose-audio.ts` (expected vs actual events), `tools/spectrogram.ts` (⚠ event log, not audio).
+
+### MANDATORY: The 6-Tier Audio Analysis Standard (issue #346, vyapti SV46)
+
+**Every Level-3 audio analysis MUST cover all six tiers. No silent omission — a tier the tool can't compute prints `not analysed` explicitly.** `compare-desktop-vs-web.ts` emits all six.
 
 ```
-Level 1: Unit tests (Vitest)         — "Did the code I expected to run, run?"
-Level 2: Event log (capture tool)    — "Did the engine schedule the right events?"
-Level 3: Audio WAV analysis          — "Did scsynth actually produce the right sound?"
+Tier 0  Validity gates   HARD fail (missing WAV / SR mismatch) ⇒ verdict INVALID,
+                          pitch unreliable. SOFT fail (window misalign >0.5s) ⇒
+                          Tier-3 + onset-count unreliable; Tier-1 pitch STILL VALID
+                          (it is prefix-compared, robust to misalignment).
+Tier 1  Musical correctness — THE VERDICT. Pitch-track / note progression, tempo
+                          (inter-onset), rhythm, note duration, polyphony,
+                          determinism. Energy/MFCC are BLIND to wrong melody (SP93).
+Tier 2  Spectral/timbral (SUPPORTING ONLY). mel-L2, MFCC (mandatory caveat:
+                          confounded by ~0.5× gain + reverb tail), per-band, peak
+                          freq, spectral TEMPORAL pattern (echo ms reveals FX bpm).
+Tier 3  Level/gain (reported, NOT a musical blocker). RMS/peak/clip + ratios,
+                          per-beat gain. Ref: RMS≈0.19, clip<0.1%.
+Tier 4  FX/routing. Tail decay, FX timing ms (bpm-scaled), accumulation-vs-
+                          suppression 200ms boundary scan, per-FX-scope energy.
+Tier 5  Stability/lifecycle. Run/Stop/hot-swap, cold-start, long-run drift.
 ```
 
-**Level 1 and 2 are INFERENCE. Level 3 is OBSERVATION.**
+**The iron rule (the SP93 / #344 lesson):** Tier 1 is the verdict. **Tiers 2–3 may NEVER override Tier 1.** A high MFCC with a Tier-1 PITCH-MATCH means timbre/gain, not wrong notes — report it as such, never as "unrelated / different synth." Tier 0 + Tier 1 are mandatory for *every* audio analysis; Tiers 4–5 mandatory when FX / multi-cycle is in scope.
 
-**Rule: Never say "verified ✓" from the event log alone. The event log is a plan, not proof.**
-
-### Level 1: Unit tests
-- `npx vitest run` — 638+ tests, all must pass
-- `npx tsc --noEmit` — zero type errors
-
-### Level 2: Event log capture
-- `npx tsx tools/capture.ts "code"` — Chromium headed, captures events + screenshots + audio WAV
-- `npx tsx tools/capture.ts --file path/to/code.rb --duration 15000`
-- `npx tsx tools/capture.ts --firefox` — Firefox headless fallback (no audio capture)
-
-### Level 3: Audio WAV analysis (THE REAL TEST)
-The capture tool records audio via Rec button in Chromium and analyzes the WAV:
-- Duration, Peak, RMS, Clipping % — compare against original Sonic Pi (RMS ≈ 0.19, clipping < 0.1%)
-- Per-beat frequency analysis — ZCR detects kick (low freq) vs snare (bright)
-
-**Reference values (original Sonic Pi, DJ Dave kick+clap code):**
-- RMS: 0.19, Peak: 1.0, Clipping: 0.01%
-- Kick peak: 0.44, Snare peak: 0.47
-- Snare/Kick ratio: 1.06x (snare LEADS)
-- Snare-present beats: 13/13 (100%)
-
-### Other tools
-- `npx tsx tools/diagnose-audio.ts "code"` — QueryInterpreter (expected) vs browser (actual), diffs events
-- `npx tsx tools/spectrogram.ts "code"` — event stream timing analysis. **WARNING:** reads event log, not audio.
+**Reference values (original Sonic Pi, DJ Dave kick+clap):** RMS 0.19 · Peak 1.0 · Clip 0.01% · Kick peak 0.44 · Snare peak 0.47 · Snare/Kick 1.06× (snare LEADS) · Snare-present 13/13.
 
 ---
 

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -296,29 +296,10 @@ export class ProgramBuilder {
     // Assign a nodeRef so the FX can be targeted by control()
     const fxRef = this.nextRef++
     this._lastRef = fxRef
-    const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-    inner.currentSynth = this.currentSynth
-    inner.densityFactor = this.densityFactor
-    inner._argBpmScaling = this._argBpmScaling
-    inner._transpose = this._transpose
-    inner._synthDefaults = { ...this._synthDefaults }
-    inner._sampleDefaults = { ...this._sampleDefaults }
-    // Inherit iteration introspection state so current_time / current_beat
-    // inside with_fx / in_thread / at blocks return the outer's values (#226).
-    inner._iterationStartAudioTime = this._iterationStartAudioTime
-    inner._currentBuildSeconds = this._currentBuildSeconds
-    inner._currentBeat = this._currentBeat
-    inner._schedAheadTime = this._schedAheadTime
-    // Share the SAME tick map (by reference, not a copy). `with_fx` does NOT
-    // fork a thread (unlike in_thread / at, which push {tag:'thread'} and
-    // correctly get an independent tick scope) — it is a synchronous FX
-    // wrapper in the same thread, so `.tick`/`.look` inside it must advance
-    // the live_loop's persistent counter. Without this, every iteration's
-    // `inner` got a fresh empty tick map that was discarded after build(),
-    // so the engine's per-loop loopTicks never saw the advance → `play
-    // notes.tick` inside a per-iteration with_fx was frozen on index 0
-    // (Solar Flare :arp stuck on one note). #340.
-    inner.ticks = this.ticks
+    // with_fx is a synchronous same-thread FX wrapper — tick map AND random
+    // stream continue through it (#340/#341 + #343 Defect C). forkBuilder is
+    // the single source of truth for sub-builder state threading.
+    const inner = this.forkBuilder('same-thread')
     fn(inner, fxRef)
     const fxOpts = !this._argBpmScaling ? { ...opts, _argBpmScaling: 0 } : opts
     this.steps.push({ tag: 'fx', name, opts: fxOpts, body: inner.build(), nodeRef: fxRef })
@@ -326,19 +307,10 @@ export class ProgramBuilder {
   }
 
   in_thread(buildFn: (b: ProgramBuilder) => void): this {
-    const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-    inner.currentSynth = this.currentSynth
-    inner.densityFactor = this.densityFactor
-    inner._argBpmScaling = this._argBpmScaling
-    inner._transpose = this._transpose
-    inner._synthDefaults = { ...this._synthDefaults }
-    inner._sampleDefaults = { ...this._sampleDefaults }
-    // Inherit iteration introspection state so current_time / current_beat
-    // inside with_fx / in_thread / at blocks return the outer's values (#226).
-    inner._iterationStartAudioTime = this._iterationStartAudioTime
-    inner._currentBuildSeconds = this._currentBuildSeconds
-    inner._currentBeat = this._currentBeat
-    inner._schedAheadTime = this._schedAheadTime
+    // in_thread forks a thread → fresh tick scope + re-seeded rng, but
+    // inherits a snapshot of thread-locals (synth/bpm/transpose/density/
+    // defaults/iteration introspection). #343 Defect: _currentBpm now threads.
+    const inner = this.forkBuilder('forked')
     buildFn(inner)
     this.steps.push({ tag: 'thread', body: inner.build() })
     return this
@@ -348,18 +320,61 @@ export class ProgramBuilder {
     for (let i = 0; i < times.length; i++) {
       const offset = times[i]
       const val = values ? values[i % values.length] : i
-      const inner = new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-      inner.currentSynth = this.currentSynth
-      inner.densityFactor = this.densityFactor
-      inner._argBpmScaling = this._argBpmScaling
-      inner._transpose = this._transpose
-      inner._synthDefaults = { ...this._synthDefaults }
-      inner._sampleDefaults = { ...this._sampleDefaults }
+      // `at` forks a thread per time like in_thread. forkBuilder also threads
+      // iteration introspection (#226 Defect B — `at` used to drop it) and
+      // _currentBpm (#343 Defect A).
+      const inner = this.forkBuilder('forked')
       if (offset > 0) inner.sleep(offset)
       buildFn(inner, val)
       this.steps.push({ tag: 'thread', body: inner.build() })
     }
     return this
+  }
+
+  /**
+   * Single source of truth for which per-thread / per-build state threads into
+   * a nested block's sub-builder. Replaces three hand-maintained copies that
+   * had drifted (#343). Desktop SP semantics (ref/sources/desktop-sp):
+   *  - 'same-thread' (with_fx): no thread fork → ALL thread-locals continue,
+   *    including the tick map and the random STREAM, shared by reference.
+   *  - 'forked' (in_thread / at): forks a thread → inherits a SNAPSHOT of
+   *    thread-locals but gets a FRESH tick scope and a RE-SEEDED rng
+   *    (runtime.rb:1062-1067 only re-seeds on a new thread).
+   */
+  private forkBuilder(mode: 'same-thread' | 'forked'): ProgramBuilder {
+    // 'forked' re-seeds the rng from the parent stream (deterministic fork);
+    // 'same-thread' shares the parent rng instance (set below) so the seed
+    // here is irrelevant and must NOT consume from the parent stream.
+    const inner = mode === 'forked'
+      ? new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
+      : new ProgramBuilder()
+    // Common — inherited by every sub-builder regardless of mode.
+    inner.currentSynth = this.currentSynth
+    inner.densityFactor = this.densityFactor
+    inner._argBpmScaling = this._argBpmScaling
+    inner._transpose = this._transpose
+    inner._synthDefaults = { ...this._synthDefaults }
+    inner._sampleDefaults = { ...this._sampleDefaults }
+    // #343 Defect A: use_bpm is thread-local in desktop SP (runtime.rb:155).
+    // with_fx (same thread) continues it; in_thread/at snapshot it at fork.
+    // Previously NO sub-builder inherited it → silent 2× tempo error.
+    inner._currentBpm = this._currentBpm
+    // Iteration introspection (#226) so current_time / current_beat inside
+    // with_fx / in_thread / at return the outer's values. #343 Defect B:
+    // `at` used to drop these.
+    inner._iterationStartAudioTime = this._iterationStartAudioTime
+    inner._currentBuildSeconds = this._currentBuildSeconds
+    inner._currentBeat = this._currentBeat
+    inner._schedAheadTime = this._schedAheadTime
+    if (mode === 'same-thread') {
+      // with_fx forks no thread: tick map AND random stream continue. Sharing
+      // the tick Map by reference is the #340/#341 fix; sharing the rng
+      // instance is its seed-fork analog (#343 Defect C). 'forked' leaves
+      // inner.ticks a fresh Map and inner.rng the re-seeded generator.
+      inner.ticks = this.ticks
+      inner.rng = this.rng
+    }
+    return inner
   }
 
   live_audio(name: string, optsOrStop?: Record<string, number> | 'stop', maybeOpts?: Record<string, number>): this {

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -716,4 +716,92 @@ describe('ProgramBuilder', () => {
       expect(b.getTicks().get('__default')).toBe(0)
     })
   })
+
+  describe('sub-builder state threading — forkBuilder(mode) (#343)', () => {
+    // Desktop SP: with_fx forks no thread → random STREAM continues (the
+    // seed-fork analog of the #340 tick fix). in_thread/at fork → re-seeded.
+    // `rng` is private — read it through a structural cast (same pattern the
+    // #340 block uses for _currentBuildSeconds).
+    const rngOf = (b: ProgramBuilder) => (b as unknown as { rng: { next(): number } }).rng
+
+    it('Defect C: with_fx continues the parent random stream (does not re-fork)', () => {
+      const flat = new ProgramBuilder()
+      flat.use_random_seed(42)
+      const baseline = [rngOf(flat).next(), rngOf(flat).next(), rngOf(flat).next(), rngOf(flat).next()]
+
+      const b = new ProgramBuilder()
+      b.use_random_seed(42)
+      const seq: number[] = [rngOf(b).next()]
+      b.with_fx('reverb', {}, (inner) => {
+        seq.push(rngOf(inner).next())
+        seq.push(rngOf(inner).next())
+        return inner
+      })
+      seq.push(rngOf(b).next())
+      expect(seq).toEqual(baseline)
+    })
+
+    it('in_thread re-forks the rng (forked thread = independent stream)', () => {
+      const flat = new ProgramBuilder()
+      flat.use_random_seed(42)
+      const baseline = [rngOf(flat).next(), rngOf(flat).next()]
+
+      const b = new ProgramBuilder()
+      b.use_random_seed(42)
+      rngOf(b).next()                            // parent pos0
+      let innerFirst = -1
+      b.in_thread((inner) => { innerFirst = rngOf(inner).next() })
+      // Forked: inner's first draw is NOT the parent's next stream position.
+      expect(innerFirst).not.toBeCloseTo(baseline[1], 9)
+    })
+
+    it('Defect A: use_bpm threads into with_fx (same-thread tempo continues)', () => {
+      const b = new ProgramBuilder()
+      b.use_bpm(120)
+      let beatSecs = -1
+      b.with_fx('reverb', {}, (inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        beatSecs = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+        return inner
+      })
+      expect(beatSecs).toBeCloseTo(0.5, 9)       // 1 beat @ bpm120, not 1.0s @ bpm60
+    })
+
+    it('Defect A: use_bpm snapshots into in_thread/at at fork', () => {
+      const bt = new ProgramBuilder()
+      bt.use_bpm(120)
+      let inThreadBeat = -1
+      bt.in_thread((inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        inThreadBeat = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+      })
+      expect(inThreadBeat).toBeCloseTo(0.5, 9)
+
+      const ba = new ProgramBuilder()
+      ba.use_bpm(120)
+      let atBeat = -1
+      ba.at([0], null, (inner) => {
+        const before = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        inner.sleep(1)
+        atBeat = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds - before
+      })
+      expect(atBeat).toBeCloseTo(0.5, 9)
+    })
+
+    it('Defect B: at inherits iteration introspection (#226), like with_fx/in_thread', () => {
+      const b = new ProgramBuilder()
+      ;(b as unknown as { _currentBuildSeconds: number })._currentBuildSeconds = 9.5
+      ;(b as unknown as { _currentBeat: number })._currentBeat = 3
+      let seenSecs = -1
+      let seenBeat = -1
+      b.at([0], null, (inner) => {
+        seenSecs = (inner as unknown as { _currentBuildSeconds: number })._currentBuildSeconds
+        seenBeat = (inner as unknown as { _currentBeat: number })._currentBeat
+      })
+      expect(seenSecs).toBe(9.5)
+      expect(seenBeat).toBe(3)
+    })
+  })
 })

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -150,13 +150,20 @@ interface SpectrogramMetrics {
   per_beat: PerBeatMetrics | null
 }
 
+interface PitchTrack {
+  count: number
+  median_spacing_s: number
+  midi: (number | null)[]
+  names: (string | null)[]
+}
+
 interface ComparisonResult {
   timestamp: string
   code: string
   duration: number
   name: string
-  desktop: { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean }
-  web:     { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean }
+  desktop: { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean; pitch: PitchTrack | null }
+  web:     { wavPath: string | null; stats: AudioStats | null; rawStdout: string; ok: boolean; pitch: PitchTrack | null }
   spectrogram: SpectrogramMetrics | null
   spectrogramError: string | null
   reportPath: string
@@ -209,36 +216,100 @@ function writeComparisonReport(r: ComparisonResult): void {
   lines.push(`| Channels | ${dStats?.channels ?? '—'} | ${wStats?.channels ?? '—'} | — |`)
   lines.push('')
 
-  // Verdict — compare key metrics with simple thresholds
-  lines.push('## Verdict')
-  const verdicts: string[] = []
-  if (!dStats) verdicts.push(`✗ Desktop produced no WAV — see desktop tool stdout in this report`)
-  if (!wStats) verdicts.push(`✗ Web produced no WAV — see web tool stdout in this report`)
+  // ── 6-Tier Audio Analysis Standard (issue #346, vyapti SV46) ───────────────
+  // Tier 0 = validity gates (fail ⇒ INVALID, no verdict). Tier 1 = musical
+  // correctness = THE verdict. Tiers 2–3 supporting, may NEVER override Tier 1
+  // (SP93). Tiers the comparator can't compute print "not analysed" explicitly.
+
+  // Tier 0 — Validity gates. Two severities:
+  //  • HARD (invalid): makes the pitch sequence itself unreliable → no Tier-1
+  //    verdict possible (missing WAV, SR mismatch needing resample).
+  //  • SOFT (aggregatesUnreliable): only invalidates COUNTS & AGGREGATES
+  //    (Tier 3 ratios, onset count). Tier 1 pitch-track is prefix-compared and
+  //    robust to window misalignment by construction — it must NOT be nuked by
+  //    a duration delta (that delta is intrinsic: scsynth warm-up + reverb
+  //    tail). Over-blocking here would flag correct PITCH-MATCH runs as
+  //    INVALID and train readers to ignore the gate.
+  const t0: string[] = []
+  let invalid = false
+  let aggregatesUnreliable = false
+  const fail = (m: string) => { t0.push(`- ✗ ${m}  **(HARD — verdict INVALID)**`); invalid = true }
+  const soft = (m: string) => { t0.push(`- ⚠ ${m}  **(SOFT — Tier 3 + 1.3 unreliable; Tier 1 pitch still valid)**`); aggregatesUnreliable = true }
+  const passG = (m: string) => t0.push(`- ✓ ${m}`)
+  if (!dStats) fail('Desktop produced no WAV — see desktop tool stdout below')
+  if (!wStats) fail('Web produced no WAV — see web tool stdout below')
+  let durDelta = 0
   if (dStats && wStats) {
-    if (dStats.sampleRate !== wStats.sampleRate) {
-      verdicts.push(`⚠ Sample-rate mismatch (${dStats.sampleRate} vs ${wStats.sampleRate} Hz) — RMS / peak / spectrum comparisons are at-source only, not resampled`)
-    }
-    const rmsRatio = dStats.rms > 0 ? wStats.rms / dStats.rms : 0
-    if (rmsRatio < 0.5 || rmsRatio > 2.0) {
-      verdicts.push(`⚠ RMS ratio web/desktop = ${rmsRatio.toFixed(2)}× — significant level divergence`)
-    } else {
-      verdicts.push(`✓ RMS ratio web/desktop = ${rmsRatio.toFixed(2)}× (within 0.5×–2× tolerance)`)
-    }
-    const peakRatio = dStats.peak > 0 ? wStats.peak / dStats.peak : 0
-    if (peakRatio < 0.5 || peakRatio > 2.0) {
-      verdicts.push(`⚠ Peak ratio web/desktop = ${peakRatio.toFixed(2)}× — significant peak divergence`)
-    } else {
-      verdicts.push(`✓ Peak ratio web/desktop = ${peakRatio.toFixed(2)}× (within 0.5×–2× tolerance)`)
-    }
-    if (dStats.clipping > 1 || wStats.clipping > 1) {
-      verdicts.push(`⚠ Clipping detected (desktop ${dStats.clipping}%, web ${wStats.clipping}%)`)
-    }
-    const durDelta = Math.abs(dStats.duration - wStats.duration)
-    if (durDelta > 1.0) {
-      verdicts.push(`⚠ Duration delta ${durDelta.toFixed(2)}s — captures may not have aligned windows`)
-    }
+    if (dStats.sampleRate !== wStats.sampleRate)
+      fail(`0.1 Sample-rate mismatch (${dStats.sampleRate} vs ${wStats.sampleRate} Hz) — SV29: cross-SR compare invalid`)
+    else passG(`0.1 Sample rate consistent (${dStats.sampleRate} Hz)`)
+    durDelta = Math.abs(dStats.duration - wStats.duration)
+    if (durDelta > 0.5)
+      soft(`0.2 Capture-window misaligned (Δ ${durDelta.toFixed(2)}s > 0.5s) — note-count / level aggregates unreliable`)
+    else passG(`0.2 Capture windows aligned (Δ ${durDelta.toFixed(2)}s)`)
   }
-  for (const v of verdicts) lines.push(`- ${v}`)
+  t0.push('- ◦ 0.3 equal preconditions / 0.4 lossless capture / 0.5 routing sanity — not auto-checked; ensure SP.app reset + raw-float32 + FX-bus wired (SV31/SV27/SV30)')
+
+  // Tier 1 — Musical correctness (THE verdict)
+  const dp = r.desktop.pitch, wp = r.web.pitch
+  const t1: string[] = []
+  let pitchVerdict = 'not analysed'
+  if (dp && wp) {
+    const ds = dp.midi.filter(x => x !== null) as number[]
+    const ws = wp.midi.filter(x => x !== null) as number[]
+    const n = Math.min(ds.length, ws.length)
+    let mismatch = -1
+    for (let i = 0; i < n; i++) if (ds[i] !== ws[i]) { mismatch = i; break }
+    if (n === 0) pitchVerdict = '⚠ no notes detected on one/both sides'
+    else if (mismatch < 0) pitchVerdict = `✓ PITCH-MATCH — note sequences identical over ${n} notes`
+    else pitchVerdict = `✗ PITCH DIVERGENCE at note ${mismatch} (desktop ${ds[mismatch]} vs web ${ws[mismatch]})`
+    const dt = dp.median_spacing_s, wt = wp.median_spacing_s
+    const tempoOk = dt > 0 && Math.abs(dt - wt) / dt < 0.1
+    t1.push(`- **1.1 Note progression:** ${pitchVerdict}`)
+    t1.push(`  - desktop: \`${dp.midi.slice(0, 24).join(',')}\``)
+    t1.push(`  - web&nbsp;&nbsp;&nbsp;: \`${wp.midi.slice(0, 24).join(',')}\``)
+    t1.push(`- **1.2 Tempo (inter-onset):** ${tempoOk ? '✓' : '✗'} desktop ${dt.toFixed(3)}s · web ${wt.toFixed(3)}s/note`)
+    t1.push(`- **1.3 Onset count:** desktop ${dp.count} · web ${wp.count}${durDelta > 0.5 ? ' (Δ explained by Tier-0 window misalignment)' : ''}`)
+    t1.push('- ◦ 1.4 note duration / 1.5 polyphony / 1.6 determinism — not auto-tracked here (unit tests cover determinism; see SV24/SV45)')
+  } else {
+    t1.push(`- ⚠ pitch-track unavailable (desktop=${dp ? 'ok' : 'none'}, web=${wp ? 'ok' : 'none'}) — Tier 1 verdict cannot be formed`)
+  }
+
+  // Headline verdict
+  const softNote = aggregatesUnreliable ? '  · ⚠ Tier-0 SOFT: level/count aggregates unreliable (Tier 1 pitch unaffected)' : ''
+  lines.push('## Verdict')
+  if (invalid) {
+    lines.push(`### ❌ INVALID — Tier 0 HARD gate failed. The pitch sequence itself is unreliable; no verdict until fixed.`)
+  } else if (pitchVerdict.startsWith('✓')) {
+    lines.push(`### ✅ Tier 1 ${pitchVerdict}  (the musical-correctness verdict)${softNote}`)
+  } else if (pitchVerdict.startsWith('✗')) {
+    lines.push(`### ❌ Tier 1 ${pitchVerdict}  (musical correctness FAILED — Tier 2/3 cannot override this)`)
+  } else {
+    lines.push(`### ⚠ Tier 1 inconclusive — ${pitchVerdict}${softNote}`)
+  }
+  lines.push('')
+  lines.push('### Tier 0 — Validity gates')
+  for (const v of t0) lines.push(v)
+  lines.push('')
+  lines.push('### Tier 1 — Musical correctness (THE verdict — energy/MFCC may never override)')
+  for (const v of t1) lines.push(v)
+  lines.push('')
+  lines.push('### Tier 3 — Level / gain (reported; NOT a musical-correctness blocker — known ~0.5× web gain-staging)')
+  if (aggregatesUnreliable) lines.push('> ⚠ Tier-0 SOFT failed — these ratios span misaligned windows; treat as indicative only.')
+  if (dStats && wStats) {
+    const rmsRatio = dStats.rms > 0 ? wStats.rms / dStats.rms : 0
+    const peakRatio = dStats.peak > 0 ? wStats.peak / dStats.peak : 0
+    lines.push(`- 3.1 RMS ratio web/desktop = ${rmsRatio.toFixed(2)}× ${rmsRatio >= 0.5 && rmsRatio <= 2 ? '(within 0.5–2× band)' : '(outside band — tracked separately, not a Tier-1 fail)'}`)
+    lines.push(`- 3.2 Peak ratio web/desktop = ${peakRatio.toFixed(2)}×`)
+    lines.push(`- 3.3 Clipping: desktop ${dStats.clipping}% · web ${wStats.clipping}% ${(dStats.clipping > 1 || wStats.clipping > 1) ? '⚠' : '✓ (< 1%)'}`)
+  } else {
+    lines.push('- not analysed (WAV missing)')
+  }
+  lines.push('')
+  lines.push('### Tier 2 — Spectral / timbral (supporting only) · Tier 4 — FX/routing · Tier 5 — lifecycle')
+  lines.push('- Tier 2: see **Spectrogram comparison** section below (MFCC carries its mandatory caveat there).')
+  lines.push('- Tier 4 (FX accumulation/suppression 200ms scan, per-FX-scope energy): **not analysed** by this tool — use the FX-sweep / boundary-scan tools when FX is in scope.')
+  lines.push('- Tier 5 (Run/Stop/hot-swap, cold-start, long-run drift): **not analysed** — single capture; use `tools/test-run-stop-cycle.ts` for lifecycle.')
   lines.push('')
 
   lines.push('## Source WAVs')
@@ -255,6 +326,7 @@ function writeComparisonReport(r: ComparisonResult): void {
     lines.push('|---|---|---|')
     lines.push(`| L2 distance (mel-dB) | ${sp.l2_mel_db.toFixed(2)} | < 10 = very close · 10–25 = similar shape · > 25 = divergent |`)
     lines.push(`| MFCC distance (timbre) | ${sp.mfcc_distance.toFixed(2)} | < 30 = similar · 30–80 = noticeably different · > 80 = unrelated |`)
+    lines.push(`| ↳ MFCC caveat | — | **Tier-2 supporting only.** Confounded by the known ~0.5× web gain ratio + desktop reverb-tail length; **never overrides Tier 1** (SP93). A high MFCC with a Tier-1 PITCH-MATCH means timbre/gain, not wrong notes. |`)
     lines.push(`| Frames compared | ${sp.frames_compared} | overlapping window after length-aligning |`)
     lines.push(`| Peak freq desktop | ${sp.desktop_peak_freq_hz.toFixed(1)} Hz | dominant frequency |`)
     lines.push(`| Peak freq web | ${sp.web_peak_freq_hz.toFixed(1)} Hz | dominant frequency |`)
@@ -263,7 +335,7 @@ function writeComparisonReport(r: ComparisonResult): void {
       lines.push(`⚠ Spectral L2 ${sp.l2_mel_db.toFixed(2)} indicates divergent spectral content — inspect the diff panel of the PNG above.`)
     }
     if (sp.mfcc_distance > 80) {
-      lines.push(`⚠ MFCC distance ${sp.mfcc_distance.toFixed(2)} indicates unrelated timbre — likely different synth or sample chain firing.`)
+      lines.push(`⚠ MFCC distance ${sp.mfcc_distance.toFixed(2)} is high — **check Tier 1 first**: if pitch-track matched, this is timbre/gain (the known 0.5× + reverb tail), NOT wrong notes. Only treat as "different synth/sample chain" when Tier 1 also diverges.`)
     }
 
     if (sp.per_beat) {
@@ -427,13 +499,26 @@ async function main(): Promise<void> {
     }
   }
 
+  // Tier 1 — pitch-track (the musical-correctness verdict). Run for each WAV
+  // independently so a missing one still yields the other's sequence.
+  const runPitch = async (wav: string | null): Promise<PitchTrack | null> => {
+    if (!wav) return null
+    try {
+      const py = await runChild('python3', ['tools/pitchtrack.py', '--json', wav])
+      if (py.exitCode !== 0) return null
+      const d = JSON.parse(py.stdout.trim().split('\n').pop() as string)
+      return { count: d.count, median_spacing_s: d.median_spacing_s, midi: d.midi, names: d.names }
+    } catch { return null }
+  }
+  const [desktopPitch, webPitch] = await Promise.all([runPitch(desktopWav), runPitch(webWav)])
+
   const result: ComparisonResult = {
     timestamp: new Date().toISOString(),
     code: args.code,
     duration: args.duration,
     name: args.name,
-    desktop: { wavPath: desktopWav, stats: desktopStats, rawStdout: desktop.stdout, ok: desktop.exitCode === 0 },
-    web:     { wavPath: webWav,     stats: webStats,     rawStdout: web.stdout,     ok: web.exitCode === 0 },
+    desktop: { wavPath: desktopWav, stats: desktopStats, rawStdout: desktop.stdout, ok: desktop.exitCode === 0, pitch: desktopPitch },
+    web:     { wavPath: webWav,     stats: webStats,     rawStdout: web.stdout,     ok: web.exitCode === 0, pitch: webPitch },
     spectrogram,
     spectrogramError,
     reportPath,

--- a/tools/pitchtrack.py
+++ b/tools/pitchtrack.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tier-1 pitch-track: per-note dominant-frequency → MIDI sequence + tempo.
+
+The musical-correctness verdict for desktop↔web audio comparison. Energy/MFCC
+aggregates are blind to a wrong melody (catalogue SP93) and confounded by the
+known ~0.5× web gain-staging and reverb-tail length — so the note SEQUENCE and
+inter-onset TEMPO are the verdict, not RMS/MFCC.
+
+Usage:  python3 tools/pitchtrack.py <wav>            # human-readable
+        python3 tools/pitchtrack.py --json <wav>     # machine (comparator)
+"""
+import sys, json, numpy as np, wave
+
+NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+
+
+def load(path):
+    w = wave.open(path, 'rb')
+    sr, n, ch = w.getframerate(), w.getnframes(), w.getnchannels()
+    a = np.frombuffer(w.readframes(n), dtype=np.int16).astype(np.float64)
+    if ch == 2:
+        a = a.reshape(-1, 2).mean(axis=1)
+    a /= (np.abs(a).max() or 1.0)          # normalise away the 0.5× gain delta
+    return a, sr
+
+
+def f2midi(f):
+    return None if f <= 0 else int(round(69 + 12 * np.log2(f / 440.0)))
+
+
+def name(m):
+    return None if m is None else f"{NAMES[m % 12]}{m // 12 - 1}"
+
+
+def track(path, note_dt=0.25):
+    a, sr = load(path)
+    hop = int(sr * 0.01)
+    env = np.array([np.sqrt(np.mean(a[i:i + hop] ** 2))
+                    for i in range(0, len(a) - hop, hop)])
+    env /= (env.max() or 1.0)
+    onsets = []
+    for i in range(2, len(env) - 1):
+        if env[i] > 0.12 and env[i] > env[i - 1] and env[i - 2] < 0.10:
+            t = i * hop / sr
+            if not onsets or t - onsets[-1] > note_dt * 0.6:
+                onsets.append(t)
+    notes = []
+    for t in onsets:
+        s = int(t * sr)
+        seg = a[s:s + int(note_dt * 0.8 * sr)]
+        if len(seg) < 512:
+            continue
+        win = seg * np.hanning(len(seg))
+        sp = np.abs(np.fft.rfft(win))
+        fr = np.fft.rfftfreq(len(win), 1 / sr)
+        m = (fr > 80) & (fr < 2000)
+        f0 = float(fr[m][np.argmax(sp[m])])
+        notes.append({'t': round(t, 3), 'hz': round(f0, 1), 'midi': f2midi(f0)})
+    iv = [round(notes[i + 1]['t'] - notes[i]['t'], 3)
+          for i in range(len(notes) - 1)]
+    return {
+        'count': len(notes),
+        'median_spacing_s': float(np.median(iv)) if iv else 0.0,
+        'midi': [n['midi'] for n in notes],
+        'names': [name(n['midi']) for n in notes],
+        'notes': notes,
+    }
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    as_json = '--json' in args
+    path = [x for x in args if x != '--json'][0]
+    r = track(path)
+    if as_json:
+        print(json.dumps(r))
+    else:
+        print(f"{r['count']} notes, median spacing {r['median_spacing_s']:.3f}s")
+        print("MIDI:", r['midi'][:32])
+        print("name:", r['names'][:16])


### PR DESCRIPTION
Part of EPIC #342. Closes #346. Methodology hardening triggered by #344.

## Problem

`compare-desktop-vs-web.ts` led its verdict with RMS/MFCC and **omitted the pitch-track entirely**. On #344 it reported `MFCC 115 = unrelated timbre` while the desktop↔web note sequence was **note-for-note identical** — a confounded aggregate masquerading as the verdict. Energy/MFCC are blind to a wrong melody (SP93); MFCC is confounded by the known ~0.5× web gain + reverb-tail length.

## The standard (now mandatory — CLAUDE.md + vyapti SV46)

| Tier | What | Role |
|---|---|---|
| 0 | Validity gates (SR, window, preconditions, lossless, routing) | HARD fail ⇒ INVALID · SOFT fail ⇒ aggregates unreliable, **pitch still valid** |
| 1 | **Musical correctness — pitch-track, tempo, rhythm, duration, polyphony, determinism** | **THE verdict** |
| 2 | Spectral/timbral (mel-L2, MFCC+caveat, per-band, temporal echo) | supporting only |
| 3 | Level/gain (RMS/peak/clip ratios) | reported, **not a musical blocker** |
| 4 | FX/routing (tail, FX-timing ms, 200ms accumulation scan) | when FX in scope |
| 5 | Stability/lifecycle (Run/Stop/hot-swap, cold-start, drift) | when multi-cycle in scope |

**Iron rule:** Tier 1 is the verdict; **Tiers 2–3 may NEVER override it.** A high MFCC with a Tier-1 PITCH-MATCH = timbre/gain, not wrong notes.

## Enforced three ways (all you asked for)

1. **Tooling** — `tools/pitchtrack.py` (new, committed: onset→dominant-freq→MIDI+tempo, gain-normalised) + `compare-desktop-vs-web.ts` emits the full 6-tier report, pitch-match headline, two-severity Tier-0, mandatory MFCC caveat. Tiers it can't compute print `not analysed` (no silent omission).
2. **CLAUDE.md** — the 3-level hierarchy replaced by the mandatory 6-tier standard + iron rule.
3. **Catalogue** — vyapti **SV46** with REF (dhyana hook surfaces it during audio work).

## Design correction during build (witness check)

First pass hard-blocked the run INVALID on the 1.68s window delta — which would have flagged *this session's correct conclusion* as invalid. Fixed: Tier-0 is HARD vs SOFT. SR-mismatch/missing-WAV (pitch unreliable) = HARD INVALID; window-misalignment = SOFT (Tier-3/count unreliable, **Tier-1 pitch unaffected** — it's prefix-compared). The gate no longer cries wolf.

## Verification (Level 3, dogfooded)

Re-ran the #344 `forkbuilder-parity` comparison. Report now leads:

> ### ✅ Tier 1 ✓ PITCH-MATCH — note sequences identical over 47 notes · ⚠ Tier-0 SOFT: level/count aggregates unreliable (Tier 1 pitch unaffected)

Tempo 0.250s both, MFCC line carries its caveat. 998/998 vitest, tsc clean.

## Scope

Other harnesses (`capture.ts` audio block, `diagnose-audio.ts`) reference the standard via CLAUDE.md; a full retrofit of every audio tool to the 6-tier emitter is tracked under EPIC #342 if needed, not bundled here (keeps this PR atomic + verified).