### PR TITLE
✨ feat(engine): SP95-loud co-gate — build-time detector for #350/#351 silent-failure patterns

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -844,6 +844,14 @@ export class App {
         this.console.log(msg, 'info')
       })
 
+      this.engine.setWarningHandler((title, msg) => {
+        // SP95-loud + future build-time lints: audio still runs, but a
+        // v1 limitation or latent issue was detected. Surfaced with the
+        // theme.warning hue so the user notices the run isn't silent (the
+        // SP95 director/section pattern was a churn-bomb without this).
+        this.console.logWarning(title, msg)
+      })
+
       this.engine.setCueHandler((name, time) => {
         this.cueLog.logCue(name, this.cueLog.currentRun, time * 1000)
       })

--- a/src/app/Console.ts
+++ b/src/app/Console.ts
@@ -4,7 +4,7 @@
 
 import { theme } from './theme'
 
-export type LogLevel = 'info' | 'error' | 'event' | 'system' | 'cue'
+export type LogLevel = 'info' | 'error' | 'event' | 'system' | 'cue' | 'warning'
 
 interface LogEntry {
   level: LogLevel
@@ -164,6 +164,17 @@ export class Console {
     this.log(`${title}\n${message}`, 'error')
   }
 
+  /**
+   * Warning — non-fatal, audio still runs, but a v1 limitation or
+   * latent issue was detected (e.g. SP95-loud cross-loop set/get,
+   * cue payload via sync return-value). Same structured-block treatment
+   * as logError but in the theme's warning hue so the user can see at a
+   * glance that the run continues vs. logError where audio doesn't start.
+   */
+  logWarning(title: string, message: string): void {
+    this.log(`${title}\n${message}`, 'warning')
+  }
+
   logSystem(text: string): void {
     this.log(text, 'system')
   }
@@ -248,6 +259,36 @@ export class Console {
         content.style.color = theme.purple
         line.style.borderLeftColor = `${theme.purple}33`
         break
+      case 'warning': {
+        // Structured warning block — same shape as 'error' but in the
+        // theme's warning hue (yellow/amber). Audio still runs; the block
+        // says "v1 limitation / latent issue, here's what to use instead."
+        line.style.background = `${theme.warning}14`
+        line.style.borderLeftColor = theme.warning
+        line.style.borderLeftWidth = '3px'
+        line.style.padding = '0.4rem 0.6rem'
+        line.style.margin = '0.2rem 0'
+        line.style.borderRadius = '0 4px 4px 0'
+
+        const parts = entry.text.split('\n')
+        const titleText = parts[0] || 'Warning'
+        const bodyText = parts.slice(1).join('\n').trim()
+
+        const titleEl = document.createElement('div')
+        titleEl.style.cssText = `color: ${theme.warning}; font-weight: 600; font-size: 0.75rem; margin-bottom: 0.25rem;`
+        titleEl.textContent = `⚠ ${titleText}`
+        content.appendChild(titleEl)
+
+        if (bodyText) {
+          const bodyEl = document.createElement('div')
+          bodyEl.style.cssText = `color: ${theme.yellow}; font-size: 0.68rem; white-space: pre-wrap; line-height: 1.5;`
+          bodyEl.textContent = bodyText
+          content.appendChild(bodyEl)
+        }
+
+        content.style.color = '' // children handle color
+        break
+      }
       case 'system':
         content.style.color = theme.comment
         content.style.fontStyle = 'italic'

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -9,6 +9,7 @@ import { ALL_FX_NAMES } from './FxNames'
 import { DSL_NAMES } from './DslNames'
 import { createIsolatedExecutor, validateCode, type ScopeHandle } from './Sandbox'
 import { autoTranspileDetailed } from './TreeSitterTranspiler'
+import { detectSp95Limitations } from './Sp95Lint'
 import { getExample, type Example } from './examples'
 import { initTreeSitter } from './TreeSitterTranspiler'
 
@@ -90,6 +91,16 @@ export class SonicPiEngine {
   private printHandler: ((msg: string) => void) | null = null
   private cueHandler: ((name: string, time: number) => void) | null = null
   private loadExampleHandler: ((example: Example) => void) | null = null
+  /**
+   * Non-fatal warnings surfaced to the user (audio still runs). Wired by
+   * App.ts to `Console.logWarning` so a v1 limitation is **visible** in
+   * the editor console rather than producing the SP95 "silent failure"
+   * churn bomb (the director/section pattern playing nothing without any
+   * indication). Title is short ("Cross-loop set/get"), message is the
+   * actionable explanation ("use same-loop sync-gate instead — #350").
+   * Per-evaluate dedup happens in the detector that emits (Sp95Lint.ts).
+   */
+  private warningHandler: ((title: string, msg: string) => void) | null = null
   /**
    * Per-evaluation dedup set for clamp/range warnings (issue #202, G4).
    * SoundLayer's validateAndClamp emits one warning per out-of-range param,
@@ -315,6 +326,23 @@ export class SonicPiEngine {
       // (the user may have changed the offending value, and they shouldn't be
       // forever-silenced because we already showed the warning once).
       this.warnDedup.clear()
+
+      // SP95-loud co-gate (#350/#351): scan source for known v1-limitation
+      // patterns BEFORE transpile, so even patterns inside broken-syntax code
+      // surface (and so the warning attaches to user intent, not to whatever
+      // the transpiler chose to do with it). Pure-regex detector lives in
+      // `Sp95Lint.ts`; dedup is per-evaluate-call (a fresh Set per Run) so
+      // a hot-swap that keeps the same pattern still shows once on each
+      // explicit Run, but never floods within a single Run.
+      if (this.warningHandler) {
+        const seen = new Set<string>()
+        for (const w of detectSp95Limitations(code)) {
+          const key = w.pattern + '|' + w.title
+          if (seen.has(key)) continue
+          seen.add(key)
+          this.warningHandler(w.title, w.message)
+        }
+      }
 
       // First run or after stop: create fresh scheduler
       if (!isReEvaluate) {
@@ -1839,6 +1867,25 @@ export class SonicPiEngine {
   /** Register a handler for runtime errors inside `live_loop` bodies. */
   setRuntimeErrorHandler(handler: (err: Error) => void): void {
     this.runtimeErrorHandler = handler
+  }
+
+  /**
+   * Register a handler for non-fatal warnings — v1 limitations and latent
+   * issues detected at build time. Audio still runs after a warning; the
+   * warning is the SP95-loud co-gate's user-facing surface (#350/#351
+   * cross-loop set/get + cue-payload-via-sync are silent without this).
+   */
+  setWarningHandler(handler: (title: string, msg: string) => void): void {
+    this.warningHandler = handler
+  }
+
+  /**
+   * Emit a build-time warning to the user. Safe no-op when no handler
+   * is wired (e.g. capture.ts headless runs) — the warning is signaled
+   * via the App's editor console only.
+   */
+  emitWarning(title: string, msg: string): void {
+    if (this.warningHandler) this.warningHandler(title, msg)
   }
 
   /** Register a handler for `puts` / `print` output from user code. */

--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -1,0 +1,196 @@
+/**
+ * SP95-Loud — build-time detector for v1 limitations of the build-once-then-
+ * interpret model (#350 + #351). These patterns produce SILENT failure today
+ * (the SP95 churn-bomb); this module converts them into a visible warning so
+ * the user sees "v1 doesn't support this — use X instead" instead of
+ * mysterious silence.
+ *
+ * Three patterns. Each must distinguish itself from the *working* same-shape
+ * idiom — false positives erode trust in the lint and would harm the gate
+ * more than the silent failure does. Each detector is regex/scan-only over
+ * the source string (no tree-sitter dependency) so it stays robust against
+ * transpiler changes and runs in <1ms on any realistic snippet.
+ *
+ * **Pattern #350 — cross-loop set/get** (silent stale-read on the reader):
+ *   `set :k, …` in `live_loop :A`, `get :k` in `live_loop :B`, A ≠ B.
+ *   Same-loop set/get works (verified by r2_syncgate_crossset — must NOT warn).
+ *
+ * **Pattern #351-payload — cue payload via sync return-value** (silent drop):
+ *   `cue :name, key: value` AND somewhere `sync :name` (or assigned and
+ *   indexed), where the receiver tries to read the payload.
+ *
+ * **Pattern #351-index — bare sync-return-value indexed** (silent undefined):
+ *   `e = sync :name` followed by `e[…]` or `e.something` — the value is the
+ *   builder, indexing yields undefined which `play` no-ops.
+ *
+ * REFS: catalogue SP95 (parent), SV47 (NOT YET IMPLEMENTED), issues #350/#351,
+ * dharana §B2 runtime-cluster co-gate per launch_acceptance_criteria.md.
+ */
+
+export interface Sp95Warning {
+  pattern: 'cross-loop-set-get' | 'cue-payload-via-sync-return' | 'sync-return-indexed'
+  title: string
+  message: string
+}
+
+/**
+ * Find `live_loop :name do … end` blocks and return [{name, body, line}].
+ * Best-effort lexical scan — handles `live_loop :foo, sync: :bar do` (kwargs
+ * before `do`) and `live_loop :foo do |i|` (block param). Doesn't parse
+ * arbitrary nesting depth perfectly; balanced via a simple `do`/`end` counter
+ * which is robust for the SP95 patterns we care about (top-level loops).
+ */
+function findLiveLoops(src: string): Array<{ name: string; body: string }> {
+  const out: Array<{ name: string; body: string }> = []
+  // Match `live_loop :NAME` (optionally followed by kwargs/whitespace, then `do`).
+  // `:NAME` matches Ruby symbol; allow underscores and digits after the first char.
+  const re = /\blive_loop\s+:([a-zA-Z_][a-zA-Z0-9_]*)\b[^\n]*?\bdo\b/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(src)) !== null) {
+    const name = m[1]
+    const bodyStart = m.index + m[0].length
+    // Walk forward counting do/end to find this block's matching end.
+    // Token-aware enough to skip `do` inside comments/strings: cheap heuristic —
+    // strip line-comments and same-line string literals before counting.
+    let depth = 1
+    let i = bodyStart
+    let bodyEnd = bodyStart
+    while (i < src.length && depth > 0) {
+      const nl = src.indexOf('\n', i)
+      const lineEnd = nl === -1 ? src.length : nl
+      const line = src.slice(i, lineEnd)
+      const sanitized = line.replace(/#.*$/, '').replace(/'[^']*'|"[^"]*"/g, '""')
+      const doCount = (sanitized.match(/\bdo\b/g) || []).length
+      const endCount = (sanitized.match(/\bend\b/g) || []).length
+      // Body includes the full line up to (but not past) the matching `end`.
+      // For pattern detection we only care that set/get/cue tokens fall
+      // inside; the closing `end` itself is harmless to include because it
+      // doesn't match any of our token regexes.
+      bodyEnd = lineEnd
+      if (depth + doCount - endCount <= 0) break
+      depth += doCount - endCount
+      if (nl === -1) break
+      i = nl + 1
+    }
+    out.push({ name, body: src.slice(bodyStart, bodyEnd) })
+  }
+  return out
+}
+
+/**
+ * Pattern #350: `set :k` in loop A, `get :k` in loop B, A ≠ B.
+ * Map key → set/get sites by enclosing loop name; warn when sets∩gets across
+ * different loops. Same-loop set/get is intentionally allowed (works on web).
+ */
+function detectCrossLoopSetGet(loops: Array<{ name: string; body: string }>): Sp95Warning[] {
+  const SET_RE = /\bset\s+:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
+  const GET_RE = /\bget\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
+  const setsByKey = new Map<string, Set<string>>()
+  const getsByKey = new Map<string, Set<string>>()
+  for (const lp of loops) {
+    let m: RegExpExecArray | null
+    SET_RE.lastIndex = 0
+    while ((m = SET_RE.exec(lp.body)) !== null) {
+      if (!setsByKey.has(m[1])) setsByKey.set(m[1], new Set())
+      setsByKey.get(m[1])!.add(lp.name)
+    }
+    GET_RE.lastIndex = 0
+    while ((m = GET_RE.exec(lp.body)) !== null) {
+      if (!getsByKey.has(m[1])) getsByKey.set(m[1], new Set())
+      getsByKey.get(m[1])!.add(lp.name)
+    }
+  }
+  const offenders = new Set<string>()
+  for (const [key, setters] of setsByKey) {
+    const getters = getsByKey.get(key)
+    if (!getters) continue
+    // Cross-loop = at least one getter loop that is NOT in the setter set.
+    for (const g of getters) if (!setters.has(g)) offenders.add(key)
+  }
+  if (offenders.size === 0) return []
+  const keys = [...offenders].map(k => `:${k}`).join(', ')
+  return [{
+    pattern: 'cross-loop-set-get',
+    title: 'Cross-loop set/get is a v1 limitation (#350)',
+    message: `Detected set in one live_loop and get(${keys}) in another — the reader will see a stale or null value because set is a deferred runtime step but get is read at build time. Same-loop set/get (or sync-as-gate within one loop) works fine. Workaround: do the set and get inside the SAME live_loop, or use cue+sync (without payload) to gate the read. See SP95 / #350.`,
+  }]
+}
+
+/**
+ * Pattern #351-payload: `cue :name, key: value` with kwargs + a matching
+ * `sync :name` somewhere. Payload is silently dropped by the build-once model.
+ * Catches both `cue(:beat, val: x)` and `cue :beat, val: x`.
+ */
+function detectCuePayloadViaSync(src: string): Sp95Warning[] {
+  // cue with kwargs: `cue :NAME` followed (allowing `(` or whitespace) by an
+  // identifier-colon-space pattern indicating a kwarg, all on the same line.
+  // Restrict to same-line so we don't accidentally pick up the next statement.
+  const CUE_KW_RE = /\bcue\b\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:,|\)\s*,)\s*[a-zA-Z_][a-zA-Z0-9_]*\s*:/g
+  const cueNames = new Set<string>()
+  let m: RegExpExecArray | null
+  while ((m = CUE_KW_RE.exec(src)) !== null) cueNames.add(m[1])
+  if (cueNames.size === 0) return []
+  // For each cue name with payload, is there a matching `sync :name`?
+  const offenders: string[] = []
+  for (const name of cueNames) {
+    const SYNC_RE = new RegExp(`\\bsync\\b\\s*\\(?\\s*:${name}\\b`)
+    if (SYNC_RE.test(src)) offenders.push(name)
+  }
+  if (offenders.length === 0) return []
+  const list = offenders.map(n => `:${n}`).join(', ')
+  return [{
+    pattern: 'cue-payload-via-sync-return',
+    title: 'cue payload via sync return-value is a v1 limitation (#351)',
+    message: `Detected cue ${list} with keyword payload + a matching sync ${list}. The payload (val:, key:, etc.) is sent on the cue but NOT delivered through sync's return value in v1 — your receiver will read nil/undefined and play silently. Workaround: store the value via globalStore (set/get within the same loop, gated by sync) instead of attaching it to the cue. See SP95 / #351.`,
+  }]
+}
+
+/**
+ * Pattern #351-index: `e = sync :name` then `e[…]` or `e.field`.
+ * Direct evidence the receiver expects payload. Catches the pattern even when
+ * the corresponding `cue` is in another file or is missing kwargs entirely.
+ */
+function detectSyncReturnIndexed(src: string): Sp95Warning[] {
+  // Match `e = sync :name` (or `e = sync(:name)`) where e is an identifier.
+  const ASSIGN_RE = /\b([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*sync\b\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
+  const bindings: Array<{ varName: string; cueName: string; afterIndex: number }> = []
+  let m: RegExpExecArray | null
+  while ((m = ASSIGN_RE.exec(src)) !== null) {
+    bindings.push({ varName: m[1], cueName: m[2], afterIndex: m.index + m[0].length })
+  }
+  if (bindings.length === 0) return []
+  const offenderCues = new Set<string>()
+  for (const b of bindings) {
+    // Look for `e[…]` or `e.foo` AFTER the assignment. Bound the search to
+    // ~2KB of following source to keep the regex linear and to avoid matching
+    // unrelated variables of the same name in later code.
+    const tail = src.slice(b.afterIndex, b.afterIndex + 2048)
+    const INDEX_RE = new RegExp(`\\b${b.varName}\\s*\\[`)
+    const DOT_RE = new RegExp(`\\b${b.varName}\\s*\\.\\s*[a-zA-Z_]`)
+    if (INDEX_RE.test(tail) || DOT_RE.test(tail)) offenderCues.add(b.cueName)
+  }
+  if (offenderCues.size === 0) return []
+  const list = [...offenderCues].map(n => `:${n}`).join(', ')
+  return [{
+    pattern: 'sync-return-indexed',
+    title: 'Indexing the sync return-value yields undefined (#351)',
+    message: `Detected the pattern: e = sync ${list} ... e[…] (or e.field). In v1, sync returns the builder itself, NOT the cue's payload — indexing it gives undefined and any play(undefined) is silently skipped. Workaround: don't rely on sync's return value; instead store the data via set in the cuer's loop and get it in the receiver after sync (same-loop set/get works inside a single loop; cross-loop is also a v1 limitation per #350). See SP95 / #351.`,
+  }]
+}
+
+/**
+ * Run all SP95-loud detectors over the given Ruby source. Returns an empty
+ * list when no patterns match. Caller is responsible for surfacing the
+ * warnings (per-evaluate dedup, formatting). Pure function — no IO.
+ *
+ * Total cost is one O(n) scan per detector; n ≪ 100KB for any realistic
+ * Sonic Pi piece, so this runs in <1ms.
+ */
+export function detectSp95Limitations(src: string): Sp95Warning[] {
+  const loops = findLiveLoops(src)
+  return [
+    ...detectCrossLoopSetGet(loops),
+    ...detectCuePayloadViaSync(src),
+    ...detectSyncReturnIndexed(src),
+  ]
+}

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Sp95Lint — pattern detector tests.
+ *
+ * Three positive patterns, plus the critical negative cases. False positives
+ * on these would erode trust in the lint and warn users about idioms that
+ * actually work — strictly worse than the silent failure we're replacing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { detectSp95Limitations } from '../Sp95Lint'
+
+describe('Sp95Lint — cross-loop set/get (#350)', () => {
+  it('warns on the canonical director/section pattern (different loops)', () => {
+    const src = `
+      live_loop :director do
+        set :root, (ring 52, 55, 57, 59).tick
+        sleep 1
+      end
+      live_loop :player do
+        sync :director
+        play get(:root), release: 0.4
+        sleep 1
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.length).toBeGreaterThan(0)
+    expect(w[0].pattern).toBe('cross-loop-set-get')
+    expect(w[0].title).toMatch(/Cross-loop set\/get/)
+  })
+
+  it('does NOT warn when set + get are in the SAME loop (works on web)', () => {
+    const src = `
+      live_loop :solo do
+        set :note, 60
+        play get(:note), release: 0.4
+        sleep 1
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+  })
+
+  it('does NOT warn on get without any matching set', () => {
+    // get with no producer — different bug class, not SP95.
+    const src = `
+      live_loop :reader do
+        play get(:never_set), release: 0.4
+        sleep 1
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+  })
+
+  it('does NOT warn on set without any matching get', () => {
+    const src = `
+      live_loop :writer do
+        set :unused, 1
+        sleep 1
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+  })
+
+  it('catches the function-call form: get(:k)', () => {
+    const src = `
+      live_loop :a do; set :x, 1; sleep 1; end
+      live_loop :b do; play get(:x); sleep 1; end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.some(x => x.pattern === 'cross-loop-set-get')).toBe(true)
+  })
+
+  it('catches the bareword form: get :k', () => {
+    const src = `
+      live_loop :a do; set :x, 1; sleep 1; end
+      live_loop :b do; play get :x; sleep 1; end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.some(x => x.pattern === 'cross-loop-set-get')).toBe(true)
+  })
+})
+
+describe('Sp95Lint — cue payload via sync return-value (#351)', () => {
+  it('warns on cue :x, kw: val + sync :x', () => {
+    const src = `
+      live_loop :sender do
+        cue :beat, val: (ring 60, 64, 67, 71).tick
+        sleep 1
+      end
+      live_loop :receiver do
+        e = sync :beat
+        play e[:val], release: 0.4
+      end
+    `
+    const w = detectSp95Limitations(src)
+    const hit = w.find(x => x.pattern === 'cue-payload-via-sync-return')
+    expect(hit).toBeDefined()
+    expect(hit!.title).toMatch(/cue payload via sync/)
+    expect(hit!.message).toMatch(/:beat/)
+  })
+
+  it('also catches function-call form: cue(:beat, val: x)', () => {
+    const src = `
+      live_loop :s do; cue(:beat, val: 60); sleep 1; end
+      live_loop :r do; sync :beat; end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.some(x => x.pattern === 'cue-payload-via-sync-return')).toBe(true)
+  })
+
+  it('does NOT warn on payload-less cue + sync (works on web)', () => {
+    const src = `
+      live_loop :s do; cue :beat; sleep 1; end
+      live_loop :r do; sync :beat; play 60; end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'cue-payload-via-sync-return')).toEqual([])
+  })
+
+  it('does NOT warn on cue with payload but no matching sync (no receiver)', () => {
+    const src = `
+      live_loop :s do; cue :beat, val: 60; sleep 1; end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'cue-payload-via-sync-return')).toEqual([])
+  })
+})
+
+describe('Sp95Lint — sync return-value indexed (#351 — broader)', () => {
+  it('warns on e = sync :x; e[:k] (even when cue is missing or in another file)', () => {
+    const src = `
+      live_loop :r do
+        e = sync :beat
+        play e[:val]
+      end
+    `
+    const w = detectSp95Limitations(src)
+    const hit = w.find(x => x.pattern === 'sync-return-indexed')
+    expect(hit).toBeDefined()
+    expect(hit!.message).toMatch(/:beat/)
+  })
+
+  it('also catches e.field accesses', () => {
+    const src = `
+      live_loop :r do
+        e = sync :beat
+        play e.val
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.some(x => x.pattern === 'sync-return-indexed')).toBe(true)
+  })
+
+  it('does NOT warn on plain sync without assignment', () => {
+    const src = `
+      live_loop :r do
+        sync :beat
+        play 60
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'sync-return-indexed')).toEqual([])
+  })
+
+  it('does NOT warn on sync return assigned but never indexed', () => {
+    // Assigning the return for logging is harmless; warn only when the user
+    // tries to dig data out of it.
+    const src = `
+      live_loop :r do
+        e = sync :beat
+        puts e  # treats it as opaque — fine
+      end
+    `
+    const w = detectSp95Limitations(src)
+    expect(w.filter(x => x.pattern === 'sync-return-indexed')).toEqual([])
+  })
+})
+
+describe('Sp95Lint — empty / unrelated programs', () => {
+  it('returns no warnings on a trivial play loop', () => {
+    expect(detectSp95Limitations('live_loop :foo do; play 60; sleep 1; end')).toEqual([])
+  })
+
+  it('returns no warnings on the empty string', () => {
+    expect(detectSp95Limitations('')).toEqual([])
+  })
+
+  it('returns no warnings on a piece with set/get/cue/sync but all SP95-safe', () => {
+    // Same-loop set/get + bare cue+sync. The director/section anti-pattern's
+    // "safe twin": the same primitives, just used inside one loop.
+    const src = `
+      live_loop :solo do
+        cue :tick                       # no payload
+        sync :tick                      # plain sync, no return-value use
+        set :n, 60
+        play get(:n)                    # same-loop set+get is OK
+        sleep 1
+      end
+    `
+    expect(detectSp95Limitations(src)).toEqual([])
+  })
+})
+
+describe('Sp95Lint — multiple patterns coexist', () => {
+  it('emits all three when the program contains all three', () => {
+    const src = `
+      live_loop :director do
+        set :root, 60
+        cue :beat, val: 64
+      end
+      live_loop :player do
+        e = sync :beat
+        play e[:val]
+        play get(:root)
+      end
+    `
+    const patterns = new Set(detectSp95Limitations(src).map(w => w.pattern))
+    expect(patterns).toContain('cross-loop-set-get')
+    expect(patterns).toContain('cue-payload-via-sync-return')
+    expect(patterns).toContain('sync-return-indexed')
+  })
+})

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -45,10 +45,14 @@ interface CaptureResult {
   appFullText: string
 
   // Engine-level captures (issue #221) — hooked via __spw_engine setter
-  // BEFORE Run click, so we capture every puts/cue from app start without
-  // depending on Console ring-buffer scrollback or DOM textContent slicing.
+  // BEFORE Run click, so we capture every puts/cue/warning from app start
+  // without depending on Console ring-buffer scrollback or DOM textContent
+  // slicing. `warnings` is the SP95-loud channel (#350/#351 build-time
+  // limitations + future lints) — a real user sees these in `.spw-console`
+  // via the theme.warning hue; this array is the headless / dashboard view.
   puts: { t: number; msg: string }[]
   cues: { t: number; name: string; audioTime: number }[]
+  warnings: { t: number; title: string; msg: string }[]
 
   // Screenshots
   screenshotBefore: string  // path
@@ -269,6 +273,7 @@ async function captureRun(
     var _engine = null;
     window.__capturedPuts = [];
     window.__capturedCues = [];
+    window.__capturedWarnings = [];
     window.__capturedStartedAt = Date.now();
     Object.defineProperty(window, '__spw_engine', {
       configurable: true,
@@ -284,6 +289,17 @@ async function captureRun(
         e.cueHandler = function(name, audioTime) {
           window.__capturedCues.push({ t: Date.now() - window.__capturedStartedAt, name: name, audioTime: audioTime });
           if (origCue) origCue(name, audioTime);
+        };
+        // SP95-loud: capture build-time warnings (#350/#351) symmetrically
+        // with puts/cues so the dashboard/comparator can see them, not just
+        // the user via the editor console. Without this hook the real user
+        // sees the warning in the spw-console DOM but the captured report
+        // misses it -- capture.ts builds its sections from these intercept
+        // arrays, not from DOM textContent (issue #221 design rationale).
+        var origWarn = e.warningHandler;
+        e.warningHandler = function(title, msg) {
+          window.__capturedWarnings.push({ t: Date.now() - window.__capturedStartedAt, title: title, msg: msg });
+          if (origWarn) origWarn(title, msg);
         };
       }
     });
@@ -457,8 +473,9 @@ async function captureRun(
   // __name rewriting of arrow-function closures.
   const engineHooks = await page.evaluate(`({
     puts: window.__capturedPuts || [],
-    cues: window.__capturedCues || []
-  })`) as { puts: { t: number; msg: string }[]; cues: { t: number; name: string; sourceLoop: string }[] }
+    cues: window.__capturedCues || [],
+    warnings: window.__capturedWarnings || []
+  })`) as { puts: { t: number; msg: string }[]; cues: { t: number; name: string; sourceLoop: string }[]; warnings: { t: number; title: string; msg: string }[] }
 
   // Try to isolate the console pane text (everything after "Audio engine ready" or "Happy live coding")
   let appConsoleText = ''
@@ -560,6 +577,7 @@ async function captureRun(
     warningsSummary,
     puts: engineHooks.puts,
     cues: engineHooks.cues,
+    warnings: engineHooks.warnings,
   }
 }
 
