### PR TITLE
🐛 fix(dsl): chord_degree default = 4 notes (Cmaj7) match desktop — partial #355

### DIFF
--- a/src/engine/ChordScale.ts
+++ b/src/engine/ChordScale.ts
@@ -288,17 +288,23 @@ export function note_range(low: string | number, high: string | number): Ring<nu
 /**
  * Return the chord built on the Nth degree of a scale.
  *
- * chord_degree(:i, :c4, :major)  → chord(:c4, :major)
- * chord_degree(:iii, :c4, :major) → chord(:e4, :minor)
+ * chord_degree(:i, :c4, :major)  → ring(60, 64, 67, 71)   # C maj 7
+ * chord_degree(:i, :a3, :major)  → ring(57, 61, 64, 68)   # A maj 7
  *
  * Sonic Pi uses Roman numeral symbols (:i through :vii).
  * We also accept 1-based integer degrees for convenience.
+ *
+ * Default chord size is **4** (diatonic 7th chord), matching desktop Sonic Pi
+ * — see `lib/sonicpi/lang/western_theory.rb:900` `number_of_notes=4` and the
+ * desktop docstring line 920: "Taking four notes is the default. This gives
+ * us 7th chords - here it plays a C major 7." Pass an explicit `3` to get
+ * triads. (#355)
  */
 export function chord_degree(
   degreeVal: string | number,
   root: string | number,
   scaleType: string = 'major',
-  chordNumNotes: number = 3
+  chordNumNotes: number = 4
 ): Ring<number> {
   const idx = parseDegree(degreeVal)
   const scaleNotes = scale(root, scaleType)

--- a/src/engine/__tests__/DSLWave1.test.ts
+++ b/src/engine/__tests__/DSLWave1.test.ts
@@ -33,38 +33,44 @@ describe('hzToMidi', () => {
 // ---------------------------------------------------------------------------
 
 describe('chord_degree', () => {
-  it('degree :i of C major → C major triad', () => {
+  // Default chord size is 4 (diatonic 7th chord) per desktop Sonic Pi
+  // `lib/sonicpi/lang/western_theory.rb:900` `number_of_notes=4`. #355.
+  it('degree :i of C major → C maj 7 chord (default = 4 notes)', () => {
     const notes = chord_degree('i', 'c4', 'major').toArray()
-    expect(notes).toEqual([60, 64, 67]) // C E G
+    expect(notes).toEqual([60, 64, 67, 71]) // C E G B
   })
 
-  it('degree :ii of C major → D minor triad', () => {
+  it('degree :ii of C major → D min 7 chord (default = 4 notes)', () => {
     const notes = chord_degree('ii', 'c4', 'major').toArray()
-    expect(notes).toEqual([62, 65, 69]) // D F A
+    expect(notes).toEqual([62, 65, 69, 72]) // D F A C
   })
 
-  it('degree :v of C major → G major triad', () => {
+  it('degree :v of C major → G dominant 7 chord (default = 4 notes)', () => {
     const notes = chord_degree('v', 'c4', 'major').toArray()
-    expect(notes).toEqual([67, 71, 74]) // G B D (stacked thirds from 5th degree)
+    expect(notes).toEqual([67, 71, 74, 77]) // G B D F (stacked thirds from 5th degree)
   })
 
   it('accepts integer degrees (1-based)', () => {
     const notes = chord_degree(1, 'c4', 'major').toArray()
-    expect(notes).toEqual([60, 64, 67])
+    expect(notes).toEqual([60, 64, 67, 71])
   })
 
-  it('4-note chords', () => {
-    const notes = chord_degree('i', 'c4', 'major', 4).toArray()
-    expect(notes.length).toBe(4)
-    expect(notes[0]).toBe(60) // C
-    expect(notes[1]).toBe(64) // E
-    expect(notes[2]).toBe(67) // G
-    expect(notes[3]).toBe(71) // B
+  // Ground-truth regression test from desktop SP's own docstring example —
+  // `western_theory.rb:915`: "puts (chord_degree :i, :A3, :major) # returns
+  // a ring of midi notes - (ring 57, 61, 64, 68) - an A major 7 chord".
+  it('matches desktop docstring example: chord_degree(:i, :a3, :major) → A maj 7', () => {
+    const notes = chord_degree('i', 'a3', 'major').toArray()
+    expect(notes).toEqual([57, 61, 64, 68]) // A C# E G#
+  })
+
+  it('explicit triad: chord_degree(:i, :c4, :major, 3) still gives 3-note C major', () => {
+    const notes = chord_degree('i', 'c4', 'major', 3).toArray()
+    expect(notes).toEqual([60, 64, 67]) // C E G — override still works
   })
 
   it('returns a Ring', () => {
     const r = chord_degree('i', 'c4', 'major')
-    expect(r.at(3)).toBe(60) // wraps
+    expect(r.at(4)).toBe(60) // wraps (ring length is now 4)
   })
 })
 
@@ -176,7 +182,7 @@ describe('ProgramBuilder Wave 1', () => {
   it('chord_degree is accessible on builder', () => {
     const b = new ProgramBuilder()
     const notes = b.chord_degree('i', 'c4', 'major')
-    expect(notes.toArray()).toEqual([60, 64, 67])
+    expect(notes.toArray()).toEqual([60, 64, 67, 71]) // Cmaj7 (default 4 — #355)
   })
 
   it('degree is accessible on builder', () => {

--- a/src/engine/__tests__/DSLWave1Integration.test.ts
+++ b/src/engine/__tests__/DSLWave1Integration.test.ts
@@ -125,7 +125,9 @@ describe('Wave 1 DSL Integration (Ruby → engine)', () => {
     expect(notes[2].note).toBe(67)  // G4
   })
 
-  it('chord_degree returns chord at scale degree (3 simultaneous notes)', async () => {
+  it('chord_degree returns chord at scale degree (4 simultaneous notes — Cmaj7 by default)', async () => {
+    // Default chord size = 4 (diatonic 7th chord) per desktop SP
+    // `western_theory.rb:900` `number_of_notes=4`. #355.
     const { events, error } = await evalAndQuery(`
       live_loop :test do
         play chord_degree(:i, :c4, :major)
@@ -134,9 +136,9 @@ describe('Wave 1 DSL Integration (Ruby → engine)', () => {
     `, 0.99)
     expect(error).toBeUndefined()
     const notes = synthNotes(events)
-    expect(notes.length).toBe(3)
+    expect(notes.length).toBe(4)
     const midiNotes = notes.map((n) => n.note).sort((a, b) => a - b)
-    expect(midiNotes).toEqual([60, 64, 67])  // C E G
+    expect(midiNotes).toEqual([60, 64, 67, 71])  // C E G B
   })
 
   it('octs generates octave-spaced notes', async () => {
@@ -187,8 +189,8 @@ describe('Wave 1 DSL Integration (Ruby → engine)', () => {
     `, 0.99)
     expect(error).toBeUndefined()
     const notes = synthNotes(events)
-    // At BPM 120: 1 beat = 0.5s. Query 0-0.99s = ~2 beats = first iteration
-    // 2 chords (3 notes each) + 2 bass notes = 8 play events
-    expect(notes.length).toBe(8)
+    // At BPM 120: 1 beat = 0.5s. Query 0-0.99s = ~2 beats = first iteration.
+    // chord_degree default = 4 notes (Cmaj7 / G7 — #355). 2 chords × 4 + 2 bass = 10.
+    expect(notes.length).toBe(10)
   })
 })


### PR DESCRIPTION
Partial #355. Follow-up #372 filed.

## Problem
`chord_degree(:i, :c4, :major)` returned a 3-note triad `(60,64,67)`; desktop Sonic Pi returns a 4-note 7th chord `(60,64,67,71)` by default.

## Ground truth (desktop `lib/sonicpi/lang/western_theory.rb`)
- **line 900:** `def chord_degree(degree, tonic, scale=:major, number_of_notes=4, *opts)`
- **line 909** docstring: *"If we choose 4 notes from degree `:i` of the C major scale, we take the 1st, 3rd, 5th and 7th notes of the scale to get a C major 7 chord."*
- **line 920** example: *"play (chord_degree :i, :C4, :major, 4) # Taking four notes is the default. This gives us 7th chords - here it plays a C major 7"*
- **line 915** docstring example (regression test source): *"puts (chord_degree :i, :A3, :major) # returns a ring of midi notes - (ring 57, 61, 64, 68) - an A major 7 chord"*

## Fix
- `src/engine/ChordScale.ts:303` `chordNumNotes` default 3 → 4. Explicit override still works (`chord_degree(:i, :c4, :major, 3)` → triad).
- Updated docstring to cite desktop ground truth.
- Cascading test updates: 3-note triad assertions → 4-note 7th-chord semantics, with full scale-degree-stacking math verified for `:i`/`:ii`/`:v`.
- **Two new ground-truth regression tests:** `chord_degree(:i, :a3, :major)` === `[57, 61, 64, 68]` (directly from desktop docstring at line 915); and an explicit-triad override test to prevent silent re-regression.

## Verification
- **Level 1:** tsc clean, **1007/1007** vitest (net +1).
- **Level 3** (Lokayata, fresh capture, `/tmp/test_chord_degree_default.rb`): desktop ↔ web `✓ PITCH-MATCH — notes identical over 2` (desktop `64,68` · web `64,68` · tempo `1.000s/1.000s` · `2/2` onsets).

## Scope-out (filed as #372)
This fix does **not** shrink the `chord_inversions.rb` row of the 8-backlog. That example uses `chord_degree d, :c, :major, 3, invert: i` — passing 3 explicitly + an `invert:` kwarg our chord_degree doesn't accept. Also our `chord_invert` negative-shift semantics differ from desktop (`western_theory.rb:1053-1064`). Both grounded in #372 with file:line citations and a path to MATCH.

This is the AnviDev "cheapest-first, smallest grounded fix" applied to #355 — the default-fix lands clean; the chord_invert + opts-threading work goes through its own grounded follow-up.