### PR TITLE
✨ feat(audio): pitchtrack contour mode + signal-derived tempo + confidence — closes #348

### DIFF
--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -154,7 +154,12 @@ interface PitchTrack {
   count: number
   median_spacing_s: number
   midi: (number | null)[]
+  pc: (number | null)[]
   names: (string | null)[]
+  method: string
+  confidence: number
+  inconclusive: boolean
+  compare: 'midi' | 'pitch_class'
 }
 
 interface ComparisonResult {
@@ -255,19 +260,27 @@ function writeComparisonReport(r: ComparisonResult): void {
   const t1: string[] = []
   let pitchVerdict = 'not analysed'
   if (dp && wp) {
-    const ds = dp.midi.filter(x => x !== null) as number[]
-    const ws = wp.midi.filter(x => x !== null) as number[]
-    const n = Math.min(ds.length, ws.length)
+    // #348: cheap contour is octave-unstable → compare pitch CLASSES when
+    // either side used contour mode (octave error cancels). Exact MIDI only
+    // when both sides are onset-tracked.
+    const pcMode = dp.compare === 'pitch_class' || wp.compare === 'pitch_class'
+    const dSeq = (pcMode ? dp.pc : dp.midi).filter(x => x !== null) as number[]
+    const wSeq = (pcMode ? wp.pc : wp.midi).filter(x => x !== null) as number[]
+    const unit = pcMode ? 'pitch-classes (octave-invariant — contour mode)' : 'notes'
+    const n = Math.min(dSeq.length, wSeq.length)
     let mismatch = -1
-    for (let i = 0; i < n; i++) if (ds[i] !== ws[i]) { mismatch = i; break }
-    if (n === 0) pitchVerdict = '⚠ no notes detected on one/both sides'
-    else if (mismatch < 0) pitchVerdict = `✓ PITCH-MATCH — note sequences identical over ${n} notes`
-    else pitchVerdict = `✗ PITCH DIVERGENCE at note ${mismatch} (desktop ${ds[mismatch]} vs web ${ws[mismatch]})`
+    for (let i = 0; i < n; i++) if (dSeq[i] !== wSeq[i]) { mismatch = i; break }
+    const inconc = dp.inconclusive || wp.inconclusive
+    if (inconc) pitchVerdict = `⚠ INCONCLUSIVE — contour-low confidence (desktop ${dp.method}/${dp.confidence}, web ${wp.method}/${wp.confidence}); sustained/noisy material, no Tier-1 verdict`
+    else if (n === 0) pitchVerdict = '⚠ no notes detected on one/both sides'
+    else if (mismatch < 0) pitchVerdict = `✓ PITCH-MATCH — ${unit} identical over ${n}`
+    else pitchVerdict = `✗ PITCH DIVERGENCE at ${pcMode ? 'pc' : 'note'} ${mismatch} (desktop ${dSeq[mismatch]} vs web ${wSeq[mismatch]})`
     const dt = dp.median_spacing_s, wt = wp.median_spacing_s
     const tempoOk = dt > 0 && Math.abs(dt - wt) / dt < 0.1
     t1.push(`- **1.1 Note progression:** ${pitchVerdict}`)
-    t1.push(`  - desktop: \`${dp.midi.slice(0, 24).join(',')}\``)
-    t1.push(`  - web&nbsp;&nbsp;&nbsp;: \`${wp.midi.slice(0, 24).join(',')}\``)
+    t1.push(`  - method: desktop \`${dp.method}\` (conf ${dp.confidence}) · web \`${wp.method}\` (conf ${wp.confidence})${pcMode ? ' · compared octave-invariant' : ''}`)
+    t1.push(`  - desktop: \`${(pcMode ? dp.pc : dp.midi).slice(0, 24).join(',')}\``)
+    t1.push(`  - web&nbsp;&nbsp;&nbsp;: \`${(pcMode ? wp.pc : wp.midi).slice(0, 24).join(',')}\``)
     t1.push(`- **1.2 Tempo (inter-onset):** ${tempoOk ? '✓' : '✗'} desktop ${dt.toFixed(3)}s · web ${wt.toFixed(3)}s/note`)
     t1.push(`- **1.3 Onset count:** desktop ${dp.count} · web ${wp.count}${durDelta > 0.5 ? ' (Δ explained by Tier-0 window misalignment)' : ''}`)
     t1.push('- ◦ 1.4 note duration / 1.5 polyphony / 1.6 determinism — not auto-tracked here (unit tests cover determinism; see SV24/SV45)')
@@ -504,10 +517,18 @@ async function main(): Promise<void> {
   const runPitch = async (wav: string | null): Promise<PitchTrack | null> => {
     if (!wav) return null
     try {
-      const py = await runChild('python3', ['tools/pitchtrack.py', '--json', wav])
+      const pArgs = ['tools/pitchtrack.py', '--json']
+      if (args.bpm !== null) pArgs.push('--bpm', String(args.bpm))
+      pArgs.push(wav)
+      const py = await runChild('python3', pArgs)
       if (py.exitCode !== 0) return null
       const d = JSON.parse(py.stdout.trim().split('\n').pop() as string)
-      return { count: d.count, median_spacing_s: d.median_spacing_s, midi: d.midi, names: d.names }
+      return {
+        count: d.count, median_spacing_s: d.median_spacing_s,
+        midi: d.midi, pc: d.pc, names: d.names,
+        method: d.method, confidence: d.confidence,
+        inconclusive: d.inconclusive, compare: d.compare,
+      }
     } catch { return null }
   }
   const [desktopPitch, webPitch] = await Promise.all([runPitch(desktopWav), runPitch(webWav)])

--- a/tools/pitchtrack.py
+++ b/tools/pitchtrack.py
@@ -32,20 +32,39 @@ def name(m):
     return None if m is None else f"{NAMES[m % 12]}{m // 12 - 1}"
 
 
-def track(path, note_dt=0.25):
-    a, sr = load(path)
+def _onsets(a, sr, min_gap):
+    """Energy-rise onsets with a minimum gap (seconds)."""
     hop = int(sr * 0.01)
     env = np.array([np.sqrt(np.mean(a[i:i + hop] ** 2))
                     for i in range(0, len(a) - hop, hop)])
     env /= (env.max() or 1.0)
-    onsets = []
+    out = []
     for i in range(2, len(env) - 1):
         if env[i] > 0.12 and env[i] > env[i - 1] and env[i - 2] < 0.10:
             t = i * hop / sr
-            if not onsets or t - onsets[-1] > note_dt * 0.6:
-                onsets.append(t)
+            if not out or t - out[-1] > min_gap:
+                out.append(t)
+    return out
+
+
+def estimate_note_dt(a, sr):
+    """#348: derive the note grid from the signal instead of hardcoding 0.25s.
+    Coarse onset pass (4ms gap) → median inter-onset, clamped to [0.05, 2.0]."""
+    coarse = _onsets(a, sr, 0.04)
+    if len(coarse) < 3:
+        return 0.25
+    iois = np.diff(coarse)
+    return float(np.clip(np.median(iois), 0.05, 2.0))
+
+
+def track(path, note_dt=None):
+    """Onset-based pitch-track. note_dt auto-estimated from the signal when
+    not given (#348 — removes the hardcoded-0.25s assumption)."""
+    a, sr = load(path)
+    if note_dt is None:
+        note_dt = estimate_note_dt(a, sr)
     notes = []
-    for t in onsets:
+    for t in _onsets(a, sr, note_dt * 0.6):
         s = int(t * sr)
         seg = a[s:s + int(note_dt * 0.8 * sr)]
         if len(seg) < 512:
@@ -56,25 +75,116 @@ def track(path, note_dt=0.25):
         m = (fr > 80) & (fr < 2000)
         f0 = float(fr[m][np.argmax(sp[m])])
         notes.append({'t': round(t, 3), 'hz': round(f0, 1), 'midi': f2midi(f0)})
-    iv = [round(notes[i + 1]['t'] - notes[i]['t'], 3)
-          for i in range(len(notes) - 1)]
+    return notes, note_dt, sr, len(a) / sr
+
+
+def _ac_pitch(seg, sr):
+    """Autocorrelation f0 for one frame, 80–2000 Hz. 0 = unvoiced.
+    Fundamental-biased: among all autocorr peaks above 0.5×max, pick the one
+    at the LONGEST lag (lowest f0). Plain argmax picks a high harmonic on
+    harmonically-rich synths (prophet/saw) → octave-up errors (#348)."""
+    seg = seg - seg.mean()
+    if np.sqrt(np.mean(seg ** 2)) < 1e-3:
+        return 0.0
+    ac = np.correlate(seg, seg, 'full')[len(seg) - 1:]
+    lo, hi = int(sr / 2000), int(sr / 80)
+    if hi >= len(ac) or hi <= lo:
+        return 0.0
+    band = ac[lo:hi]
+    if band.max() < 0.3 * ac[0]:        # weak periodicity → unvoiced
+        return 0.0
+    thresh = 0.5 * band.max()
+    # local maxima above threshold; choose the largest lag (the fundamental).
+    cand = [k for k in range(1, len(band) - 1)
+            if band[k] >= thresh and band[k] >= band[k - 1] and band[k] >= band[k + 1]]
+    peak = lo + (max(cand) if cand else int(np.argmax(band)))
+    return sr / peak
+
+
+def contour(path):
+    """#348: pitch-contour fallback for sustained / slow-attack material that
+    has no sharp onsets. Per-frame autocorrelation → median-filter → segment
+    runs of stable MIDI into notes."""
+    a, sr = load(path)
+    fl, hop = int(sr * 0.046), int(sr * 0.01)
+    midis = []
+    for i in range(0, len(a) - fl, hop):
+        f0 = _ac_pitch(a[i:i + fl] * np.hanning(fl), sr)
+        midis.append(f2midi(f0) if f0 > 0 else None)
+    # 5-frame median smoothing over voiced frames
+    sm = list(midis)
+    for i in range(2, len(midis) - 2):
+        w = [x for x in midis[i - 2:i + 3] if x is not None]
+        sm[i] = int(np.median(w)) if w else None
+    notes, run, start = [], None, 0
+    voiced = sum(1 for x in sm if x is not None)
+    framed = 0                                            # frames in stable runs
+    for i, m in enumerate(sm + [None]):
+        if m != run:
+            if run is not None and i - start >= 6:        # ≥60ms stable
+                framed += i - start
+                t = start * hop / sr
+                notes.append({'t': round(t, 3),
+                              'hz': round(440 * 2 ** ((run - 69) / 12), 1),
+                              'midi': run})
+            run, start = m, i
+    # Confidence = fraction of voiced frames that settled into a stable run.
+    # Jittery octave/harmonic noise → low confidence → reported inconclusive.
+    conf = round(framed / voiced, 2) if voiced else 0.0
+    return notes, sr, len(a) / sr, conf
+
+
+def analyse(path, note_dt=None):
+    on, ndt, sr, dur = track(path, note_dt)
+    method, conf = 'onset', 1.0
+    # Expected note count is unknown; fall back to contour when onset yields
+    # implausibly few notes for the signal length (sustained/legato material).
+    if len(on) < max(2, dur / (ndt * 8)):
+        cn, _, _, ccon = contour(path)
+        if len(cn) > len(on):
+            on, conf = cn, ccon
+            method = 'contour' if ccon >= 0.6 else 'contour-low'
+    iv = [round(on[i + 1]['t'] - on[i]['t'], 3) for i in range(len(on) - 1)]
+    midi = [n['midi'] for n in on]
     return {
-        'count': len(notes),
+        'method': method,
+        'confidence': conf,
+        'inconclusive': method == 'contour-low',
+        # Cheap autocorrelation contour is octave-unstable (period doubling) but
+        # octave-CONSISTENT, so parity must compare pitch CLASSES in contour
+        # mode (octave error cancels desktop↔web). onset mode stays exact-MIDI.
+        'compare': 'pitch_class' if method.startswith('contour') else 'midi',
+        'note_dt': round(ndt, 4),
+        'count': len(on),
         'median_spacing_s': float(np.median(iv)) if iv else 0.0,
-        'midi': [n['midi'] for n in notes],
-        'names': [name(n['midi']) for n in notes],
-        'notes': notes,
+        'midi': midi,
+        'pc': [m % 12 if m is not None else None for m in midi],
+        'names': [name(m) for m in midi],
+        'notes': on,
     }
 
 
 if __name__ == '__main__':
     args = sys.argv[1:]
     as_json = '--json' in args
-    path = [x for x in args if x != '--json'][0]
-    r = track(path)
+
+    def opt(flag):
+        return float(args[args.index(flag) + 1]) if flag in args else None
+    note_dt = opt('--note-dt')
+    bpm = opt('--bpm')
+    if note_dt is None and bpm:                 # one beat = the default grid
+        note_dt = 60.0 / bpm
+    pos = [x for i, x in enumerate(args)
+           if not x.startswith('--')
+           and (i == 0 or args[i - 1] not in ('--note-dt', '--bpm'))]
+    r = analyse(pos[0], note_dt)
     if as_json:
         print(json.dumps(r))
     else:
-        print(f"{r['count']} notes, median spacing {r['median_spacing_s']:.3f}s")
+        tag = f"[{r['method']} conf={r['confidence']}]"
+        warn = '  ⚠ INCONCLUSIVE (sustained/noisy — not a Tier-1 verdict)' if r['inconclusive'] else ''
+        print(f"{tag} {r['count']} notes, "
+              f"median spacing {r['median_spacing_s']:.3f}s "
+              f"(note_dt={r['note_dt']}s){warn}")
         print("MIDI:", r['midi'][:32])
         print("name:", r['names'][:16])


### PR DESCRIPTION
Part of EPIC #342. Closes #348 (self-review follow-up from #347).

## Problem

`pitchtrack.py` (the Tier-1 verdict tool from #347) was onset-only with a hardcoded 0.25s grid. Slow-attack pads/drones → no onsets → no Tier-1 verdict; non-0.25s tempos merged/split notes.

## Fix

| Limit | Fix |
|---|---|
| Hardcoded `note_dt=0.25` | Derived from the signal (coarse-onset median IOI, clamped [0.05,2.0]); `--note-dt` / `--bpm` overrides. Discrete material auto-estimates 0.25 → **unchanged** (regression-safe). |
| Onset-only (misses sustained) | `contour()` fallback: per-frame autocorrelation (numpy-only), fundamental-biased peak, median-smoothed, segmented into stable runs. Engages when onset count ≪ duration-implied. |
| Could emit authoritative noise | `confidence` (voiced frames in stable runs) + `inconclusive` (<0.6) → reported as **"no Tier-1 verdict"**, never false pass/fail. Honest degradation = the 6-tier principle (SV46). |
| Octave instability | Matched verdict strictness to detector reliability: cheap autocorrelation is octave-unstable but octave-**consistent**, so contour mode compares pitch **classes** (`pc`, octave error cancels desktop↔web); onset stays exact-MIDI. |

Comparator (`compare-desktop-vs-web.ts`) consumes `method/confidence/inconclusive/compare`: inconclusive → Tier-1 "INCONCLUSIVE"; contour → octave-invariant PC compare; method+confidence shown in §1.1.

## Verification (Level 3)

- **Regression:** discrete `forkbuilder-parity` end-to-end still `✅ Tier 1 ✓ PITCH-MATCH — notes identical over 47` (onset/exact-midi). tsc clean.
- **New capability:** sustained `:prophet` pad (attack 0.8s) — onset mode found nothing; contour now tracks the E/A alternation (conf 0.96) where the tool was previously blind.
- Engine untouched (tooling only) — 998/998 unaffected.

## Design note (witness check during build)

First contour pass had octave-up harmonic noise; fundamental-bias fixed that but introduced consistent octave-**down**. Rather than chase perfect absolute pitch from a numpy autocorrelator (second hand-tune = wrong frame), the principled fix was octave-invariant comparison in contour mode + the confidence/inconclusive safety net. The tool now reports what it can reliably know, at the strictness it can support.