@@ -650,6 +668,24 @@ function writeCaptureReport(result: CaptureResult, outputPath: string): void {
   } else {
     for (const p of result.puts) {
       lines.push(`[${p.t}ms] ${p.msg}`)
+    }
+  }
+  lines.push('```')
+  lines.push('')
+
+  // Engine warnings (SP95-loud + future build-time lints).
+  // Real users see these in `.spw-console` via theme.warning hue; this
+  // section is the headless / dashboard view. Symmetric with App Console
+  // Output above — always emitted (`(none)` when empty) so the dashboard
+  // can deterministically count zero-warning runs.
+  lines.push('## Engine Warnings')
+  lines.push('```')
+  if (result.warnings.length === 0) {
+    lines.push('(none)')
+  } else {
+    for (const w of result.warnings) {
+      lines.push(`[${w.t}ms] ${w.title}`)
+      lines.push(`         ${w.msg}`)
     }
   }
   lines.push('```')


### PR DESCRIPTION
Closes #350 #351. Realises one of the three hard launch-hardening co-gates (dharana §28-UPDATE: "silent SP95 director-section pattern made loud").

## The launch-gate co-blocker
SP95 catalogue names two idioms whose silent failure was the documented "churn bomb" for v1 readiness — a user pastes a piece from the internet, hits Run, hears nothing, gives up:

