### PR TITLE
🐛 fix(engine): Ring#mirror/#reflect match desktop semantics — closes #354

### DIFF
--- a/src/engine/Ring.ts
+++ b/src/engine/Ring.ts
@@ -107,10 +107,19 @@ export class Ring<T> {
     return new Ring([...this.items.slice(offset), ...this.items.slice(0, offset)])
   }
 
-  /** Mirror: [1,2,3] → [1,2,3,2,1] */
-  mirror(): Ring<T> {
-    const mid = this.items.slice(1, -1).reverse()
-    return new Ring([...this.items, ...mid])
+  /**
+   * Mirror: `[a,b,c]` → `[a,b,c,c,b,a]` — endpoints duplicated, length 2N.
+   * Matches desktop Sonic Pi `core.rb:802`: `(self + self.reverse) * n`
+   * (optional `n` repeats the whole mirrored ring). #354 — previously this
+   * dropped the boundary duplication (desktop's `.reflect` shape) and was
+   * swapped with `reflect()`.
+   */
+  mirror(n: number = 1): Ring<T> {
+    const base = [...this.items, ...[...this.items].reverse()]
+    const reps = Math.max(0, Math.floor(n))
+    const out: T[] = []
+    for (let i = 0; i < reps; i++) out.push(...base)
+    return new Ring(out)
   }
 
   /** First element. */
@@ -128,8 +137,24 @@ export class Ring<T> {
     return new Ring([...this.items, ...otherItems])
   }
 
-  /** Reflect: like mirror but no middle duplication for even-length. */
-  reflect(): Ring<T> { return new Ring([...this.items, ...[...this.items].reverse()]) }
+  /**
+   * Reflect: `[a,b,c]` → `[a,b,c,b,a]` — palindrome, NO boundary duplication,
+   * length 2N-1. Matches desktop Sonic Pi `core.rb:796`:
+   * `res = self + self.reverse.drop(1); res += res.drop(1)*(n-1) if n>1`
+   * (`n<2` returns the single palindrome unchanged). #354 — previously this
+   * produced the boundary-duplicated shape (desktop's `.mirror`).
+   */
+  reflect(n: number = 1): Ring<T> {
+    let res = [...this.items, ...[...this.items].reverse().slice(1)]
+    const reps = Math.max(0, Math.floor(n))
+    if (reps > 1) {
+      const tail = res.slice(1)
+      const extra: T[] = []
+      for (let i = 0; i < reps - 1; i++) extra.push(...tail)
+      res = [...res, ...extra]
+    }
+    return new Ring(res)
+  }
 
   /** Last n elements. */
   take_last(n: number): Ring<T> { return new Ring(this.items.slice(-n)) }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1327,9 +1327,12 @@ function transpileReceiverMethodCall(
     return `__b.shuffle(${recStr})`
   }
 
-  // .mirror → .mirror()
-  if (method === 'mirror') {
-    return `${recStr}.mirror()`
+  // .mirror(n) / .reflect(n) → thread the optional repeat arg (desktop
+  // core.rb:796-805 both take n=1). #354 — was hardcoded `.mirror()`,
+  // silently dropping `n`.
+  if (method === 'mirror' || method === 'reflect') {
+    const args = argsNode ? transpileArgList(argsNode, ctx) : ''
+    return `${recStr}.${method}(${args})`
   }
 
   // .ramp → .ramp()

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -109,6 +109,52 @@ describe('Ring', () => {
     const r = ring(1, 2, 3)
     expect([...r]).toEqual([1, 2, 3])
   })
+
+  // #354 — desktop Sonic Pi core.rb:796-805 parity. Previously mirror/reflect
+  // were swapped AND neither matched desktop; `.mirror.tick` produced a
+  // different note sequence than desktop (Tier-1 pitch divergence at note 2).
+  describe('mirror / reflect (#354 desktop parity)', () => {
+    it('mirror duplicates the boundary: [a,b,c] → [a,b,c,c,b,a]', () => {
+      // desktop: (self + self.reverse) * n
+      expect(ring(1, 2, 3).mirror().toArray()).toEqual([1, 2, 3, 3, 2, 1])
+    })
+
+    it('mirror of the #354 reproducer ring is the desktop 8-element shape', () => {
+      // (ring 60,64,67,71).mirror — desktop pitch-track cycle, sampled
+      // every-other onset by .tick at 0.5s: 64,71,67,60 (positions 1,3,5,7).
+      expect(ring(60, 64, 67, 71).mirror().toArray())
+        .toEqual([60, 64, 67, 71, 71, 67, 64, 60])
+    })
+
+    it('reflect is a palindrome with no boundary dup: [a,b,c] → [a,b,c,b,a]', () => {
+      // desktop: self + self.reverse.drop(1)
+      expect(ring(1, 2, 3).reflect().toArray()).toEqual([1, 2, 3, 2, 1])
+      expect(ring(60, 64, 67, 71).reflect().toArray())
+        .toEqual([60, 64, 67, 71, 67, 64, 60])
+    })
+
+    it('mirror(n) repeats the whole mirrored ring', () => {
+      // desktop: (self + self.reverse) * n
+      expect(ring(1, 2, 3).mirror(2).toArray())
+        .toEqual([1, 2, 3, 3, 2, 1, 1, 2, 3, 3, 2, 1])
+      expect(ring(1, 2, 3).mirror(0).toArray()).toEqual([])
+    })
+
+    it('reflect(n) appends res.drop(1) (n-1) times; n<2 unchanged', () => {
+      // desktop: res = self + self.reverse.drop(1);
+      //          res = res + (res.drop(1) * (n-1)) if n > 1
+      expect(ring(1, 2, 3).reflect(2).toArray())
+        .toEqual([1, 2, 3, 2, 1, 2, 3, 2, 1])
+      expect(ring(1, 2, 3).reflect(1).toArray()).toEqual([1, 2, 3, 2, 1])
+    })
+
+    it('single-element and empty rings match desktop', () => {
+      expect(ring(7).mirror().toArray()).toEqual([7, 7])
+      expect(ring(7).reflect().toArray()).toEqual([7])
+      expect(ring<number>().mirror().toArray()).toEqual([])
+      expect(ring<number>().reflect().toArray()).toEqual([])
+    })
+  })
 })
 
 describe('Global tick context (#211 Tier A)', () => {


### PR DESCRIPTION
## Problem

`(ring 60,64,67,71).mirror.tick` produced a different note sequence on web than desktop Sonic Pi — Tier-1 pitch divergence at note 2, found by the EPIC #342 §6 matrix sweep. `Ring.mirror` dropped the boundary duplication while `Ring.reflect` added it: **the two were swapped** relative to desktop, and neither implemented the optional `n` repeat arg. The transpiler additionally hardcoded `.mirror()`, silently dropping any argument.

## Ground truth (desktop Sonic Pi `core.rb:796-805`)

```ruby
def reflect(n=1)
  res = self + self.reverse.drop(1)          # [a,b,c] → [a,b,c,b,a]
  res = res + (res.drop(1) * (n - 1)) if n > 1
  res
end
def mirror(n=1)
  (self + self.reverse) * n                  # [a,b,c] → [a,b,c,c,b,a]
end
```

## Fix

- `Ring.mirror(n=1)` → `(self + self.reverse) * n` — boundary duplicated, length 2N.
- `Ring.reflect(n=1)` → `self + self.reverse.drop(1)`, then `+ res.drop(1)*(n-1)` when `n>1` — palindrome, no dup, length 2N-1.
- Transpiler threads the `n` arg for both `.mirror` and `.reflect`.

## Test plan

- [x] Level 1 — `npx vitest run` 1000/1000, `npx tsc --noEmit` clean. 6 new #354 regression tests in `DSLHelpers.test.ts` (desktop-spec values incl. the reproducer ring, the `n` arg, single/empty edge cases).
- [x] Level 2 — `/s_new` note stream on the issue reproducer = `60,64,67,71,71,67,64,60` cycling (desktop 8-element mirror; was the 6-element no-dup shape).
- [x] Level 3 — WAV pitch-track confirms rendered audio period-8 `[60,64,67,71,71,67,64,60]` = desktop. **Tier-1 PITCH-MATCH.**

## Note

`.mirror` callers in shipped examples (incl. the default "Solar Flare") now produce the desktop-correct sweep shape (2N, endpoint held) instead of the old 2N−2. This is the intended correctness change — web now matches desktop — but it audibly alters the default track. Tests unaffected (none asserted exact swept values).

Closes #354. Part of EPIC #342 §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)