### PR TITLE
🐛 fix(engine): reset top-level current_time per Run (match desktop) — partial #364

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -72,6 +72,20 @@ export class SonicPiEngine {
   private eventStream = new SoundEventStream()
   private initialized = false
   private playing = false
+  /**
+   * Origin for top-level `current_time` rebase (#364 item 4). Desktop SP resets
+   * `spider_time` to 0 at every job start (`runtime.rb:120,939`
+   * `__init_spider_time_and_beat!`). Our `scheduler.audioTime` is a live read
+   * of the monotonic `AudioContext.currentTime` clock, which only resets when
+   * the context is closed. `stop()` correctly preserves the bridge for reuse,
+   * so without this rebase a fresh Run after Stop reports prior session time
+   * (verified: V1=1.616, V2 after 5s wait + Run=8.677, Δ=+7.061s).
+   *
+   * Internal scheduling MUST keep using absolute `audioCtx.currentTime` (sleep
+   * queues, cue timestamps, /s_new timetags all interact with audioCtx). Only
+   * the user-visible top-level `current_time` reader subtracts this origin.
+   */
+  private _spiderTimeOrigin = 0
   private runtimeErrorHandler: ((err: Error) => void) | null = null
   private printHandler: ((msg: string) => void) | null = null
   private cueHandler: ((name: string, time: number) => void) | null = null
@@ -363,6 +377,14 @@ export class SonicPiEngine {
         }
 
         const audioCtx = this.bridge?.audioContext
+        // #364 item 4 — desktop's `__init_spider_time_and_beat!`
+        // (runtime.rb:120,939) resets `spider_time = 0` at every job start.
+        // We rebase here on every fresh Run (NOT hot-swap; hot-swap correctly
+        // preserves the same scheduler so live-coding `current_time` keeps
+        // advancing — there's no session-restart marker for live coding).
+        // Verified: V1=1.616s on first Run, V2=8.677s on Run after Stop+5s
+        // wait, Δ=+7.061s (`tools/test_current_time_reset.ts`).
+        this._spiderTimeOrigin = audioCtx?.currentTime ?? 0
         this.scheduler = new VirtualTimeScheduler({
           getAudioTime: () => audioCtx?.currentTime ?? 0,
           schedAheadTime: this.schedAheadTime,
@@ -726,8 +748,15 @@ export class SonicPiEngine {
           // loopBeats persists current_beat across iterations like loopTicks does.
           // task.bpm seeds the builder's bpm so current_beat_duration reflects a
           // top-level use_bpm; user's own use_bpm inside the body overrides.
+          // #364 item 4 — rebase task.virtualTime against _spiderTimeOrigin so
+          // `current_time` inside live_loops (incl. the synthetic `__run_once`
+          // wrapper for bare top-level code) reads per-Run elapsed seconds,
+          // not absolute audioCtx wall clock. task.virtualTime advances by
+          // sleep durations from iteration start, so subtracting the per-Run
+          // origin yields desktop-equivalent semantics
+          // (runtime.rb:120,939 `__init_spider_time_and_beat!`).
           builder.setIterationContext(
-            task.virtualTime,
+            task.virtualTime - this._spiderTimeOrigin,
             this.loopBeats.get(name) ?? 0,
             this.schedAheadTime,
             task.bpm,
@@ -1199,7 +1228,7 @@ export class SonicPiEngine {
         // BUILDER_METHODS so __b.current_* gives per-task reads.
         () => 0,                                                    // current_beat: top-level has no beat counter
         () => 60 / defaultBpm,                                       // current_beat_duration
-        () => scheduler.audioTime,                                   // current_time: audio-context wall clock at top level
+        () => scheduler.audioTime - this._spiderTimeOrigin,          // current_time: rebased per-Run (#364 item 4)
         () => this.schedAheadTime,                                   // current_sched_ahead_time
         // Tier B — PRNG inspection (#227). Top-level mutates topLevelBuilder's
         // RNG; inside live_loops these route to __b.* for per-loop RNG.
@@ -1431,10 +1460,11 @@ export class SonicPiEngine {
         // Tier C PR #3 — vt / bt / rt (#255). Pure BPM math + virtual-time
         // alias. At top level use_bpm only updates `defaultBpm` (it does not
         // call topLevelBuilder.use_bpm), and `current_time` reads
-        // scheduler.audioTime (line 1051) — so we mirror those sources here.
-        // Inside live_loops the transpiler routes through __b via
-        // BUILDER_METHODS, where per-task _currentBpm and _audioTime are correct.
-        () => scheduler.audioTime,                                   // vt: thread's local virtual run time
+        // scheduler.audioTime rebased per-Run (#364 item 4) — so we mirror
+        // those sources here. Inside live_loops the transpiler routes through
+        // __b via BUILDER_METHODS, where per-task _currentBpm and _audioTime
+        // are correct.
+        () => scheduler.audioTime - this._spiderTimeOrigin,          // vt: thread's local virtual run time (rebased)
         (t: number) => t * 60 / defaultBpm,                          // bt: beats → seconds at current bpm
         (t: number) => t * defaultBpm / 60,                          // rt: seconds → beats (bypasses bpm scaling)
       ]

--- a/tools/test_current_time_reset.ts
+++ b/tools/test_current_time_reset.ts
@@ -1,0 +1,122 @@
+/**
+ * #364 item 4 — verify spider_time reset bug.
+ *
+ * Hypothesis (per runtime.rb:120,939): desktop SP resets spider_time=0 every Run.
+ * Our scheduler.audioTime is a live read of audioCtx.currentTime (monotonic,
+ * never resets unless AudioContext is closed). Since stop() does NOT close the
+ * AudioContext, Stop → wait → Run → current_time should return elapsed wall
+ * clock since first AudioContext creation, not 0.
+ *
+ * Experiment:
+ *   1. Open app, install __spw_engine hook (capture.ts pattern)
+ *   2. Paste `puts current_time`, click Run → record V1 from printHandler
+ *   3. Click Stop, wait 5s real time
+ *   4. Click Run again → record V2
+ *   Predicted: V2 ≈ V1 + 5  (bug confirmed)
+ *   Null:      V2 ≈ V1 ≈ 0  (something resets it)
+ */
+import { chromium } from 'playwright'
+
+async function main() {
+  const browser = await chromium.launch({
+    headless: false,
+    args: ['--autoplay-policy=no-user-gesture-required'],
+  })
+  const page = await (await browser.newContext()).newPage()
+  await page.goto('http://localhost:5173')
+  await page.waitForTimeout(2000)
+  if (!(await page.evaluate(() => Boolean(document.querySelector('#app'))))) {
+    throw new Error('Not the SonicPi.js app')
+  }
+
+  // Install the engine hook BEFORE Run (capture.ts pattern, #221).
+  await page.evaluate(`(function() {
+    var _engine = null;
+    window.__putsLog = [];
+    Object.defineProperty(window, '__spw_engine', {
+      configurable: true,
+      get: function() { return _engine; },
+      set: function(e) {
+        _engine = e;
+        var origPrint = e.printHandler;
+        e.printHandler = function(msg) {
+          window.__putsLog.push({ t: Date.now(), msg: String(msg) });
+          if (origPrint) origPrint(msg);
+        };
+      }
+    });
+  })()`)
+
+  // Paste the test code
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await page.waitForTimeout(100)
+  await editor.fill('puts current_time')
+  await page.waitForTimeout(200)
+
+  const runBtn = page.locator('.spw-btn-label:has-text("Run")')
+  const stopBtn = page.locator('.spw-btn-label:has-text("Stop")')
+
+  // === Run #1 ===
+  await runBtn.click()
+  // First Run needs the engine to boot — wait for "Audio engine ready" then settle
+  await page.waitForFunction(
+    () => document.querySelector('#app')?.textContent?.includes('Audio engine ready'),
+    { timeout: 30000 },
+  ).catch(() => {})
+  await page.waitForTimeout(1500)  // let `puts current_time` print
+  const log1 = await page.evaluate(() => (window as any).__putsLog as { t: number; msg: string }[])
+  await stopBtn.click()
+  await page.waitForTimeout(500)
+
+  // === Wait 5s real time ===
+  console.log('\nWaiting 5s real time before Run #2 ...')
+  await page.waitForTimeout(5000)
+
+  // === Run #2 (same buffer) ===
+  const splitIdx = log1.length
+  await runBtn.click()
+  await page.waitForTimeout(2500)  // already booted; just need the puts
+  await stopBtn.click()
+  await page.waitForTimeout(500)
+
+  const log2All = await page.evaluate(() => (window as any).__putsLog as { t: number; msg: string }[])
+  const log2 = log2All.slice(splitIdx)
+
+  const extractNum = (arr: { msg: string }[]): number | null => {
+    for (const p of arr) {
+      const m = p.msg.match(/-?\d+\.\d+|\d+/)
+      if (m) {
+        const n = parseFloat(m[0])
+        if (!isNaN(n)) return n
+      }
+    }
+    return null
+  }
+
+  console.log(`\n--- Run #1 puts (${log1.length}) ---`)
+  log1.forEach((p) => console.log(`  ${p.msg}`))
+  console.log(`\n--- Run #2 puts (${log2.length}) ---`)
+  log2.forEach((p) => console.log(`  ${p.msg}`))
+
+  const v1 = extractNum(log1)
+  const v2 = extractNum(log2)
+  console.log(`\n=== RESULT ===`)
+  console.log(`V1 = ${v1}`)
+  console.log(`V2 = ${v2}`)
+  if (v1 !== null && v2 !== null) {
+    const d = v2 - v1
+    console.log(`Δ  = ${d.toFixed(3)}s  (real-time gap was ~5s + 2 Runs of ~2s each)`)
+    if (d > 4) console.log('⇒ BUG CONFIRMED — current_time does NOT reset on Run')
+    else if (Math.abs(d) < 0.5) console.log('⇒ NO BUG — current_time resets between Runs')
+    else console.log(`⇒ Inconclusive — Δ=${d.toFixed(3)} doesn't clearly match either prediction`)
+  } else {
+    console.log('⇒ Could not extract numeric values — check puts log above')
+  }
+
+  await browser.close()
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Problem

Bare top-level `puts current_time` returns audio-context wall-clock since first init, not seconds since current Run start. **Stop → wait 5s → Run emits ~7s, desktop emits ~0** — confirmed by direct observation, not inference.

Surfaced while reverse-engineering desktop `runtime.rb` (see #364). Item 4 of 4.

## Root cause (grounded)

- `SonicPiEngine.ts:380` — scheduler getter `() => audioCtx?.currentTime ?? 0` (live read of monotonic clock).
- `VirtualTimeScheduler.ts:161` — `get audioTime(): number { return this.getAudioTime() }`.
- `AudioContext.currentTime` only resets when the context is closed.
- `stop()` correctly preserves `bridge` + `AudioContext` for reuse (#152 / SP90 family) — so the clock keeps advancing through Stop into the next Run.
- Desktop SP resets `spider_time = 0` at every job start: `runtime.rb:120, 939` (`__init_spider_time_and_beat!`).

## Fix

New field `_spiderTimeOrigin`; rebased at the same point the scheduler is recreated (fresh Run only — hot-swap correctly preserves live-coding semantics by reusing the scheduler). Subtract origin at **three** top-level reader sites:

| Site | What it reads |
|---|---|
| `SonicPiEngine.ts:1224` | `current_time` DSL exposure |
| `SonicPiEngine.ts:1460` | `vt` helper (bt/rt/vt at top level) |
| `SonicPiEngine.ts:752` | `builder.setIterationContext` for `__run_once` + every live_loop — `task.virtualTime` is the absolute clock; bare top-level `puts current_time` routes through `__b.current_time`, NOT the DSL closures |

Internal scheduler/sleep/cue queues keep using absolute `audioCtx.currentTime`. The fix is surgical: 3 subtractions, 1 new field, 1 origin assignment.

## Test plan

- [x] Level 1: `npx vitest run` → 1000/1000 · `npx tsc --noEmit` → clean
- [x] Level 3: `tools/test_current_time_reset.ts` Playwright reproducer (committed)

  | | Before | After |
  |---|---|---|
  | Run #1 `puts current_time` | 1.626 | **0.005** |
  | Run #2 (Stop + 5s wait + Run) | 8.677 | **0.000** |
  | Δ | +7.061s | **−0.005s** |

## Methodology note

First attempt rebased only the DSL closures and missed the builder iteration context. The Playwright reproducer caught it — Lokayata observation over inference. The discovery path is captured in the commit message; the reproducer is committed as a regression test.

Partial #364 (item 4). Items 1–3 are design phases:
- Item 1 — `wait_for_threads(t)` primitive → SP95 design (#350/#351, vyapti SV47)
- Item 2 — 4-stage lifecycle hooks → next teardown touch
- Item 3 — time density stack → #356 with_swing

🤖 Generated with [Claude Code](https://claude.com/claude-code)