- **#350 cross-loop set/get** — `set :k` in loop A, `get :k` in loop B. The reader sees stale / null because `set` is a deferred runtime step but `get` is read at build time.
- **#351 cue payload via sync return-value** — `cue :x, val: y` + `e = sync :x; e[:val]`. `b.sync()` returns the builder itself, so `e[:val]` is `undefined` → `play undefined` silently no-ops. Used by Solar Flare and most coordinated pieces.

Catalogue framing for the launch gate: *"either fix architecturally OR make it loud — silence is the actual blocker."* This PR is the **make-it-loud** path. Architectural fix (continuation-split / lazy thunks) remains as `.planning/sp95-architectural/PLAN.md` post-launch work.

## The fix — 4 atomic layers, no engine-semantics change

1. **Engine warning channel** — `SonicPiEngine.setWarningHandler(handler)` API + `private warningHandler` field, mirroring `setRuntimeErrorHandler` exactly. App.ts wires it to `Console.logWarning`. Engine code can call `emitWarning(title, msg)` for any non-fatal v1-limitation surface; no-op when no handler set (capture.ts headless still works).

2. **Source-pattern detector** — new module `src/engine/Sp95Lint.ts` with pure regex/scan detection for three patterns:
   - cross-loop set/get (same-loop case explicitly stays silent)
   - cue payload via sync return-value
   - sync-return indexed/property-accessed (broader cover)

   **18 unit tests** including the critical negative-control cases (same-loop set/get must NOT warn — a false positive there is strictly worse than the silent failure we're replacing).

3. **Wiring in evaluate()** — detector runs AFTER the no-op short-circuit (re-pressing Run on identical code stays silent) but BEFORE transpile (so patterns inside broken-syntax code still surface). Per-Run dedup.

4. **User-visible Console surface** — new `LogLevel 'warning'` + `case 'warning'` styling in `Console.ts` mirroring 'error' but in `theme.warning` hue (yellow/amber). Structured block: `⚠ <title>` headline + workaround body. Audio keeps running (vs. error which means audio didn't start).

## Capture-pipeline plumbing
`capture.ts` intercepts `e.warningHandler` symmetrically with `printHandler`/`cueHandler` via the `__spw_engine` setter trap (#221 pattern). New `## Engine Warnings` report section parallel to App Console Output and Cue Log. Without this, the **real user sees the warning** in `.spw-console` but headless capture-tool runs would miss it (capture.ts's report sections are built from interceptor arrays, NOT from DOM textContent per #221 design rationale).

**Trap caught via Lokayata mid-session:** backticks inside comments within the `page.evaluate(\`...\`)` template-literal trap terminate the OUTER template literal. First run failed with `console is not a function`. Fixed; commit body has the warning for future contributors.

## Verified (Level 3 — three reproducers via tools/capture.ts)

| Reproducer | Result |
|---|---|
| `/tmp/sp95_350_cross_set_get.rb` | ✅ **1 warning** fires with exact #350 title + workaround text. Audio still plays. |
| `/tmp/sp95_351_cue_payload.rb` | ✅ **2 warnings** fire (kwarg-payload pattern AND indexed-return pattern — defense in depth). |
| `/tmp/sp95_negative_control.rb` (same-loop set/get + payload-less cue/sync — both idioms work on v1) | ✅ **`(none)`** — confirms no false positives on working idioms. |

**Level 1:** tsc clean (`rc=0`, honestly-checked), **1034/1034** vitest (+18 lint tests).

## Out of scope (filed / pre-existing)

- **SP95 architectural fix** (continuation-split). Post-launch; see `.planning/sp95-architectural/PLAN.md`.
- Dashboard surface for the `warnings` array — capture report now has a parsable `## Engine Warnings` section; `compare-desktop-vs-web.ts` / `build-examples-sweep.ts` can opt in in a future PR.

## Remaining launch-hardening co-gates (per dharana §28-UPDATE)

- ✅ SP95 made loud (this PR)
- ⏳ Cross-browser cold-load (Chrome / Firefox / Safari first-try)
- ⏳ Broken-Ruby never silently hangs

Engine impact: **zero behavior change.** No transpiler, scheduler, sandbox, scsynth-bus, or play-arg-shape paths touched. Only adds a non-fatal warning channel + a build-time lint that runs before everything else.

Claude never merges.