### PR TITLE
🐛 fix(engine): thread _oscHost/_oscPort through forkBuilder — closes #345

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -359,6 +359,14 @@ export class ProgramBuilder {
     // with_fx (same thread) continues it; in_thread/at snapshot it at fork.
     // Previously NO sub-builder inherited it → silent 2× tempo error.
     inner._currentBpm = this._currentBpm
+    // #345: use_osc sets :sonic_pi_osc_client as a thread-local in desktop SP
+    // (core.rb:649-653). Same SP94 drift class as #343 — the inherit-list
+    // omitted this field. Same handling as _currentBpm: with_fx (same thread)
+    // continues; in_thread/at snapshot at fork. Without this, `osc "/path"`
+    // inside a sub-builder targets the default localhost:4560 instead of the
+    // outer's use_osc target.
+    inner._oscHost = this._oscHost
+    inner._oscPort = this._oscPort
     // Iteration introspection (#226) so current_time / current_beat inside
     // with_fx / in_thread / at return the outer's values. #343 Defect B:
     // `at` used to drop these.

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -790,6 +790,66 @@ describe('ProgramBuilder', () => {
       expect(atBeat).toBeCloseTo(0.5, 9)
     })
 
+    it('#345: use_osc target threads into with_fx/in_thread/at (SP94 class)', () => {
+      // Desktop SP `core.rb:649-653` stores [host, port] in :sonic_pi_osc_client
+      // thread-local. with_fx continues it; in_thread/at snapshot at fork. Prior
+      // to the #345 fix, none of the three modes inherited it — `osc` inside a
+      // sub-builder fell back to the default localhost:4560.
+
+      type OscSend = { tag: 'oscSend'; host: string; port: number }
+      const findOsc = (steps: Array<{ tag: string }>): OscSend =>
+        steps.find((s) => s.tag === 'oscSend') as OscSend
+      const subBody = (s: { tag: string }): Array<{ tag: string }> =>
+        (s as unknown as { body: Array<{ tag: string }> }).body
+
+      // with_fx: same-thread continuation
+      const bf = new ProgramBuilder()
+      bf.use_osc('remote.host', 9000)
+      bf.with_fx('reverb', {}, (inner) => { inner.osc('/path', 1); return inner })
+      const fxStep = bf.build().find((s) => s.tag === 'fx')!
+      const fxOsc = findOsc(subBody(fxStep))
+      expect(fxOsc.host).toBe('remote.host')
+      expect(fxOsc.port).toBe(9000)
+
+      // in_thread: forked snapshot
+      const bt = new ProgramBuilder()
+      bt.use_osc('thread.host', 9001)
+      bt.in_thread((inner) => { inner.osc('/path', 1) })
+      const tStep = bt.build().find((s) => s.tag === 'thread')!
+      const tOsc = findOsc(subBody(tStep))
+      expect(tOsc.host).toBe('thread.host')
+      expect(tOsc.port).toBe(9001)
+
+      // at: forked snapshot per offset
+      const ba = new ProgramBuilder()
+      ba.use_osc('at.host', 9002)
+      ba.at([0], null, (inner) => { inner.osc('/path', 1) })
+      const aStep = ba.build().find((s) => s.tag === 'thread')!
+      const aOsc = findOsc(subBody(aStep))
+      expect(aOsc.host).toBe('at.host')
+      expect(aOsc.port).toBe(9002)
+    })
+
+    it('#345: in_thread/at snapshot use_osc at fork (outer reassign does not retro-affect inner)', () => {
+      // Forked semantics: thread-local value is captured at fork time. A later
+      // outer `use_osc` must NOT change what the inner already-built program
+      // sees (it built its osc step with the value at fork).
+      const b = new ProgramBuilder()
+      b.use_osc('first.host', 9100)
+      b.in_thread((inner) => { inner.osc('/path', 1) })
+      b.use_osc('second.host', 9200)              // outer reassigns AFTER fork
+      b.osc('/outer', 1)                          // outer's osc uses the new value
+      type OscSend = { tag: 'oscSend'; host: string; port: number }
+      const prog = b.build()
+      const threadStep = prog.find((s) => s.tag === 'thread') as { tag: 'thread'; body: Array<{ tag: string }> }
+      const innerOsc = threadStep.body.find((s) => s.tag === 'oscSend') as OscSend
+      const outerOsc = prog.find((s) => s.tag === 'oscSend') as OscSend
+      expect(innerOsc.host).toBe('first.host')    // inner captured pre-reassign
+      expect(innerOsc.port).toBe(9100)
+      expect(outerOsc.host).toBe('second.host')   // outer sees post-reassign
+      expect(outerOsc.port).toBe(9200)
+    })
+
     it('Defect B: at inherits iteration introspection (#226), like with_fx/in_thread', () => {
       const b = new ProgramBuilder()
       ;(b as unknown as { _currentBuildSeconds: number })._currentBuildSeconds = 9.5


### PR DESCRIPTION
## Summary
- `forkBuilder` (introduced in #344) now threads `_oscHost` / `_oscPort` alongside `_currentBpm` and iteration introspection. Before this fix, `osc "/path"` inside `with_fx` / `in_thread` / `at` fell back to the default `localhost:4560` even after `use_osc` had been called on the outer builder.
- Desktop SP stores `[host, port]` in `:sonic_pi_osc_client` as a thread-local (`core.rb:649-653`) — same semantics that justified threading `_currentBpm` in #343/#344. Same SP94 drift class: an inherited field that the inherit-list omitted, found after the consolidation.
- Plain assignment matches the existing `_currentBpm` pattern: with_fx (same-thread) continues the value; in_thread / at (forked) snapshot at fork — outer reassignment after the fork does NOT retro-affect the inner.

## Diff
- `src/engine/ProgramBuilder.ts` — two assignments in `forkBuilder` with the SP94 rationale.
- `src/engine/__tests__/ProgramBuilder.test.ts` — two new tests in the existing `forkBuilder(mode)` describe block: (1) target reaches the `oscSend` step inside each of the three sub-builder modes, (2) snapshot semantics — outer reassign after fork doesn't change what the inner built.

## Test plan
- [x] `npx vitest run` — 1000/1000 passing locally (was 998/998 pre-change; +2 new).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run src/engine/__tests__/ProgramBuilder.test.ts` — 68/68 in the dedicated suite.
- [ ] Level-3 audio observation not applicable — `osc` is a pure transport step, no audio path. The assertion is on the built `Program`'s `host`/`port` fields, which is the exact contract the interpreter then reads.

Closes #345.