### PR TITLE
🐛 fix(engine, tools): cogate-2 SILENT-FAIL trifecta — broken Ruby never silently disappears

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -316,9 +316,16 @@ export class ProgramBuilder {
     return this
   }
 
-  at(times: number[], values: unknown[] | null, buildFn: (b: ProgramBuilder, ...args: unknown[]) => void): this {
-    for (let i = 0; i < times.length; i++) {
-      const offset = times[i]
+  at(times: number | number[], values: unknown[] | null, buildFn: (b: ProgramBuilder, ...args: unknown[]) => void): this {
+    // Desktop SP accepts BOTH `at 1 do … end` (scalar) and `at [1, 2] do … end`
+    // (array). Our transpiler currently emits a scalar unwrapped (`__b.at(1,
+    // null, fn)`) and pre-#383 the runtime iterated `times.length` — `(1).length`
+    // is `undefined`, the for-loop body never ran, and the callback silently
+    // never fired. Normalize here so both call shapes work without depending
+    // on the transpiler emitting consistent forms. (#383)
+    const timesArr: number[] = Array.isArray(times) ? times : [times]
+    for (let i = 0; i < timesArr.length; i++) {
+      const offset = timesArr[i]
       const val = values ? values[i % values.length] : i
       // `at` forks a thread per time like in_thread. forkBuilder also threads
       // iteration introspection (#226 Defect B — `at` used to drop it) and

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -755,10 +755,17 @@ function transpileNode(node: any, ctx: TranspileContext): string {
 
     // ---- Method/function definitions ----
     case 'method': {
-      // def name(args) ... end — not used in Sonic Pi DSL but handle it
+      // def name(args) ... end — not the DSL's `define`, but allowed (#382).
       const nameNode = node.namedChildren[0]
       const params = node.namedChildren.find((c: any) => c.type === 'method_parameters')
       const body = node.namedChildren.find((c: any) => c.type === 'body_statement')
+      // Register the def name BEFORE transpiling the body so a recursive
+      // self-call (and any in-scope reference after the def) resolves to a JS
+      // call `name(__b)` instead of a bare reference. Without this, the body
+      // of `def f; f; end` emitted `function f() { f }` — valid JS that does
+      // nothing — and unconditional recursion never tripped a stack overflow,
+      // so the user saw silent acceptance of demonstrably broken Ruby (#382).
+      ctx.definedFunctions.add(nameNode.text)
       const paramStr = params
         ? params.namedChildren.map((c: any) => transpileNode(c, ctx)).join(', ')
         : ''

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { initTreeSitter, autoTranspileDetailed } from '../TreeSitterTranspiler'
+import { ProgramBuilder } from '../ProgramBuilder'
+
+beforeAll(async () => {
+  await initTreeSitter({
+    treeSitterWasmUrl: './node_modules/web-tree-sitter/tree-sitter.wasm',
+    rubyWasmUrl: './node_modules/tree-sitter-wasms/out/tree-sitter-ruby.wasm',
+  })
+})
+
+describe('cogate-2 SILENT-FAIL fixes (#382 #383 #384)', () => {
+  describe('#382 — user-defined def calls are emitted as calls, not bare references', () => {
+    it('def f; f; end emits function f() { f(__b) } (call, not reference)', () => {
+      const r = autoTranspileDetailed('def f\n  f\nend\n')
+      expect(r.hasError).toBe(false)
+      // Before fix: `function f() { f }` — bare reference, no recursion possible.
+      // After fix: `function f() { f(__b) }` — recursion → stack overflow → user-visible error.
+      expect(r.code).toMatch(/function\s+f\s*\(\s*\)\s*\{\s*f\(__b\)\s*\}/)
+    })
+
+    it('def + call afterwards: f resolves to f(__b)', () => {
+      const r = autoTranspileDetailed('def f\n  play 60\nend\nf\n')
+      expect(r.hasError).toBe(false)
+      // The post-def `f` MUST be a call. Before fix it was a bare reference
+      // (no-op evaluating to the function object), so user code did nothing.
+      expect(r.code).toMatch(/^\s*f\(__b\)/m)
+    })
+
+    it('B6 reproducer compiles to recursing JS that throws RangeError', () => {
+      const r = autoTranspileDetailed('def f\n  f\nend\nf\n')
+      expect(r.hasError).toBe(false)
+      expect(() => {
+        // Direct exec — emulate Sandbox `with(scope){ … }` so the bare `f` and
+        // bare `__b` resolve. RangeError is the user-visible signal.
+        const fn = new Function('__scope__', `with(__scope__){ ${r.code} }`)
+        const scope = new Proxy({} as Record<string, unknown>, {
+          has: () => true,
+          get: () => undefined,
+        })
+        fn(scope)
+      }).toThrow(/maximum call stack/i)
+    })
+  })
+
+  describe('#383 — at() accepts scalar OR array time arg', () => {
+    it('at(1, null, fn) iterates once (scalar normalized to [1])', () => {
+      const b = new ProgramBuilder()
+      let calls = 0
+      // Before fix: times.length === undefined → for loop never iterates → callback never fires.
+      // After fix: Array.isArray check → [1] → callback fires once.
+      // Pass scalar via `as any` to mirror what the transpiler emits today.
+      b.at(1 as unknown as number[], null, (inner) => {
+        calls++
+        inner.play(60)
+      })
+      expect(calls).toBe(1)
+      // The build output should include a thread step for this at(1).
+      const program: ReadonlyArray<{ tag: string }> = b.build()
+      const threadSteps = program.filter(s => s.tag === 'thread')
+      expect(threadSteps.length).toBe(1)
+    })
+
+    it('at([1, 2, 3], null, fn) still iterates three times (array path unchanged)', () => {
+      const b = new ProgramBuilder()
+      const seen: number[] = []
+      b.at([1, 2, 3], null, (_inner, i) => { seen.push(i as number) })
+      expect(seen).toEqual([0, 1, 2])  // 3 invocations, indices passed
+    })
+
+    it('B8 reproducer transpiles to __b.at(1, null, fn) and that no longer silently no-ops', () => {
+      const r = autoTranspileDetailed('at(1) { play 60 }\nsleep 2\n')
+      expect(r.hasError).toBe(false)
+      // The transpiler still emits the scalar form (open follow-up #383 if/when
+      // we wrap at the transpile layer too). The runtime defensiveness is what
+      // closes the silent-failure gap.
+      expect(r.code).toContain('__b.at(1, null,')
+    })
+  })
+
+  describe('#384 — capture.ts runtimePatterns covers friendly parse-error titles', () => {
+    it('the friendly title "Syntax error — your code could not be parsed" contains a matched pattern', () => {
+      // Mirror the runtimePatterns list from tools/capture.ts:513. This test
+      // doesn't run capture.ts — it asserts the pattern coverage contract
+      // (any future-renamed friendly title MUST add the new prefix to the
+      // pattern list, else the comparator silently mis-classifies).
+      const runtimePatterns = [
+        'not a function', 'not defined', 'Something went wrong',
+        'Error in loop', "isn't available",
+        'SyntaxError', 'TypeError', 'ReferenceError', 'Unexpected token',
+        'Parse error', 'Syntax error ', 'Code nested too deeply',
+      ]
+      const friendlyParseTitle = 'Syntax error — your code could not be parsed'
+      const friendlyParseMsg = 'Parse error at line 2: @'
+      const friendlyStackTitle = 'Code nested too deeply'  // from B6 stack-overflow path
+      expect(runtimePatterns.some(p => friendlyParseTitle.includes(p))).toBe(true)
+      expect(runtimePatterns.some(p => friendlyParseMsg.includes(p))).toBe(true)
+      expect(runtimePatterns.some(p => friendlyStackTitle.includes(p))).toBe(true)
+    })
+  })
+})

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -509,11 +509,26 @@ async function captureRun(
     errorSummary.push(`[network ${n.status} @ ${n.time}ms] ${n.url}`)
   }
 
-  // Check app console for runtime errors
+  // Check app console for runtime errors.
+  // The patterns scan `appConsoleText` (spw-console DOM textContent slice) for
+  // tokens that uniquely identify error blocks the engine renders via
+  // `friendlyError → console.logError`. New tokens MUST be added when a new
+  // friendly title shape lands — otherwise the comparator/cogate sweeps
+  // silently mis-classify the row as PASS-with-no-output (the SP98 / #384
+  // instrument-blindspot pattern). Includes both the user-facing friendly
+  // title ("Syntax error — your code could not be parsed", "Parse error at
+  // line N: ...") AND the raw token forms ("SyntaxError", "TypeError") in
+  // case any error path skips the friendly transform.
   const runtimePatterns = [
     'not a function', 'not defined', 'Something went wrong',
-    'Error in loop', "isn't available", 'SyntaxError', 'TypeError',
-    'ReferenceError', 'Unexpected token',
+    'Error in loop', "isn't available",
+    'SyntaxError', 'TypeError', 'ReferenceError', 'Unexpected token',
+    // #384 — friendly-error titles from FriendlyErrors.ts that the prior
+    // pattern list missed. Trailing space on 'Syntax error ' disambiguates
+    // from the no-space 'SyntaxError' token already above. Includes the
+    // stack-overflow title "Code nested too deeply" so #382-style recursion
+    // shows up as an error (previously the report said "None.").
+    'Parse error', 'Syntax error ', 'Code nested too deeply',
   ]
   for (const pattern of runtimePatterns) {
     if (appConsoleText.includes(pattern)) {


### PR DESCRIPTION
Closes #382, #383, #384. Realises **CO-GATE 2** of dharana §29 (launch hardening — "broken Ruby never silently hangs", interpreted at its spirit as "broken Ruby never silently fails — engine produces a visible signal whenever the user's input was rejected or wrong").

## Summary
Fact-find against 10 deliberate-break shapes (B1..B10) ran them through the capture pipeline, classified each on the §28 contract, and confirmed via direct `.spw-console` DOM read what the user actually sees. Found **three SILENT-FAIL classes** — distinct root causes, one shared user-experience symptom (silence with no diagnostic):

| Bug | Layer | Symptom | Root cause |
|---|---|---|---|
| **#382 B6** `def f; f; end; f` | transpiler | recursion never happens — no overflow, no error, no audio | `case 'method'` emitted `function f() { f }` (bare reference), and never added `f` to `definedFunctions` so the post-def call also stayed bare |
| **#383 B8** `at(1) { play 60 }` | runtime | callback never fires | `ProgramBuilder.at(times: number[], …)` iterated `times.length`; scalar `1` gave `undefined`, loop body skipped |
| **#384 B1** `play 60\n@#%` | instrument | engine surfaces "Syntax error — …" correctly, but capture.ts grep misses it | `runtimePatterns` had `'SyntaxError'` (no space) but not `'Parse error'` or `'Syntax error '` (em-dash). SP98-class blindspot |

## Fix
- **`TreeSitterTranspiler.ts:757`** — register `nameNode.text` in `ctx.definedFunctions` BEFORE transpiling the body. Recursive `def`s now emit `function f() { f(__b) }` and FriendlyErrors.ts's existing "Code nested too deeply" handler catches the RangeError.
- **`ProgramBuilder.ts:319`** — `Array.isArray(times) ? times : [times]`. Matches desktop SP's flexible `at 1 do… / at [1,2] do…` contract; runtime-level fix because the transpiler's scalar emission for `at(1)` is intuitive — accept both shapes at the receiving end.
- **`tools/capture.ts:513`** — add `'Parse error'`, `'Syntax error '`, `'Code nested too deeply'` to `runtimePatterns`. New unit test locks the pattern-coverage contract; any future friendly-title addition in FriendlyErrors.ts must add the prefix here.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **1041/1041** (+7 new in `src/engine/__tests__/Cogate2BrokenRuby.test.ts`)
- [x] Level-3 Lokayata: 10/10 break-shape re-capture post-fix

| # | shape | WAV peak | spw-console | verdict |
|---|---|---|---|---|
| B1 | `play 60\n@#%` | 0 | "Syntax error — …" | **PASS** ✅ |
| B2 | `puts "hello\nplay 60` | 2459 | (audio fires) | WRONG-AUDIO (out of scope) |
| B3 | `xylophone 60` | 0 | "xylophone is not a function" | PASS |
| B4 | `play "not a note"` | 4508 | (audio fires) | WRONG-AUDIO (out of scope) |
| B5 | `live_loop :spin do; end` | 0 | "Infinite loop detected" | PASS |
| B6 | `def f; f; end; f` | 0 | "Code nested too deeply" | **PASS** ✅ |
| B7 | `play 60 / 0` | 4513 | (audio fires) | WRONG-AUDIO (out of scope) |
| B8 | `at(1) { play 60 }` | **4529** | `/s_new note:60` at vt≈1 | **PASS** ✅ |
| B9 | `raise "boom"` | 0 | "raise is not a function" | PASS (POOR-MESSAGE) |
| B10 | (empty) | 0 | — | PASS |

**Spirit-gate verdict: 0 SILENT-HANG, 0 SILENT-FAIL, 3 WRONG-AUDIO** (B2/B4/B7 audible — out of scope per the next-session prompt's "fix only the silent class" rule; WRONG-AUDIO at least tells the user something is running).

- [x] Direct Playwright DOM probe confirms friendly blocks render correctly in `.spw-console` for B1 and B6.

## Carries forward
- CO-GATE 3 (cross-browser cold-load) still open per dharana §29.
- WRONG-AUDIO follow-ups (B2 unbalanced-string parse leniency, B4 string→note coercion, B7 Infinity guard) — file as P2 audio-correctness when prioritising.
- B9 POOR-MESSAGE ("raise is not a function") — friendly handler upgrade — backlog.

## Related
- dharana §29 (CO-GATE 2 of three) · §28-UPDATE (re-scoped launch gate)
- SV50 (build-time-detectable silent failures must emit a visible warning) — extends in spirit to runtime-detectable
- SV27 (capture pipeline must be lossless)
- SP98 (instrument-defect class — same pattern as the comparator blindspot fix in PR #370)

Claude never merges.