### PR TITLE
🐛 fix(dsl): chord_invert negative-shift + chord_degree invert: opt threading — closes #372

### DIFF
--- a/src/engine/ChordScale.ts
+++ b/src/engine/ChordScale.ts
@@ -241,19 +241,36 @@ export function scale(root: string | number, type: string = 'major', numOctavesO
 }
 
 /**
- * Invert a chord by shifting the lowest N notes up an octave.
+ * Invert a chord. Positive shift rotates the lowest note up an octave;
+ * negative shift rotates the highest note down an octave. The result is
+ * always returned sorted ascending.
  *
- * chord_invert(chord(:c4, :major), 1) → [64, 67, 72]
+ * chord_invert(chord(:c4, :major),  1) → ring(64, 67, 72)
+ * chord_invert(chord(:c4, :major), -1) → ring(55, 60, 64)
+ *
+ * Matches desktop SP `lib/sonicpi/lang/western_theory.rb:1053-1064` exactly,
+ * including the final `.sort` (line 1062). Previously our implementation
+ * coerced negative shifts to positive remainders and skipped the sort,
+ * producing the wrong notes for negative inversions and any case where
+ * rotation broke sorted-ascending order. (#372)
  */
 export function chord_invert(notes: Ring<number> | number[], inversion: number): Ring<number> {
-  const arr = Array.isArray(notes) ? [...notes] : notes.toArray()
-
-  let inv = ((inversion % arr.length) + arr.length) % arr.length
-  for (let i = 0; i < inv; i++) {
+  let arr = Array.isArray(notes) ? [...notes] : notes.toArray()
+  let shift = Math.round(inversion)
+  while (shift > 0) {
+    // desktop: notes[1..-1] + [notes[0]+12]
     const lowest = arr.shift()!
     arr.push(lowest + 12)
+    shift -= 1
   }
-
+  while (shift < 0) {
+    // desktop: (notes[0..-2] + [notes[-1]-12]).sort
+    const highest = arr.pop()!
+    arr.push(highest - 12)
+    arr.sort((a, b) => a - b)
+    shift += 1
+  }
+  arr.sort((a, b) => a - b)  // desktop `notes.ring.sort` at line 1062
   return new Ring(arr)
 }
 
@@ -288,8 +305,9 @@ export function note_range(low: string | number, high: string | number): Ring<nu
 /**
  * Return the chord built on the Nth degree of a scale.
  *
- * chord_degree(:i, :c4, :major)  → ring(60, 64, 67, 71)   # C maj 7
- * chord_degree(:i, :a3, :major)  → ring(57, 61, 64, 68)   # A maj 7
+ * chord_degree(:i, :c4, :major)              → ring(60, 64, 67, 71)   # C maj 7
+ * chord_degree(:i, :a3, :major)              → ring(57, 61, 64, 68)   # A maj 7
+ * chord_degree(:i, :c4, :major, 3, {invert:1}) → ring(64, 67, 72)     # 1st inv
  *
  * Sonic Pi uses Roman numeral symbols (:i through :vii).
  * We also accept 1-based integer degrees for convenience.
@@ -299,12 +317,18 @@ export function note_range(low: string | number, high: string | number): Ring<nu
  * desktop docstring line 920: "Taking four notes is the default. This gives
  * us 7th chords - here it plays a C major 7." Pass an explicit `3` to get
  * triads. (#355)
+ *
+ * Accepts an `opts` hash with `invert: N` matching desktop line 904:
+ *   `chord_invert(Chord.resolve_degree(...), opts[:invert]).ring`
+ * Without this, snippets like `chord_degree d, :c, :major, 3, invert: i`
+ * (chord_inversions.rb) silently dropped the kwarg. (#372)
  */
 export function chord_degree(
   degreeVal: string | number,
   root: string | number,
   scaleType: string = 'major',
-  chordNumNotes: number = 4
+  chordNumNotes: number = 4,
+  opts: { invert?: number } = {}
 ): Ring<number> {
   const idx = parseDegree(degreeVal)
   const scaleNotes = scale(root, scaleType)
@@ -321,6 +345,12 @@ export function chord_degree(
     const degIdx = (idx + i * 2) % len
     const octOffset = Math.floor((idx + i * 2) / len) * 12
     notes.push(noteToMidi(root) + scaleIntervals[degIdx] + octOffset)
+  }
+  // #372: thread invert: opt through chord_invert, matching desktop line 904.
+  // `if(opts[:invert])` in Ruby treats `nil` and `false` as falsy and any
+  // numeric (including 0) as truthy. We match: only skip when undefined/null.
+  if (opts.invert !== undefined && opts.invert !== null) {
+    return chord_invert(notes, opts.invert)
   }
   return new Ring(notes)
 }

--- a/src/engine/__tests__/ChordScale.test.ts
+++ b/src/engine/__tests__/ChordScale.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { chord, scale, chord_invert, note, note_range } from '../ChordScale'
+import { chord, scale, chord_invert, chord_degree, note, note_range } from '../ChordScale'
 
 describe('chord', () => {
   it('major chord from C4', () => {
@@ -95,6 +95,8 @@ describe('scale', () => {
 })
 
 describe('chord_invert', () => {
+  // All assertions match desktop SP `lib/sonicpi/lang/western_theory.rb:1053-1064`.
+
   it('first inversion of C major', () => {
     const c = chord('c4', 'major')
     expect(chord_invert(c, 1).toArray()).toEqual([64, 67, 72])
@@ -112,6 +114,59 @@ describe('chord_invert', () => {
 
   it('works with plain arrays', () => {
     expect(chord_invert([60, 64, 67], 1).toArray()).toEqual([64, 67, 72])
+  })
+
+  // #372: negative-shift cases. Desktop: `(notes[0..-2] + [notes[-1]-12]).sort`.
+  // Pre-fix our impl coerced negatives to positive remainders and produced
+  // the wrong notes (e.g. chord_invert([60,64,67], -1) returned [67,72,76]).
+  it('negative inversion (-1) of C major', () => {
+    // Desktop: pop 67, push 67-12=55, sort → [55, 60, 64]
+    expect(chord_invert([60, 64, 67], -1).toArray()).toEqual([55, 60, 64])
+  })
+
+  it('negative inversion (-2) of C major', () => {
+    // Desktop chained: shift=-2 → [55,60,64], shift=-1 → [52,55,60]
+    expect(chord_invert([60, 64, 67], -2).toArray()).toEqual([52, 55, 60])
+  })
+
+  it('negative inversion (-3) of C major', () => {
+    // Three iterations of pop-last/−12/sort
+    expect(chord_invert([60, 64, 67], -3).toArray()).toEqual([48, 52, 55])
+  })
+
+  // Ground-truth regression test from desktop's own docstring example —
+  // `western_theory.rb:1078`: "play (chord_invert (chord :A3, "M"), 0)
+  //   #No inversion - (ring 57, 61, 64)".
+  it('matches desktop docstring: chord_invert(chord(:a3, "M"), 0) → [57,61,64]', () => {
+    expect(chord_invert(chord('a3', 'major'), 0).toArray()).toEqual([57, 61, 64])
+  })
+
+  it('rounds non-integer shift (matches desktop shift.round)', () => {
+    expect(chord_invert([60, 64, 67], 0.6).toArray()).toEqual([64, 67, 72]) // 0.6 → 1
+    expect(chord_invert([60, 64, 67], -0.6).toArray()).toEqual([55, 60, 64]) // -0.6 → -1
+  })
+})
+
+describe('chord_degree with invert: opt (#372)', () => {
+  // Desktop `western_theory.rb:904`:
+  //   chord_invert(Chord.resolve_degree(degree, tonic, scale, number_of_notes), opts[:invert]).ring
+  it('invert: 0 returns the un-inverted chord (sorted)', () => {
+    expect(chord_degree('i', 'c4', 'major', 3, { invert: 0 }).toArray()).toEqual([60, 64, 67])
+  })
+
+  it('matches desktop docstring example: chord_degree(:i, :C, :major, 3, invert: 1) → [64, 67, 72]', () => {
+    // Desktop docstring at `western_theory.rb:922`:
+    //   "play (chord_degree :i, :C4, :major, 3, invert: 1) # Play the first
+    //   inversion of chord i in C major - (ring 64, 67, 72)"
+    expect(chord_degree('i', 'c4', 'major', 3, { invert: 1 }).toArray()).toEqual([64, 67, 72])
+  })
+
+  it('invert: -1 on triad threads negative shift through chord_invert', () => {
+    expect(chord_degree('i', 'c4', 'major', 3, { invert: -1 }).toArray()).toEqual([55, 60, 64])
+  })
+
+  it('without invert: opt, default still gives 4-note Cmaj7 (#355 Part A)', () => {
+    expect(chord_degree('i', 'c4', 'major').toArray()).toEqual([60, 64, 67, 71])
   })
 })
 


### PR DESCRIPTION
Closes #372. Stacked on #373 (#355 Part A). Discovered #374.

## Problem
Two grounded gaps from the #355 family kept `chord_inversions.rb` from matching desktop semantically:

1. **`chord_invert` negative-shift wrong.** Our impl coerced negatives via `((shift % n) + n) % n` then up-rotated. Desktop (`western_theory.rb:1060`): pop last, −12, sort, recurse with shift+1. A/B: `chord_invert([60,64,67], -1)` returned `[67,72,76]`; desktop returns `[55,60,64]`. Also missing the trailing `.sort` of line 1062.
2. **`chord_degree` silently dropped `invert:` kwarg.** Desktop (`western_theory.rb:904`) threads it through `chord_invert`. We had no opts arg → `chord_degree d, :c, :major, 3, invert: i` played the same chord 7 times across `i ∈ -3..3`.

## Fix (engine — `src/engine/ChordScale.ts`)
- `chord_invert` rewritten to mirror desktop's recursion exactly:
  - positive: pop first, push first+12 (sort after, defensively)
  - negative: pop last, push last−12, sort each iteration (matching desktop's `.sort` in the recursive call)
  - base: final unconditional `.sort` (matches `notes.ring.sort` line 1062)
  - `Math.round(inversion)` matches desktop `shift.round` line 1055
- `chord_degree` gains 5th opts arg `{ invert?: number }`; chains through `chord_invert` when provided (treating 0 as truthy, matching Ruby's `if(opts[:invert])`).
- Transpiler kwarg path (`TreeSitterTranspiler.ts:2253-2266`) already converts `:invert =>` to a `{ invert: ... }` JS positional object — **no transpiler change needed**, confirmed by Level-3 below.

## Verification
- **Level 1:** tsc clean (honestly checked rc=0 this time — blind-spot caught mid-session: piped `| tail` masks tsc's exit code), **1016/1016** vitest (+9 net new tests).
- **+9 grounded tests:**
  - `chord_invert` negative shifts −1/−2/−3 against desktop chained-recursion math.
  - **Ground-truth regression** from desktop docstring `western_theory.rb:1078`: `chord_invert(chord(:a3, "M"), 0)` === `[57, 61, 64]`.
  - `shift.round` rounding (0.6 → 1, −0.6 → −1).
  - `chord_degree` with `invert:` opt: invert 0 returns un-inverted sorted; **ground-truth** from desktop docstring `western_theory.rb:922`: `chord_degree(:i, :C4, :major, 3, invert: 1)` === `[64, 67, 72]`; invert −1 threads negative-shift through.
- **Level 3 (Lokayata, fresh capture):** monophonic walk of 5 inversions (−2..2) of `chord_degree(1, :c4, :major, 3)` — instrument-friendly so the pitch-tracker can fairly judge each note:
  ```
  desktop: 52,55,60,55,60,64,60,64,67,64,67,72,67,72,76
  web:     52,55,60,55,60,64,60,64,67,64,67,72,67,72,76
  ✓ PITCH-MATCH — notes identical over 15 (conf 1 both sides)
  ```
  All five inversions including the previously-broken negative cases produce the desktop sequence **exactly**.

## Why chord_inversions.rb stays DIVERGE in the sweep (filed as #374)
The polyphonic `play_chord chord_degree(d, :c, :major, 3, invert: i)` reproducer keeps reading DIVERGE — but Lokayata locates that as a **#368 / SP98-class pitch-tracker limitation** on stacked-chord arpeggios (both sides emit `contour`-mode pitch-classes OUT of the expected set, confidence 0.9). NOT an engine bug. Filed as #374 with three candidate comparator solution directions.

## Stack discipline
Stacked on `fix/chord-degree-default-4-355` (PR #373). Will rebase onto main after #373 lands (SP91 stacked-PR-against-squash discipline). Claude never merges.