### PR TITLE
🐛 Tier-1 polish: close cogate-2 WRONG-AUDIO / POOR-MESSAGE tail (B7/B4/B2/B9)

### DIFF
--- a/src/engine/FriendlyErrors.ts
+++ b/src/engine/FriendlyErrors.ts
@@ -356,6 +356,22 @@ const ERROR_PATTERNS: Array<{
         `Note: Sharps use "s" (not #), flats use "b".`,
     }),
   },
+  // B9 (#390): `raise`/`fail` are real Ruby keywords we don't support in the
+  // browser sandbox. They transpile to a bare call, so the generic handler below
+  // would frame them as a typo ("raise is not a function"). Name them as
+  // unsupported keywords instead. Must precede the generic "is not a function".
+  {
+    test: (msg) => /\b(raise|fail) is not a function/i.test(msg),
+    transform: (msg) => {
+      const kw = /\bfail is not a function/i.test(msg) ? 'fail' : 'raise'
+      return {
+        title: `${kw} isn't supported yet`,
+        message: `"${kw}" is a Ruby keyword that isn't available in the browser sandbox yet.\n\n` +
+          `If you want to stop your code, use \`stop\` instead.\n` +
+          `To leave a note for yourself, use a comment (\`# like this\`).`,
+      }
+    },
+  },
   // Type errors (common JS mistakes)
   {
     test: (msg) => /is not a function/i.test(msg),

--- a/src/engine/NoteToFreq.ts
+++ b/src/engine/NoteToFreq.ts
@@ -13,20 +13,22 @@ const NOTE_NAMES: Record<string, number> = {
 }
 
 /**
- * Convert a note name like "c4", "fs3", "eb5" to a MIDI number.
- * Also accepts bare MIDI numbers as strings or numbers.
+ * Strict note resolution: returns NaN for an unparseable note name instead of
+ * falling back to middle C. Callers that must distinguish "the user typed
+ * garbage" from "the user typed middle C" (e.g. play's dispatch guard, B4 #388)
+ * use this; everything else uses `noteToMidi`, which keeps the lenient fallback.
  */
-export function noteToMidi(note: string | number): number {
+export function noteToMidiStrict(note: string | number): number {
   if (typeof note === 'number') return note
 
   const str = note.toLowerCase().trim()
 
-  // Try parsing as plain number
+  // Try parsing as plain number (e.g. "60", and "" → 0, matching prior behavior).
   const num = Number(str)
   if (!isNaN(num)) return num
 
   const match = str.match(/^([a-g])(s|b|#)?(\d+)?$/)
-  if (!match) return MIDDLE_C_MIDI
+  if (!match) return NaN
 
   const [, letter, accidental, octaveStr] = match
   const base = NOTE_NAMES[letter]
@@ -38,6 +40,18 @@ export function noteToMidi(note: string | number): number {
   if (accidental === 'b') midi -= 1
 
   return midi
+}
+
+/**
+ * Convert a note name like "c4", "fs3", "eb5" to a MIDI number.
+ * Also accepts bare MIDI numbers as strings or numbers.
+ * Falls back to middle C (60) when a note name can't be parsed — preserves the
+ * lenient behavior relied on by chord/scale/control helpers. Use
+ * `noteToMidiStrict` where an unparseable name must be detectable.
+ */
+export function noteToMidi(note: string | number): number {
+  const midi = noteToMidiStrict(note)
+  return Number.isNaN(midi) ? MIDDLE_C_MIDI : midi
 }
 
 /**

--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -7,7 +7,12 @@
  */
 
 export type Step =
-  | { tag: 'play'; note: number; opts: Record<string, number>; synth?: string; srcLine?: number }
+  | { tag: 'play'; note: number; opts: Record<string, number>; synth?: string; srcLine?: number;
+      /** B4 (#388): the original unparseable note-name string, set only when
+       *  `note` is NaN because a string like "not a note" failed to resolve.
+       *  Lets the dispatch-time guard name the bad input instead of silently
+       *  sounding the middle-C fallback. */
+      noteName?: string }
   | { tag: 'sample'; name: string; opts: Record<string, number>; srcLine?: number }
   | { tag: 'sleep'; beats: number }
   | { tag: 'useSynth'; name: string }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -10,7 +10,7 @@
 
 import type { Step, Program } from './Program'
 import { SeededRandom } from './SeededRandom'
-import { noteToMidi, midiToFreq, hzToMidi, noteInfo } from './NoteToFreq'
+import { noteToMidi, noteToMidiStrict, midiToFreq, hzToMidi, noteInfo } from './NoteToFreq'
 import { ring, knit, range, line, Ring, Ramp } from './Ring'
 import { spread } from './EuclideanRhythm'
 import { chord, scale, chord_invert, note, note_range, chord_degree, degree, chord_names, scale_names } from './ChordScale'
@@ -81,7 +81,19 @@ export class ProgramBuilder {
   private _pushPlayStep(noteVal: number | string | null | undefined, opts?: Record<string, unknown>): void {
     // :rest / nil — Desktop SP skips the synth trigger entirely
     if (noteVal === null || noteVal === undefined || noteVal === 'rest') return
-    const midi = (typeof noteVal === 'string' ? noteToMidi(noteVal) : noteVal) + this._transpose
+    // B4 (#388): resolve string note names strictly. An unparseable name (e.g.
+    // "not a note") yields NaN here instead of silently coercing to middle C;
+    // the NaN note is carried with its original string so the dispatch-time
+    // guard can skip it and name the bad input. Numeric notes pass through.
+    let midi: number
+    let noteName: string | undefined
+    if (typeof noteVal === 'string') {
+      const resolved = noteToMidiStrict(noteVal)
+      if (Number.isNaN(resolved)) noteName = noteVal
+      midi = resolved + this._transpose
+    } else {
+      midi = noteVal + this._transpose
+    }
     const synth = opts?.synth as string | undefined
     const srcLine = opts?._srcLine as number | undefined
     // Strip non-numeric keys before storing; remaining values are synthesis params (all numbers).
@@ -97,6 +109,7 @@ export class ProgramBuilder {
       opts: cleanOpts,
       synth: synth ?? this.currentSynth,
       srcLine,
+      ...(noteName !== undefined ? { noteName } : {}),
     })
   }
 

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -141,6 +141,20 @@ export interface TreeSitterTranspileResult {
  * If tree-sitter is not ready, returns `{ ok: false }` so the caller
  * can fall back to the regex transpiler.
  */
+/**
+ * Depth-first search for the first ERROR or MISSING node in the tree — used to
+ * locate the line of a parse failure that tree-sitter recovered from. Returns
+ * null if none is found (caller only calls this when rootNode.hasError).
+ */
+function findFirstErrorNode(node: any): any | null {
+  if (node.type === 'ERROR' || node.isMissing) return node
+  for (let i = 0; i < node.childCount; i++) {
+    const found = findFirstErrorNode(node.child(i))
+    if (found) return found
+  }
+  return null
+}
+
 export function treeSitterTranspile(ruby: string): TreeSitterTranspileResult {
   if (!isTreeSitterReady()) {
     return { code: '', ok: false, errors: ['tree-sitter not initialized'] }
@@ -169,6 +183,24 @@ export function treeSitterTranspile(ruby: string): TreeSitterTranspileResult {
   }
 
   const js = transpileNode(tree.rootNode, ctx)
+
+  // B2 (#389) — SV19 refuse-or-accept safety net. tree-sitter recovers from
+  // malformed input (e.g. an unterminated string `puts "hello`) by inserting
+  // ERROR/MISSING nodes, but those can sit as children of a node whose handler
+  // only visits specific named fields (e.g. `call` reads identifier +
+  // argument_list, skipping the orphaned-quote ERROR). The walker never visits
+  // them, so no parse error is pushed and the malformed program silently
+  // degrades while the next line's audio fires. `rootNode.hasError` is true iff
+  // any ERROR/MISSING node exists anywhere in the tree — catch it here so the
+  // run is refused with a syntax error rather than partially executed. Valid
+  // heredocs and multi-line strings parse cleanly (hasError=false), so this
+  // does not over-refuse.
+  if (errors.length === 0 && tree.rootNode.hasError) {
+    const bad = findFirstErrorNode(tree.rootNode)
+    const line = (bad ?? tree.rootNode).startPosition.row + 1
+    const snippet = (bad?.text ?? '').replace(/\s+/g, ' ').trim().slice(0, 50)
+    errors.push(`Syntax error at line ${line}: your code could not be parsed${snippet ? ` (near \`${snippet}\`)` : ''}`)
+  }
 
   // Validate output
   if (errors.length > 0) {

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -182,4 +182,58 @@ describe('Tier-1 polish — WRONG-AUDIO / POOR-MESSAGE tail (PATH B)', () => {
       expect(warnings.some(w => /note resolved to NaN/i.test(w))).toBe(true)
     })
   })
+
+  describe('#388 (B4) — unparseable note name is skipped + named, not silently coerced to 60', () => {
+    it('build-time: play("not a note") yields a NaN note carrying the original string', () => {
+      const program = new ProgramBuilder(0).play('not a note').play(72).build()
+      const plays = program.filter((s): s is typeof s & { note: number; noteName?: string } => s.tag === 'play')
+      expect(Number.isNaN(plays[0].note)).toBe(true)
+      expect(plays[0].noteName).toBe('not a note')
+      // The valid note after it is unaffected and carries no noteName marker.
+      expect(plays[1].note).toBe(72)
+      expect(plays[1].noteName).toBeUndefined()
+    })
+
+    it('dispatch: the bad name is NOT triggered; a warning names it; the valid note still plays', async () => {
+      const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+      const eventStream = new SoundEventStream()
+      const bridge = createNoteRecordingBridge()
+      const warnings: string[] = []
+      const program = new ProgramBuilder(0).play('not a note').play(72).sleep(999999).build()
+
+      const ctx: AudioCtx = {
+        bridge, scheduler, taskId: 'test', eventStream, schedAheadTime: 100,
+        nodeRefMap: new Map(), reusableFx: new Map(),
+        printHandler: (m) => warnings.push(m),
+      }
+      scheduler.registerLoop('test', async () => { await runProgram(program, ctx) })
+      scheduler.tick(100)
+      await flushMicrotasks()
+
+      expect(bridge.triggeredNotes).toEqual([72])  // no phantom note:60
+      expect(warnings.some(w => /"not a note" isn't a valid note name/i.test(w))).toBe(true)
+    })
+
+    it('NEGATIVE CONTROL: valid note names (numbers, "c4", "eb3", "fs5") still resolve and play', async () => {
+      const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+      const eventStream = new SoundEventStream()
+      const bridge = createNoteRecordingBridge()
+      const warnings: string[] = []
+      const program = new ProgramBuilder(0)
+        .play(60).play('c4').play('eb3').play('fs5').sleep(999999).build()
+
+      const ctx: AudioCtx = {
+        bridge, scheduler, taskId: 'test', eventStream, schedAheadTime: 100,
+        nodeRefMap: new Map(), reusableFx: new Map(),
+        printHandler: (m) => warnings.push(m),
+      }
+      scheduler.registerLoop('test', async () => { await runProgram(program, ctx) })
+      scheduler.tick(100)
+      await flushMicrotasks()
+
+      // c4=60, eb3=51 (E♭3), fs5=78 (F♯5) — all valid, none refused.
+      expect(bridge.triggeredNotes).toEqual([60, 60, 51, 78])
+      expect(warnings.length).toBe(0)
+    })
+  })
 })

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -236,4 +236,37 @@ describe('Tier-1 polish — WRONG-AUDIO / POOR-MESSAGE tail (PATH B)', () => {
       expect(warnings.length).toBe(0)
     })
   })
+
+  describe('#389 (B2) — unterminated string is refused (SV19), not silently degraded', () => {
+    it('puts "hello (unterminated) → hasError, not a silent puts(hello) + play 60', () => {
+      const r = autoTranspileDetailed('puts "hello\nplay 60\n')
+      // Before fix: hasError:false, emitted __b.puts(hello) + __b.play(60).
+      // tree-sitter recovers with an ERROR node nested in the `call`, which the
+      // walker never visits — rootNode.hasError catches it.
+      expect(r.hasError).toBe(true)
+      expect(r.errorMessage ?? '').toMatch(/syntax error/i)
+    })
+
+    it('NEGATIVE CONTROL: a properly-terminated string is NOT refused (same construct, no over-refusal)', () => {
+      // The discriminator vs B2: this string is closed. Refusal must key on the
+      // ERROR/MISSING node, not on the presence of a string literal.
+      const r = autoTranspileDetailed('puts "hello world"\nplay 60\n')
+      expect(r.hasError).toBe(false)
+    })
+
+    it('NEGATIVE CONTROL: a block + symbol program parses cleanly', () => {
+      const r = autoTranspileDetailed('with_fx :reverb do\n  play 60\n  sleep 1\nend\n')
+      expect(r.hasError).toBe(false)
+    })
+
+    it('NEGATIVE CONTROL: a times-block with kwargs parses cleanly', () => {
+      const r = autoTranspileDetailed('use_synth :tb303\n8.times do\n  play 60, cutoff: 100\n  sleep 0.25\nend\n')
+      expect(r.hasError).toBe(false)
+    })
+
+    it('NEGATIVE CONTROL: ordinary valid program is unaffected', () => {
+      const r = autoTranspileDetailed('play 60\nsleep 1\nplay 72\n')
+      expect(r.hasError).toBe(false)
+    })
+  })
 })

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -1,6 +1,35 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { initTreeSitter, autoTranspileDetailed } from '../TreeSitterTranspiler'
 import { ProgramBuilder } from '../ProgramBuilder'
+import { VirtualTimeScheduler } from '../VirtualTimeScheduler'
+import { runProgram, type AudioContext as AudioCtx } from '../interpreters/AudioInterpreter'
+import { SoundEventStream } from '../SoundEventStream'
+import type { SuperSonicBridge } from '../SuperSonicBridge'
+
+async function flushMicrotasks(rounds = 10) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+/** Mock bridge that records the `note` of every triggerSynth call. */
+function createNoteRecordingBridge(): SuperSonicBridge & { triggeredNotes: number[] } {
+  let nextNode = 5000
+  const triggeredNotes: number[] = []
+  return {
+    triggeredNotes,
+    async triggerSynth(_name: string, _time: number, params: Record<string, number>) {
+      triggeredNotes.push(params.note)
+      return nextNode++
+    },
+    async playSample() { return nextNode++ },
+    allocateBus() { return 16 },
+    freeBus() {},
+    freeNode() {},
+    flushMessages() {},
+    get audioContext() { return null as unknown as AudioContext },
+    send() {},
+    isLiveAudioStreaming() { return false },
+  } as unknown as SuperSonicBridge & { triggeredNotes: number[] }
+}
 
 beforeAll(async () => {
   await initTreeSitter({
@@ -96,6 +125,61 @@ describe('cogate-2 SILENT-FAIL fixes (#382 #383 #384)', () => {
       expect(runtimePatterns.some(p => friendlyParseTitle.includes(p))).toBe(true)
       expect(runtimePatterns.some(p => friendlyParseMsg.includes(p))).toBe(true)
       expect(runtimePatterns.some(p => friendlyStackTitle.includes(p))).toBe(true)
+    })
+  })
+})
+
+describe('Tier-1 polish — WRONG-AUDIO / POOR-MESSAGE tail (PATH B)', () => {
+  describe('#387 (B7) — non-finite note (play 60 / 0 → Infinity) is skipped, not sent to scsynth', () => {
+    it('build-time: play(60 / 0) produces a non-finite play step', () => {
+      // `60 / 0` is Infinity in JS (not a throw). The note is finalized at
+      // build time in _pushPlayStep, so the step carries a non-finite note.
+      const program = new ProgramBuilder(0).play(60 / 0).play(72).build()
+      const plays = program.filter((s): s is typeof s & { note: number } => s.tag === 'play')
+      expect(Number.isFinite(plays[0].note)).toBe(false)
+      expect(plays[1].note).toBe(72)
+    })
+
+    it('dispatch: Infinity note is NOT triggered; a warning fires; the valid note still plays', async () => {
+      const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+      const eventStream = new SoundEventStream()
+      const bridge = createNoteRecordingBridge()
+      const warnings: string[] = []
+      const program = new ProgramBuilder(0).play(60 / 0).play(72).sleep(999999).build()
+
+      const ctx: AudioCtx = {
+        bridge, scheduler, taskId: 'test', eventStream, schedAheadTime: 100,
+        nodeRefMap: new Map(), reusableFx: new Map(),
+        printHandler: (m) => warnings.push(m),
+      }
+      scheduler.registerLoop('test', async () => { await runProgram(program, ctx) })
+      scheduler.tick(100)
+      await flushMicrotasks()
+
+      // The non-finite note must NOT reach the synth; only the valid 72 does.
+      expect(bridge.triggeredNotes).toEqual([72])
+      // A visible diagnostic must be surfaced naming the non-finite resolution.
+      expect(warnings.some(w => /note resolved to Infinity/i.test(w))).toBe(true)
+    })
+
+    it('NaN note (0 / 0) is also skipped', async () => {
+      const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+      const eventStream = new SoundEventStream()
+      const bridge = createNoteRecordingBridge()
+      const warnings: string[] = []
+      const program = new ProgramBuilder(0).play(0 / 0).play(48).sleep(999999).build()
+
+      const ctx: AudioCtx = {
+        bridge, scheduler, taskId: 'test', eventStream, schedAheadTime: 100,
+        nodeRefMap: new Map(), reusableFx: new Map(),
+        printHandler: (m) => warnings.push(m),
+      }
+      scheduler.registerLoop('test', async () => { await runProgram(program, ctx) })
+      scheduler.tick(100)
+      await flushMicrotasks()
+
+      expect(bridge.triggeredNotes).toEqual([48])
+      expect(warnings.some(w => /note resolved to NaN/i.test(w))).toBe(true)
     })
   })
 })

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -5,6 +5,7 @@ import { VirtualTimeScheduler } from '../VirtualTimeScheduler'
 import { runProgram, type AudioContext as AudioCtx } from '../interpreters/AudioInterpreter'
 import { SoundEventStream } from '../SoundEventStream'
 import type { SuperSonicBridge } from '../SuperSonicBridge'
+import { friendlyError } from '../FriendlyErrors'
 
 async function flushMicrotasks(rounds = 10) {
   for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
@@ -267,6 +268,28 @@ describe('Tier-1 polish — WRONG-AUDIO / POOR-MESSAGE tail (PATH B)', () => {
     it('NEGATIVE CONTROL: ordinary valid program is unaffected', () => {
       const r = autoTranspileDetailed('play 60\nsleep 1\nplay 72\n')
       expect(r.hasError).toBe(false)
+    })
+  })
+
+  describe('#390 (B9) — raise is named as an unsupported keyword, not framed as a typo', () => {
+    it('"raise is not a function" → titled as an unsupported keyword, not "raise is not a function"', () => {
+      const fe = friendlyError(new Error('raise is not a function'))
+      expect(fe.title).toMatch(/raise isn't supported/i)
+      expect(fe.message).toMatch(/ruby keyword/i)
+      // Must NOT fall through to the generic typo framing.
+      expect(fe.title).not.toMatch(/raise is not a function/i)
+      expect(fe.message).not.toMatch(/typo/i)
+    })
+
+    it('"fail is not a function" gets the same keyword treatment', () => {
+      const fe = friendlyError(new Error('fail is not a function'))
+      expect(fe.title).toMatch(/fail isn't supported/i)
+    })
+
+    it('NEGATIVE CONTROL: a genuine unknown function still uses the typo-aware generic handler', () => {
+      const fe = friendlyError(new Error('wibble is not a function'))
+      expect(fe.title).toMatch(/wibble is not a function/i)
+      expect(fe.message).toMatch(/typo/i)
     })
   })
 })

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -106,6 +106,20 @@ export async function runProgram(
         // Sonic Pi's should_trigger?: skip if on: is present and falsy
         if ('on' in step.opts && !step.opts.on) break
 
+        // B7 (#387): validate-at-boundary. JS `60 / 0` evaluates to Infinity
+        // (not a throw), and `0 / 0` to NaN — both flow straight to scsynth as
+        // `note: Infinity`/`note: NaN`, producing audible garbage with no
+        // diagnostic. Skip the trigger and surface a visible warning so a
+        // first-time user knows their arithmetic resolved to a non-pitch.
+        // The valid notes around it are independent steps and still fire.
+        if (!Number.isFinite(step.note)) {
+          ctx.printHandler?.(
+            `[Warning] play skipped — note resolved to ${step.note}. ` +
+            `Check for division by zero or invalid arithmetic (e.g. \`play 60 / 0\`).`
+          )
+          break
+        }
+
         const audioTime = task.virtualTime + ctx.schedAheadTime
         const synth = resolveSynthName(step.synth ?? currentSynth)
         const nodeRef = nextNodeRef++

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -106,17 +106,20 @@ export async function runProgram(
         // Sonic Pi's should_trigger?: skip if on: is present and falsy
         if ('on' in step.opts && !step.opts.on) break
 
-        // B7 (#387): validate-at-boundary. JS `60 / 0` evaluates to Infinity
-        // (not a throw), and `0 / 0` to NaN — both flow straight to scsynth as
-        // `note: Infinity`/`note: NaN`, producing audible garbage with no
-        // diagnostic. Skip the trigger and surface a visible warning so a
-        // first-time user knows their arithmetic resolved to a non-pitch.
-        // The valid notes around it are independent steps and still fire.
+        // B7 (#387) / B4 (#388): validate-at-boundary. A non-finite note never
+        // reaches scsynth — it would produce audible garbage with no diagnostic.
+        // Two sources converge here:
+        //   - B4: an unparseable note-name string ("not a note") resolves to NaN
+        //     and carries the original string in step.noteName, so we can name it
+        //     rather than silently sounding middle C.
+        //   - B7: arithmetic like `60 / 0` (Infinity) or `0 / 0` (NaN).
+        // Skip the trigger, surface a visible warning. Valid notes around it are
+        // independent steps and still fire.
         if (!Number.isFinite(step.note)) {
-          ctx.printHandler?.(
-            `[Warning] play skipped — note resolved to ${step.note}. ` +
-            `Check for division by zero or invalid arithmetic (e.g. \`play 60 / 0\`).`
-          )
+          const reason = step.noteName !== undefined
+            ? `"${step.noteName}" isn't a valid note name (use e.g. 60, :c4, :eb3)`
+            : `note resolved to ${step.note}. Check for division by zero or invalid arithmetic (e.g. \`play 60 / 0\`).`
+          ctx.printHandler?.(`[Warning] play skipped — ${reason}`)
           break
         }
 


### PR DESCRIPTION
## Summary
PATH B (dharana §31): the three launch-hardening co-gates were already closed (§30), but the cogate-2 fact-find left four rows where odd/broken input produces confusing-audio-without-diagnostic. This closes all four — first-impression hardening so a curious first-time user always gets a clear signal about their odd input. Diagnosis-first, smallest-first, one atomic commit + Level-3 Lokayata re-capture per row. No features.

| Row | Before | After |
|-----|--------|-------|
| **B7** `play 60 / 0` | `note: Infinity` → audible garbage, silent | skipped + `[Warning] note resolved to Infinity` |
| **B4** `play "not a note"` | silently sounds note 60 | skipped + `"not a note" isn't a valid note name` |
| **B2** `puts "hello` (unterminated) | transpiles clean, next line `play 60` fires | refused: `Syntax error at line 1` (SV19) |
| **B9** `raise "boom"` | `raise is not a function` (typo framing) | `raise isn't supported yet` (Ruby keyword) |

## How
- **B7** (`5535003`) — `Number.isFinite(step.note)` guard at the AudioInterpreter dispatch boundary. JS `60/0`=Infinity / `0/0`=NaN don't throw; they were forwarded to scsynth as `note:`. Skip + visible warning; valid notes around it still fire.
- **B4** (`d7464bb`) — `noteToMidiStrict` returns NaN for an unparseable name (vs the lenient `noteToMidi` 60-fallback, kept for chord/scale/control); the play step carries the original string so the B7 guard names it.
- **B2** (`f999df9`) — post-parse `tree.rootNode.hasError` refuse safety-net in `treeSitterTranspile`. tree-sitter recovered with an ERROR node nested in `call`, which the walker never visits; `rootNode.hasError` is the only complete refuse gate (SV19).
- **B9** (`486eb11`) — FriendlyErrors special-case for `raise`/`fail` before the generic "is not a function" handler; names them as unsupported Ruby keywords, not typos. Does not implement `raise`.

## Test plan
- `npx tsc --noEmit` — clean.
- `npx vitest run` — **1055/1055** (+15 new tests in the `Cogate2BrokenRuby` family, incl. a negative control per row: NaN path, valid note names c4/eb3/fs5, terminated-string/block/times-block not refused, genuine-unknown-fn still typo-framed).
- **Level-3 Lokayata** (`tools/capture.ts`) per row — confirmed App Console / `## Errors` shows the intended signal, the valid note after each break still fires, and B2/B7 produce no phantom note.
- Over-refusal guard for B2: all 27 RubyExamples still parse `hasError:false`.

## Catalogues
hetvabhasa **SP102** (non-finite numeric → scsynth unchecked), **SP103** (tree-sitter ERROR nested in a handled node escapes the walker; `rootNode.hasError` is the only complete gate); vyapti **SV51** (numeric synth args must be finite before dispatch); dharana §31 closed + §32 (ship decision re-presented).

Closes #387, closes #388, closes #389, closes #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)