### PR TITLE
✨ SP95(d): build-time sync + time-indexed Time State — cross-loop set/get/cue/sync match desktop (#350, #351)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -50,6 +50,15 @@ export class ProgramBuilder {
   private _currentBuildSeconds: number = 0
   private _currentBeat: number = 0
   private _schedAheadTime: number = 0
+  // SP95(d) #393: scheduler access for build-time sync resolution. When set
+  // (the audio build path wires it before builderFn), `sync` awaits the
+  // scheduler-resolved cue payload mid-build instead of pushing a runtime
+  // step — so the value binds to `e` and post-sync reads (get / e[:val]) run
+  // AFTER the cue fires. Null on manual / capture builders, which keep the
+  // legacy runtime-step path (the QueryInterpreter never wires it, so an
+  // S3 sync loop can't register a phantom waiter through the capture pass).
+  private _syncScheduler: { waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }> } | null = null
+  private _syncTaskId: string | null = null
 
   constructor(seed: number = 0, initialTicks?: Map<string, number>) {
     this.rng = new SeededRandom(seed)
@@ -235,6 +244,21 @@ export class ProgramBuilder {
     if (bpm !== undefined) this._currentBpm = bpm
   }
 
+  /**
+   * SP95(d) #393: give this builder scheduler access so `sync` can await a
+   * cue payload during build (audio path only). The scheduler is the SOLE
+   * resolver — same invariant as scheduleSleep (SV2). Cleared implicitly by
+   * builder recreation each iteration; manual / capture builders never call
+   * this, so their `sync` keeps the legacy runtime-step behavior.
+   */
+  setSyncContext(
+    scheduler: { waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }> },
+    taskId: string,
+  ): void {
+    this._syncScheduler = scheduler
+    this._syncTaskId = taskId
+  }
+
   /** Read the build-phase beat counter (engine persists this across iterations). */
   get currentBeatRaw(): number { return this._currentBeat }
 
@@ -269,8 +293,25 @@ export class ProgramBuilder {
     return this
   }
 
-  sync(name: string, opts?: { bpm_sync?: boolean }): this {
+  sync(name: string, opts?: { bpm_sync?: boolean }): this | Promise<unknown> {
     const bpmSync = opts?.bpm_sync === true
+    // SP95(d) #393: build-time await path. The scheduler resolves the cue
+    // payload through the SAME channel as sleep (a Promise only tick() can
+    // resolve), so the build "blocks" in virtual time exactly like desktop's
+    // `prom.get` (event_history.rb:221, krama SK15). The resolved payload
+    // becomes sync's return value, so `e = sync :beat; e[:val]` binds the
+    // real value and `play get(:root)` after a bare sync reads fresh state.
+    //
+    // Gated to plain `sync` only: `sync_bpm` still needs the runtime step to
+    // mutate task.bpm mid-iteration (#236) — and only when a scheduler is
+    // wired (audio path). Manual / capture builders fall through to the
+    // legacy runtime step, returning `this` for chaining.
+    if (!bpmSync && this._syncScheduler && this._syncTaskId !== null) {
+      const taskId = this._syncTaskId
+      return this._syncScheduler.waitForSync(name, taskId).then(
+        (payload) => syncArgsToMap(payload.args),
+      )
+    }
     this.steps.push(bpmSync ? { tag: 'sync', name, bpmSync: true } : { tag: 'sync', name })
     return this
   }
@@ -281,7 +322,11 @@ export class ProgramBuilder {
    * Matches desktop `core.rb:4490-4494`.
    */
   sync_bpm(name: string): this {
-    return this.sync(name, { bpm_sync: true })
+    // sync_bpm keeps the runtime-step path (it must mutate task.bpm mid-
+    // iteration, #236), so it never takes sync's build-time await branch and
+    // always returns `this`. Push the step directly to keep the return type.
+    this.steps.push({ tag: 'sync', name, bpmSync: true })
+    return this
   }
 
   control(nodeRef: number, params: Record<string, number>): this {
@@ -1181,4 +1226,19 @@ export class ProgramBuilder {
   build(): Program {
     return [...this.steps]
   }
+}
+
+/**
+ * SP95(d) #393: shape the cue args into `sync`'s Ruby-equivalent return value.
+ * Desktop `cue :beat, val: X` → `e = sync :beat` makes `e` the kwargs map, so
+ * `e[:val]` (transpiled `e["val"]`) reads X. Mirrors Sonic Pi's splat of cue
+ * args back to the synced thread:
+ *   - no args        → {}            (bare `cue :name`; bare `sync` ignores it)
+ *   - one arg        → that arg      (kwargs hash → indexable; scalar → as-is)
+ *   - many args      → the array     (positional `cue :n, 1, 2`)
+ */
+function syncArgsToMap(args: unknown[]): unknown {
+  if (args.length === 0) return {}
+  if (args.length === 1) return args[0]
+  return args
 }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -59,6 +59,13 @@ export class ProgramBuilder {
   // S3 sync loop can't register a phantom waiter through the capture pass).
   private _syncScheduler: { waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }> } | null = null
   private _syncTaskId: string | null = null
+  // SP95(d) #350 slice 2: the virtual-time-indexed Time State the engine wires
+  // during build (setTimeStateContext). `b.set` writes EAGERLY here at
+  // current_time() so the write lands before the loop's first await — giving a
+  // cross-loop post-sync `get` a write-before-read happens-before by causation,
+  // not by scheduler wake order. Null on builders that were never wired (the
+  // deferred {tag:'set'} step still records the write at interpret time).
+  private _timeState: { set(key: string | symbol, value: unknown, t: number): void; get(key: string | symbol, t: number): unknown } | null = null
 
   constructor(seed: number = 0, initialTicks?: Map<string, number>) {
     this.rng = new SeededRandom(seed)
@@ -257,6 +264,18 @@ export class ProgramBuilder {
   ): void {
     this._syncScheduler = scheduler
     this._syncTaskId = taskId
+  }
+
+  /**
+   * SP95(d) #350 slice 2: wire the virtual-time-indexed Time State so `b.set`
+   * can apply eagerly at build current_time() and `b.get` can read at the
+   * reader's current_time(). Set alongside setIterationContext/setSyncContext
+   * during the engine's build setup; null on builders that never wire it.
+   */
+  setTimeStateContext(
+    timeState: { set(key: string | symbol, value: unknown, t: number): void; get(key: string | symbol, t: number): unknown },
+  ): void {
+    this._timeState = timeState
   }
 
   /** Read the build-phase beat counter (engine persists this across iterations). */
@@ -776,8 +795,24 @@ export class ProgramBuilder {
   current_arg_checks(): boolean { return this._argChecks }
   current_timing_guarantees(): boolean { return this._timingGuarantees }
 
-  /** Deferred set — fires at runtime (interleaved with sleeps). */
+  /**
+   * `set` does BOTH (SP95(d) #350 slice 2, Decision Q3):
+   *   1. EAGERLY writes to the Time State at current_time() — synchronously,
+   *      during build, before the loop's first await. This is the ORDERING fix:
+   *      a cross-loop post-sync `get` (a microtask queued by the cuer's cue) can
+   *      only run once the writer yields, so the eager write happens-before it
+   *      by causation — independent of scheduler wake order.
+   *   2. STILL pushes the deferred {tag:'set'} step (SV20/SP41 contract — set
+   *      stays a builder method with a step, DslBuilderContract green) for the
+   *      QueryInterpreter / capture / event-stream paths.
+   * The timestamp is current_time() AT the call, which has already advanced by
+   * any preceding intra-iteration b.sleep — so `set :x,1; sleep 2; set :x,2`
+   * records x=1@T and x=2@(T+2) (SV20 preserved). The interpreter's deferred
+   * `case 'set'` is a no-op on the Time State path so this stays the single
+   * write per (key, build-vt) — no phantom shadow entry at a different vt.
+   */
   set(key: string | symbol, value: unknown): this {
+    this._timeState?.set(key, value, this.current_time())
     this.steps.push({ tag: 'set', key, value })
     return this
   }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -817,6 +817,41 @@ export class ProgramBuilder {
     return this
   }
 
+  /**
+   * `get` reads the Time State at the READER's virtual time (SP95(d) #350
+   * slice 2). Routing through the builder (rather than the shared
+   * SonicPiEngine `get` closure) makes the reader vt come from the body's OWN
+   * builder — SV28-safe across interleaved/awaited builds, the same reason
+   * Slice 1 routed `sync` through `b.sync`.
+   *
+   * Returns a Proxy callable so BOTH Sonic Pi forms resolve to the same
+   * vt-aware lookup:
+   *   - `get(:k)`  → transpiles to `__b.get("k")` → the Proxy's apply trap
+   *   - `get[:k]`  → transpiles to `__b.get["k"]` → the Proxy's get trap
+   * Reads `current_time()` AT the call site (post-sync, post-sleep), never a
+   * cached value. Falls back to the no-vt facade (latest value) if no Time
+   * State is wired. `?? null` matches the prior sandbox-get behavior.
+   */
+  get get(): ((key: string | symbol) => unknown) & Record<string | symbol, unknown> {
+    const read = (key: string | symbol): unknown => {
+      if (!this._timeState) return null
+      return this._timeState.get(key, this.current_time()) ?? null
+    }
+    return new Proxy(read, {
+      apply(_target, _thisArg, args) {
+        return read(args[0] as string | symbol)
+      },
+      get(target, property, receiver) {
+        // Real function internals (name, length, call, apply, Symbol.*) fall
+        // through to the function so the value stays a normal callable.
+        if (typeof property === 'symbol' || property in target) {
+          return Reflect.get(target, property, receiver)
+        }
+        return read(property)
+      },
+    }) as ((key: string | symbol) => unknown) & Record<string | symbol, unknown>
+  }
+
   puts(...args: unknown[]): this {
     const msg = args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')
     this.steps.push({ tag: 'print', message: msg })

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -57,7 +57,10 @@ export class ProgramBuilder {
   // AFTER the cue fires. Null on manual / capture builders, which keep the
   // legacy runtime-step path (the QueryInterpreter never wires it, so an
   // S3 sync loop can't register a phantom waiter through the capture pass).
-  private _syncScheduler: { waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }> } | null = null
+  private _syncScheduler: {
+    waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }>
+    getTask?(taskId: string): { virtualTime: number } | undefined
+  } | null = null
   private _syncTaskId: string | null = null
   // SP95(d) #350 slice 2: the virtual-time-indexed Time State the engine wires
   // during build (setTimeStateContext). `b.set` writes EAGERLY here at
@@ -259,7 +262,10 @@ export class ProgramBuilder {
    * this, so their `sync` keeps the legacy runtime-step behavior.
    */
   setSyncContext(
-    scheduler: { waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }> },
+    scheduler: {
+      waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }>
+      getTask?(taskId: string): { virtualTime: number } | undefined
+    },
     taskId: string,
   ): void {
     this._syncScheduler = scheduler
@@ -327,8 +333,29 @@ export class ProgramBuilder {
     // legacy runtime step, returning `this` for chaining.
     if (!bpmSync && this._syncScheduler && this._syncTaskId !== null) {
       const taskId = this._syncTaskId
-      return this._syncScheduler.waitForSync(name, taskId).then(
-        (payload) => syncArgsToMap(payload.args),
+      const scheduler = this._syncScheduler
+      // Capture pre-sync task vt so we can compute the delta the cue's wake
+      // injected (waiterTask.virtualTime = cueVirtualTime, fireCue path). The
+      // builder's current_time() = _iterationStartAudioTime + _currentBuildSeconds,
+      // none of which advance on await; we add the delta into _currentBuildSeconds
+      // so a post-sync b.get / b.set / current_time reads the cuer's vt, not the
+      // syncer's frozen iteration-start. The plan's pre-mortem (a): "Confirm
+      // current_time() advances across await b.sync ... before wiring" — this
+      // closes that gap. (#350 / SV47 slice 2.)
+      const taskBefore = scheduler.getTask?.(taskId)?.virtualTime
+      return scheduler.waitForSync(name, taskId).then(
+        (payload) => {
+          const taskAfter = scheduler.getTask?.(taskId)?.virtualTime
+          if (typeof taskBefore === 'number' && typeof taskAfter === 'number') {
+            const delta = taskAfter - taskBefore
+            // Defensive: a cue should advance the syncer's vt monotonically.
+            // A negative delta would mean a cuer fired at a past vt — Slice 1's
+            // strictly-after gate (VirtualTimeScheduler.ts:425) forbids that,
+            // but guard anyway so we never rewind current_time().
+            if (delta > 0) this._currentBuildSeconds += delta
+          }
+          return syncArgsToMap(payload.args)
+        },
       )
     }
     this.steps.push(bpmSync ? { tag: 'sync', name, bpmSync: true } : { tag: 'sync', name })

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1,5 +1,6 @@
 import { VirtualTimeScheduler, DEFAULT_SCHED_AHEAD_TIME } from './VirtualTimeScheduler'
 import { ProgramBuilder } from './ProgramBuilder'
+import { TimeState } from './TimeState'
 import { runProgram, type AudioContext as AudioCtx } from './interpreters/AudioInterpreter'
 import { queryLoopProgram, type QueryEvent } from './interpreters/QueryInterpreter'
 import { SuperSonicBridge, type SuperSonicBridgeOptions } from './SuperSonicBridge'
@@ -180,8 +181,12 @@ export class SonicPiEngine {
    * scheduler-aware and time-stamped correctly.
    */
   readonly midiBridge = new MidiBridge()
-  /** Global key-value store — shared across all loops via get/set */
-  private globalStore = new Map<string | symbol, unknown>()
+  /** Global key-value store — shared across all loops via get/set.
+   *  SP95(d) #350 slice 2: virtual-time-indexed TimeState (was a plain Map).
+   *  Writes carry the writer's current_time(); reads resolve "last set ≤ reader
+   *  vt". A back-compat facade (.get(key)/.size/.clear) keeps Map-shaped tests
+   *  green. Cleared only on dispose (SK14). */
+  private globalStore = new TimeState()
   /** User-defined functions — `define`/`ndefine` register here. Seeded back into the
    *  next eval's scopeBase so removing a `define` line from the buffer does not
    *  break a still-running live_loop that calls it. (#215) */
@@ -818,6 +823,9 @@ export class SonicPiEngine {
           // QueryInterpreter/capture build (S2-gated) never does, so an S3
           // sync loop cannot register a phantom waiter through capture.
           builder.setSyncContext(scheduler, name)
+          // SP95(d) #350 slice 2: wire the Time State so `b.set` writes eagerly
+          // at current_time() and `b.get` reads at the reader's current_time().
+          builder.setTimeStateContext(this.globalStore)
           try {
             // SP95(d) #393: await so an S3 body can suspend on a scheduler-resolved
             // sync mid-build. For today's synchronous S1/S2 bodies this `await` is
@@ -1054,8 +1062,19 @@ export class SonicPiEngine {
       // so `get["key"]` would return undefined. The Proxy routes property access
       // through the store while leaving `get(...)` calls and standard function
       // internals (name, length, call, apply, Symbol.toPrimitive, ...) alone.
+      // SP95(d) #350 slice 2: bare top-level `set` runs through the :__run_once
+      // builder (it gets setIterationContext, so current_time() resolves) —
+      // routing through b.set gives it the same eager write as loop bodies. If
+      // no builder is active (defensive fallback only), write at vt 0 against
+      // the Time State directly. (get is still the facade read here; Task 3
+      // routes get through b.get so it reads at the reader's vt.)
       const set = (key: string | symbol, value: unknown): void => {
-        this.globalStore.set(key, value)
+        const b = this.currentBuildBuilder
+        if (b) {
+          b.set(key, value)
+        } else {
+          this.globalStore.set(key, value, 0)
+        }
       }
       const storeGet = (key: string | symbol): unknown => this.globalStore.get(key) ?? null
       const getFn = (key: string | symbol): unknown => storeGet(key)

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1076,7 +1076,15 @@ export class SonicPiEngine {
           this.globalStore.set(key, value, 0)
         }
       }
-      const storeGet = (key: string | symbol): unknown => this.globalStore.get(key) ?? null
+      // SP95(d) #350 slice 2: bare top-level `get` (and any path that hits this
+      // sandbox closure rather than the in-loop __b.get) reads vt-aware through
+      // the active build builder (the :__run_once builder gets a current_time()).
+      // Falls back to the no-vt facade (latest value) if no builder is active.
+      const storeGet = (key: string | symbol): unknown => {
+        const b = this.currentBuildBuilder
+        if (b) return b.get(key)
+        return this.globalStore.get(key) ?? null
+      }
       const getFn = (key: string | symbol): unknown => storeGet(key)
       const get = new Proxy(getFn, {
         get(target, property, receiver) {

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -128,7 +128,11 @@ export class SonicPiEngine {
   /** Pending volume to apply when bridge initializes */
   private pendingVolume: number | null = null
   /** Stored builder functions for capture/query path */
-  private loopBuilders = new Map<string, (b: ProgramBuilder) => void>()
+  // SP95(d) #393: builderFn may be async — an S3 (sync/cue) loop body awaits a
+  // scheduler-resolved sync payload mid-build (matching desktop's blocking sync).
+  // S1/S2 bodies stay synchronous; `await` on their void return is identity, and
+  // the QueryInterpreter path (capture, S1/S2 only) ignores the return value.
+  private loopBuilders = new Map<string, (b: ProgramBuilder) => void | Promise<void>>()
   /** Per-loop seed counters for deterministic random */
   private loopSeeds = new Map<string, number>()
   /** Per-loop tick counters — persisted across iterations so ring.tick() advances correctly */
@@ -642,9 +646,9 @@ export class SonicPiEngine {
       // Scope handle — set when executor is created, used to isolate loop scopes
       let scopeHandle: ScopeHandle | null = null
 
-      const wrappedLiveLoop = (name: string, builderFnOrOpts: ((b: ProgramBuilder) => void) | Record<string, unknown>, maybeFn?: (b: ProgramBuilder) => void) => {
+      const wrappedLiveLoop = (name: string, builderFnOrOpts: ((b: ProgramBuilder) => void | Promise<void>) | Record<string, unknown>, maybeFn?: (b: ProgramBuilder) => void | Promise<void>) => {
         // Support both: live_loop("name", fn) and live_loop("name", {sync: "x"}, fn)
-        let builderFn: (b: ProgramBuilder) => void
+        let builderFn: (b: ProgramBuilder) => void | Promise<void>
         let syncTarget: string | null = null
         if (typeof builderFnOrOpts === 'function') {
           builderFn = builderFnOrOpts
@@ -809,7 +813,12 @@ export class SonicPiEngine {
           const prevBuildBuilder = this.currentBuildBuilder
           this.currentBuildBuilder = builder
           try {
-            builderFn(builder)
+            // SP95(d) #393: await so an S3 body can suspend on a scheduler-resolved
+            // sync mid-build. For today's synchronous S1/S2 bodies this `await` is
+            // identity (await on a non-thenable void). The single-field
+            // currentBuildBuilder above stays safe until sync actually awaits — the
+            // re-entrancy hardening is tracked in #395.
+            await builderFn(builder)
           } finally {
             this.currentBuildBuilder = prevBuildBuilder
             this.buildNestingDepth--
@@ -944,7 +953,7 @@ export class SonicPiEngine {
       // Matches desktop Sonic Pi: top-level with_fx creates FX once, GC blocked by subthread.join.
       const originalWrappedLiveLoop = wrappedLiveLoop
       const fxAwareWrappedLiveLoop = (name: string, builderFnOrOpts: ((b: ProgramBuilder) => void) | Record<string, unknown>, maybeFn?: (b: ProgramBuilder) => void) => {
-        let builderFn: (b: ProgramBuilder) => void
+        let builderFn: (b: ProgramBuilder) => void | Promise<void>
         let opts: Record<string, unknown> | null = null
         if (typeof builderFnOrOpts === 'function') {
           builderFn = builderFnOrOpts

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -812,6 +812,12 @@ export class SonicPiEngine {
           // ANOTHER live_loop's body still see the correct (innermost) parent.
           const prevBuildBuilder = this.currentBuildBuilder
           this.currentBuildBuilder = builder
+          // SP95(d) #393: wire the scheduler so `b.sync()` awaits the cue
+          // payload mid-build (build-time resolution → post-sync get/e[:val]
+          // read fresh state). Only this audio build path wires it; the
+          // QueryInterpreter/capture build (S2-gated) never does, so an S3
+          // sync loop cannot register a phantom waiter through capture.
+          builder.setSyncContext(scheduler, name)
           try {
             // SP95(d) #393: await so an S3 body can suspend on a scheduler-resolved
             // sync mid-build. For today's synchronous S1/S2 bodies this `await` is

--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -28,7 +28,9 @@
  */
 
 export interface Sp95Warning {
-  pattern: 'cross-loop-set-get' | 'cue-payload-via-sync-return' | 'sync-return-indexed'
+  // 'cross-loop-set-get' was retired 2026-05-28 once SV47 #350 became
+  // IMPLEMENTED; #351 detectors remain.
+  pattern: 'cue-payload-via-sync-return' | 'sync-return-indexed'
   title: string
   message: string
 }
@@ -78,43 +80,16 @@ function findLiveLoops(src: string): Array<{ name: string; body: string }> {
 }
 
 /**
- * Pattern #350: `set :k` in loop A, `get :k` in loop B, A ≠ B.
- * Map key → set/get sites by enclosing loop name; warn when sets∩gets across
- * different loops. Same-loop set/get is intentionally allowed (works on web).
+ * Pattern #350 cross-loop set/get — RETIRED 2026-05-28 (SV47 slice 2 / commit
+ * 73a4475). The time-indexed Time State + eager b.set at build current_time() +
+ * b.get vt-aware reader + post-sync iteration-vt bump together make the
+ * director/section idiom read the cuer's same-vt value (desktop-matching
+ * {55,59...} on r1). Warning here would be a SV50 false positive and erode the
+ * lint's trust budget. The detector + its emitted warning are removed; the
+ * negative-control assertion (now NO warn on the canonical pattern) is added
+ * in Sp95Lint.test.ts. #351 detectors below are untouched — PLAN-d finalize
+ * owns those.
  */
-function detectCrossLoopSetGet(loops: Array<{ name: string; body: string }>): Sp95Warning[] {
-  const SET_RE = /\bset\s+:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
-  const GET_RE = /\bget\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
-  const setsByKey = new Map<string, Set<string>>()
-  const getsByKey = new Map<string, Set<string>>()
-  for (const lp of loops) {
-    let m: RegExpExecArray | null
-    SET_RE.lastIndex = 0
-    while ((m = SET_RE.exec(lp.body)) !== null) {
-      if (!setsByKey.has(m[1])) setsByKey.set(m[1], new Set())
-      setsByKey.get(m[1])!.add(lp.name)
-    }
-    GET_RE.lastIndex = 0
-    while ((m = GET_RE.exec(lp.body)) !== null) {
-      if (!getsByKey.has(m[1])) getsByKey.set(m[1], new Set())
-      getsByKey.get(m[1])!.add(lp.name)
-    }
-  }
-  const offenders = new Set<string>()
-  for (const [key, setters] of setsByKey) {
-    const getters = getsByKey.get(key)
-    if (!getters) continue
-    // Cross-loop = at least one getter loop that is NOT in the setter set.
-    for (const g of getters) if (!setters.has(g)) offenders.add(key)
-  }
-  if (offenders.size === 0) return []
-  const keys = [...offenders].map(k => `:${k}`).join(', ')
-  return [{
-    pattern: 'cross-loop-set-get',
-    title: 'Cross-loop set/get is a v1 limitation (#350)',
-    message: `Detected set in one live_loop and get(${keys}) in another — the reader will see a stale or null value because set is a deferred runtime step but get is read at build time. Same-loop set/get (or sync-as-gate within one loop) works fine. Workaround: do the set and get inside the SAME live_loop, or use cue+sync (without payload) to gate the read. See SP95 / #350.`,
-  }]
-}
 
 /**
  * Pattern #351-payload: `cue :name, key: value` with kwargs + a matching
@@ -187,9 +162,10 @@ function detectSyncReturnIndexed(src: string): Sp95Warning[] {
  * Sonic Pi piece, so this runs in <1ms.
  */
 export function detectSp95Limitations(src: string): Sp95Warning[] {
-  const loops = findLiveLoops(src)
+  // findLiveLoops kept for the future — only #351 detectors fire today
+  // (#350 cross-loop set/get is now supported, see SV47 IMPLEMENTED).
+  void findLiveLoops
   return [
-    ...detectCrossLoopSetGet(loops),
     ...detectCuePayloadViaSync(src),
     ...detectSyncReturnIndexed(src),
   ]

--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -1,172 +1,47 @@
 /**
- * SP95-Loud — build-time detector for v1 limitations of the build-once-then-
- * interpret model (#350 + #351). These patterns produce SILENT failure today
- * (the SP95 churn-bomb); this module converts them into a visible warning so
- * the user sees "v1 doesn't support this — use X instead" instead of
- * mysterious silence.
+ * SP95-Loud — RETIRED 2026-05-28 (SP95(d) Slices 1 & 2, EPIC #392).
  *
- * Three patterns. Each must distinguish itself from the *working* same-shape
- * idiom — false positives erode trust in the lint and would harm the gate
- * more than the silent failure does. Each detector is regex/scan-only over
- * the source string (no tree-sitter dependency) so it stays robust against
- * transpiler changes and runs in <1ms on any realistic snippet.
+ * This module was a build-time detector that converted three SILENT-failure
+ * patterns of the old build-once-then-interpret model into visible warnings
+ * (the SP95 launch co-gate, PR #381 / SV50). All three patterns now produce
+ * CORRECT, desktop-matching audio, so every warning here became a false
+ * positive — and a false positive erodes the lint's trust budget worse than
+ * the original silence did (SV50's own negative-control discipline). The
+ * detectors are removed; `detectSp95Limitations` returns `[]`.
  *
- * **Pattern #350 — cross-loop set/get** (silent stale-read on the reader):
- *   `set :k, …` in `live_loop :A`, `get :k` in `live_loop :B`, A ≠ B.
- *   Same-loop set/get works (verified by r2_syncgate_crossset — must NOT warn).
+ * What changed (why each pattern is no longer a limitation):
+ *   • #350 cross-loop set/get — RESOLVED by the time-indexed `TimeState` +
+ *     eager `b.set` at build `current_time()` + `b.get` reader-vt routing
+ *     (Slice 2, commits e5e13e8→0fe871c). r1 director/section reads the
+ *     cuer's same-vt value: desktop-matching {55,59} (Level-3 PITCH-MATCH ×3).
+ *   • #351-payload (`cue :x, k: v` + `sync :x`) and #351-index
+ *     (`e = sync :x; e[:k]`) — RESOLVED by build-time `sync` await returning
+ *     the cue payload (Slice 1, commit 402f691). r3/r4 Level-3 PITCH-MATCH.
  *
- * **Pattern #351-payload — cue payload via sync return-value** (silent drop):
- *   `cue :name, key: value` AND somewhere `sync :name` (or assigned and
- *   indexed), where the receiver tries to read the payload.
+ * The generic warning CHANNEL it introduced (SonicPiEngine.setWarningHandler /
+ * emitWarning, Console.logWarning, capture.ts `## Engine Warnings`) is kept —
+ * it is reusable infrastructure for any future build-time lint. Only the
+ * SP95-specific detectors are gone. SV50 still holds as a discipline; it just
+ * no longer has an SP95 pattern to apply to.
  *
- * **Pattern #351-index — bare sync-return-value indexed** (silent undefined):
- *   `e = sync :name` followed by `e[…]` or `e.something` — the value is the
- *   builder, indexing yields undefined which `play` no-ops.
- *
- * REFS: catalogue SP95 (parent), SV47 (NOT YET IMPLEMENTED), issues #350/#351,
- * dharana §B2 runtime-cluster co-gate per launch_acceptance_criteria.md.
+ * REFS: SV47 (IMPLEMENTED), krama SK16/SK17, hetvabhasa SP95 (RESOLVED blocks),
+ * dharana §26 (RESOLVED). Issues #350/#351 (done); #400 (Slice 3 deferred —
+ * reversed-loop-order (t,p,i,d) total order, a wake-phase parity feature, NOT
+ * a silent-failure pattern this lint would catch). Prior loud-path: PR #381.
  */
 
 export interface Sp95Warning {
-  // 'cross-loop-set-get' was retired 2026-05-28 once SV47 #350 became
-  // IMPLEMENTED; #351 detectors remain.
-  pattern: 'cue-payload-via-sync-return' | 'sync-return-indexed'
+  pattern: string
   title: string
   message: string
 }
 
 /**
- * Find `live_loop :name do … end` blocks and return [{name, body, line}].
- * Best-effort lexical scan — handles `live_loop :foo, sync: :bar do` (kwargs
- * before `do`) and `live_loop :foo do |i|` (block param). Doesn't parse
- * arbitrary nesting depth perfectly; balanced via a simple `do`/`end` counter
- * which is robust for the SP95 patterns we care about (top-level loops).
+ * Run all SP95-loud detectors over the given Ruby source. All SP95 idioms are
+ * now implemented (see module header), so this returns `[]`. Retained as the
+ * integration point for the warning channel so a future build-time lint can
+ * slot in here without re-wiring SonicPiEngine / App / capture.ts. Pure, O(1).
  */
-function findLiveLoops(src: string): Array<{ name: string; body: string }> {
-  const out: Array<{ name: string; body: string }> = []
-  // Match `live_loop :NAME` (optionally followed by kwargs/whitespace, then `do`).
-  // `:NAME` matches Ruby symbol; allow underscores and digits after the first char.
-  const re = /\blive_loop\s+:([a-zA-Z_][a-zA-Z0-9_]*)\b[^\n]*?\bdo\b/g
-  let m: RegExpExecArray | null
-  while ((m = re.exec(src)) !== null) {
-    const name = m[1]
-    const bodyStart = m.index + m[0].length
-    // Walk forward counting do/end to find this block's matching end.
-    // Token-aware enough to skip `do` inside comments/strings: cheap heuristic —
-    // strip line-comments and same-line string literals before counting.
-    let depth = 1
-    let i = bodyStart
-    let bodyEnd = bodyStart
-    while (i < src.length && depth > 0) {
-      const nl = src.indexOf('\n', i)
-      const lineEnd = nl === -1 ? src.length : nl
-      const line = src.slice(i, lineEnd)
-      const sanitized = line.replace(/#.*$/, '').replace(/'[^']*'|"[^"]*"/g, '""')
-      const doCount = (sanitized.match(/\bdo\b/g) || []).length
-      const endCount = (sanitized.match(/\bend\b/g) || []).length
-      // Body includes the full line up to (but not past) the matching `end`.
-      // For pattern detection we only care that set/get/cue tokens fall
-      // inside; the closing `end` itself is harmless to include because it
-      // doesn't match any of our token regexes.
-      bodyEnd = lineEnd
-      if (depth + doCount - endCount <= 0) break
-      depth += doCount - endCount
-      if (nl === -1) break
-      i = nl + 1
-    }
-    out.push({ name, body: src.slice(bodyStart, bodyEnd) })
-  }
-  return out
-}
-
-/**
- * Pattern #350 cross-loop set/get — RETIRED 2026-05-28 (SV47 slice 2 / commit
- * 73a4475). The time-indexed Time State + eager b.set at build current_time() +
- * b.get vt-aware reader + post-sync iteration-vt bump together make the
- * director/section idiom read the cuer's same-vt value (desktop-matching
- * {55,59...} on r1). Warning here would be a SV50 false positive and erode the
- * lint's trust budget. The detector + its emitted warning are removed; the
- * negative-control assertion (now NO warn on the canonical pattern) is added
- * in Sp95Lint.test.ts. #351 detectors below are untouched — PLAN-d finalize
- * owns those.
- */
-
-/**
- * Pattern #351-payload: `cue :name, key: value` with kwargs + a matching
- * `sync :name` somewhere. Payload is silently dropped by the build-once model.
- * Catches both `cue(:beat, val: x)` and `cue :beat, val: x`.
- */
-function detectCuePayloadViaSync(src: string): Sp95Warning[] {
-  // cue with kwargs: `cue :NAME` followed (allowing `(` or whitespace) by an
-  // identifier-colon-space pattern indicating a kwarg, all on the same line.
-  // Restrict to same-line so we don't accidentally pick up the next statement.
-  const CUE_KW_RE = /\bcue\b\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:,|\)\s*,)\s*[a-zA-Z_][a-zA-Z0-9_]*\s*:/g
-  const cueNames = new Set<string>()
-  let m: RegExpExecArray | null
-  while ((m = CUE_KW_RE.exec(src)) !== null) cueNames.add(m[1])
-  if (cueNames.size === 0) return []
-  // For each cue name with payload, is there a matching `sync :name`?
-  const offenders: string[] = []
-  for (const name of cueNames) {
-    const SYNC_RE = new RegExp(`\\bsync\\b\\s*\\(?\\s*:${name}\\b`)
-    if (SYNC_RE.test(src)) offenders.push(name)
-  }
-  if (offenders.length === 0) return []
-  const list = offenders.map(n => `:${n}`).join(', ')
-  return [{
-    pattern: 'cue-payload-via-sync-return',
-    title: 'cue payload via sync return-value is a v1 limitation (#351)',
-    message: `Detected cue ${list} with keyword payload + a matching sync ${list}. The payload (val:, key:, etc.) is sent on the cue but NOT delivered through sync's return value in v1 — your receiver will read nil/undefined and play silently. Workaround: store the value via globalStore (set/get within the same loop, gated by sync) instead of attaching it to the cue. See SP95 / #351.`,
-  }]
-}
-
-/**
- * Pattern #351-index: `e = sync :name` then `e[…]` or `e.field`.
- * Direct evidence the receiver expects payload. Catches the pattern even when
- * the corresponding `cue` is in another file or is missing kwargs entirely.
- */
-function detectSyncReturnIndexed(src: string): Sp95Warning[] {
-  // Match `e = sync :name` (or `e = sync(:name)`) where e is an identifier.
-  const ASSIGN_RE = /\b([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*sync\b\s*\(?\s*:([a-zA-Z_][a-zA-Z0-9_]*)\b/g
-  const bindings: Array<{ varName: string; cueName: string; afterIndex: number }> = []
-  let m: RegExpExecArray | null
-  while ((m = ASSIGN_RE.exec(src)) !== null) {
-    bindings.push({ varName: m[1], cueName: m[2], afterIndex: m.index + m[0].length })
-  }
-  if (bindings.length === 0) return []
-  const offenderCues = new Set<string>()
-  for (const b of bindings) {
-    // Look for `e[…]` or `e.foo` AFTER the assignment. Bound the search to
-    // ~2KB of following source to keep the regex linear and to avoid matching
-    // unrelated variables of the same name in later code.
-    const tail = src.slice(b.afterIndex, b.afterIndex + 2048)
-    const INDEX_RE = new RegExp(`\\b${b.varName}\\s*\\[`)
-    const DOT_RE = new RegExp(`\\b${b.varName}\\s*\\.\\s*[a-zA-Z_]`)
-    if (INDEX_RE.test(tail) || DOT_RE.test(tail)) offenderCues.add(b.cueName)
-  }
-  if (offenderCues.size === 0) return []
-  const list = [...offenderCues].map(n => `:${n}`).join(', ')
-  return [{
-    pattern: 'sync-return-indexed',
-    title: 'Indexing the sync return-value yields undefined (#351)',
-    message: `Detected the pattern: e = sync ${list} ... e[…] (or e.field). In v1, sync returns the builder itself, NOT the cue's payload — indexing it gives undefined and any play(undefined) is silently skipped. Workaround: don't rely on sync's return value; instead store the data via set in the cuer's loop and get it in the receiver after sync (same-loop set/get works inside a single loop; cross-loop is also a v1 limitation per #350). See SP95 / #351.`,
-  }]
-}
-
-/**
- * Run all SP95-loud detectors over the given Ruby source. Returns an empty
- * list when no patterns match. Caller is responsible for surfacing the
- * warnings (per-evaluate dedup, formatting). Pure function — no IO.
- *
- * Total cost is one O(n) scan per detector; n ≪ 100KB for any realistic
- * Sonic Pi piece, so this runs in <1ms.
- */
-export function detectSp95Limitations(src: string): Sp95Warning[] {
-  // findLiveLoops kept for the future — only #351 detectors fire today
-  // (#350 cross-loop set/get is now supported, see SV47 IMPLEMENTED).
-  void findLiveLoops
-  return [
-    ...detectCuePayloadViaSync(src),
-    ...detectSyncReturnIndexed(src),
-  ]
+export function detectSp95Limitations(_src: string): Sp95Warning[] {
+  return []
 }

--- a/src/engine/TimeState.ts
+++ b/src/engine/TimeState.ts
@@ -1,0 +1,112 @@
+/**
+ * TimeState — a virtual-time-indexed key/value store for `set`/`get`.
+ *
+ * Mirrors Desktop Sonic Pi's Time State layer (`event_history.rb`): a `get`
+ * resolves "the last seen version at or before the reader's time" (the
+ * inclusive "last ≤ t" lookup, `event_history.rb:180`), and a `set` appends a
+ * timestamped entry rather than blindly overwriting. Desktop has a dedicated
+ * layer for this; per CLAUDE.md's "Architecture Principle" we mirror that
+ * boundary in a single standalone module instead of scattering Map-of-arrays
+ * logic across SonicPiEngine / ProgramBuilder / AudioInterpreter.
+ *
+ * Why time-indexed (SP95 / SV47 / #350): under the plain `Map` the apply moment
+ * WAS the visibility moment, so a cross-loop `set`/`get` at the same virtual
+ * time raced on microtask ordering. With a time index each `set` carries its
+ * OWN recorded virtual time, so visibility is defined by the recorded TIMESTAMP,
+ * not by the moment of application — eager build-time application no longer
+ * collapses the intra-loop timeline the way SP41 feared (`set :x,1; sleep 2;
+ * set :x,2` records x=1@T and x=2@(T+2); a reader at vt T+1 reads 1).
+ *
+ * v1 scope (Decision Q2/Q4): per-key append history without pruning (bounded by
+ * run length, cleared only on dispose — SK14). No priority/thread fields; the
+ * rare same-vt same-key two-writer case is resolved as last-write-wins (append
+ * order among equal-t entries). The full desktop `(time, priority, thread_delta,
+ * thread_id, beat, path)` total order is explicitly OUT of v1.
+ */
+
+interface TimeEntry {
+  /** The virtual time (seconds) at which this value was written. */
+  t: number
+  value: unknown
+}
+
+export class TimeState {
+  /**
+   * Per-key time-ordered entries. Entries are kept in ascending `t` order; for
+   * equal `t` the latest write is appended last (last-write-wins, Decision Q2).
+   */
+  private readonly store = new Map<string | symbol, TimeEntry[]>()
+
+  /**
+   * Append `{t, value}` for `key`.
+   *
+   * Idempotency requirement (Decision Q3): the interpreter's deferred `case
+   * 'set'` may re-apply the SAME (key, value) at the SAME `t` that the eager
+   * build-time write already recorded. A blind append would create a phantom
+   * duplicate that could shadow the eager entry, so a re-application of the
+   * identical (key, value, t) that is already the latest entry is a no-op —
+   * guaranteeing "exactly one entry per (key, build-vt, value)".
+   */
+  set(key: string | symbol, value: unknown, t: number): void {
+    const entries = this.store.get(key)
+    if (!entries) {
+      this.store.set(key, [{ t, value }])
+      return
+    }
+    const last = entries[entries.length - 1]
+    // Idempotent re-apply: identical (key, value, t) already the latest entry.
+    if (last !== undefined && last.t === t && last.value === value) {
+      return
+    }
+    // Maintain ascending-t order. The common case is an append (writes advance
+    // monotonically with virtual time); a rare out-of-order write is inserted
+    // at the correct position so the "last ≤ t" lookup stays correct.
+    if (last === undefined || t >= last.t) {
+      entries.push({ t, value })
+      return
+    }
+    let i = entries.length
+    while (i > 0 && entries[i - 1].t > t) i--
+    entries.splice(i, 0, { t, value })
+  }
+
+  /**
+   * Resolve the value of `key` at the reader's virtual time.
+   *
+   * - `get(key, t)` → value of the entry with the GREATEST `t` ≤ the argument
+   *   `t` (INCLUSIVE — a set recorded at vt t IS visible to a get at vt t), or
+   *   `null` if no entry is at or before `t` (matches the prior `?? null` at
+   *   SonicPiEngine.ts:1060).
+   * - `get(key)` (no `t`) → facade: the LATEST value (greatest t), or
+   *   `undefined` if the key was never set (Map-compatible facade for tests).
+   */
+  get(key: string | symbol): unknown
+  get(key: string | symbol, t: number): unknown
+  get(key: string | symbol, t?: number): unknown {
+    const entries = this.store.get(key)
+    if (!entries || entries.length === 0) {
+      // No-vt facade returns `undefined` (Map.get parity); vt-aware lookup
+      // returns `null` to match the prior sandbox-get `?? null` behavior.
+      return t === undefined ? undefined : null
+    }
+    if (t === undefined) {
+      return entries[entries.length - 1].value
+    }
+    // Greatest entry with recorded vt ≤ t (inclusive). Linear scan from the end
+    // is fine for v1's bounded histories; entries are ascending-t ordered.
+    for (let i = entries.length - 1; i >= 0; i--) {
+      if (entries[i].t <= t) return entries[i].value
+    }
+    return null
+  }
+
+  /** Number of distinct keys (facade for tests that read `.size`). */
+  get size(): number {
+    return this.store.size
+  }
+
+  /** Clear all entries. Dispose-only (SK14) — never on stop/run. */
+  clear(): void {
+    this.store.clear()
+  }
+}

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -232,6 +232,15 @@ interface TranspileContext {
   srcLine?: number
   /** Hoisted-loop counter for `loop do` inside `in_thread` (issue #205). */
   inthreadLoopCounter?: { n: number }
+  /**
+   * SP95(d) #393: true while transpiling the *direct* body of a live_loop,
+   * whose wrapper arrow is emitted `async`. Lets `sync` emit `await __b.sync()`
+   * (build-time cue resolution). Propagates through control-flow blocks
+   * (if/for/times/each — same JS function scope) but MUST be reset to false at
+   * every nested non-async function boundary (with_fx/in_thread/define/at/…),
+   * or `await` would land in a non-async arrow → refused run.
+   */
+  asyncBody?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -1023,7 +1032,9 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
 
   // Transpile bare code inside an implicit in_thread (runs once, not forever)
   // Desktop SP runs bare code once — thread terminates at end.
-  const bareCtx: TranspileContext = { ...ctx, insideLoop: true }
+  // SP95(d): bare top-level code runs inside an async `__run_once` live_loop,
+  // so `await __b.sync()` is legal there too.
+  const bareCtx: TranspileContext = { ...ctx, insideLoop: true, asyncBody: true }
   const bareJS = bareCode
     .map(c => '  ' + transpileNode(c, bareCtx))
     .filter(s => s.trim())
@@ -1040,10 +1051,10 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     if (m === 'loop') {
       const body = c.namedChildren.find((x: any) => x.type === 'do_block' || x.type === 'block')
       if (body) {
-        const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
+        const bodyCtx: TranspileContext = { ...ctx, insideLoop: true, asyncBody: true }
         const bodyStr = transpileBlockBody(body, bodyCtx)
         const name = `__loop_${topLoopCounter++}`
-        return `live_loop("${name}", (__b) => {\n${bodyStr}\n${ctx.indent}})`
+        return `live_loop("${name}", async (__b) => {\n${bodyStr}\n${ctx.indent}})`
       }
     }
     return transpileNode(c, ctx)
@@ -1052,7 +1063,7 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   const parts: string[] = []
   if (topJS.length > 0) parts.push(topJS.join('\n'))
   if (bareJS.length > 0) {
-    parts.push(`live_loop("__run_once", (__b) => {\n${bareJS.join('\n')}\n  __b.stop()\n})`)
+    parts.push(`live_loop("__run_once", async (__b) => {\n${bareJS.join('\n')}\n  __b.stop()\n})`)
   }
   if (blockJS.length > 0) parts.push(blockJS.join('\n'))
 
@@ -1234,6 +1245,17 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
       const prefix = ctx.insideLoop ? '__b.' : ''
       const args = argsNode ? transpileArgList(argsNode, ctx) : ''
       return `${prefix}${cleanName}(${args})`
+    }
+
+    // SP95(d) #393: `sync` resolves a cue payload at BUILD time (returns the
+    // payload), so `e = sync :beat; e[:val]` and `play get(:root)` after a
+    // bare `sync` read fresh state. Emit `await` only inside an async live_loop
+    // body (asyncBody) — inside with_fx/define/in_thread the arrow is not async,
+    // so sync there falls back to the (non-awaited) runtime-step path. sync_bpm
+    // keeps the runtime step (returns this); awaiting a non-thenable is identity.
+    if ((methodName === 'sync' || methodName === 'sync_bpm') && ctx.asyncBody) {
+      const args = argsNode ? transpileArgList(argsNode, ctx) : ''
+      return `await __b.${methodName}(${args})`
     }
 
     // --- Dispatch by which set the function belongs to ---
@@ -1655,14 +1677,16 @@ function transpileLiveLoop(
     return `/* parse error: live_loop :${name} missing block */`
   }
 
-  const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
+  // SP95(d) #393: live_loop body is emitted `async` so `await __b.sync()` can
+  // resolve a cue payload mid-build. asyncBody scopes that await to this arrow.
+  const bodyCtx: TranspileContext = { ...ctx, insideLoop: true, asyncBody: true }
   const bodyStr = transpileBlockBody(blockNode, bodyCtx)
 
   // sync: option — pass as registration option (one-time sync before first iteration),
   // NOT as b.sync() inside the body (which would re-sync every iteration).
   const optsArg = syncName ? `{sync: "${syncName}"}, ` : ''
 
-  return `live_loop("${name}", ${optsArg}(__b) => {\n${bodyStr}\n${ctx.indent}})`
+  return `live_loop("${name}", ${optsArg}async (__b) => {\n${bodyStr}\n${ctx.indent}})`
 }
 
 function transpileDefine(

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -253,7 +253,7 @@ interface TranspileContext {
  */
 const BUILDER_METHODS = new Set([
   // Core
-  'play', 'sleep', 'wait', 'sample', 'sync', 'sync_bpm', 'cue', 'set',
+  'play', 'sleep', 'wait', 'sample', 'sync', 'sync_bpm', 'cue', 'set', 'get',
   'use_synth', 'use_bpm', 'use_random_seed',
   'control', 'stop', 'live_audio',
   'with_fx', 'in_thread', 'at',
@@ -548,6 +548,17 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       // Top-level bare callables — no b. prefix, just append ()
       if (BARE_CALLABLE_TOP_LEVEL.has(name)) {
         return `${name}()`
+      }
+
+      // SP95(d) #350 slice 2: bare `get` identifier (e.g. the bracket form
+      // `get[:k]` → element_reference whose object is the identifier `get`)
+      // must route to the builder's vt-aware `get` Proxy inside a loop, so the
+      // bracket read happens at the reader's current_time() (SV28-safe). The
+      // call form `get(:k)` is handled via BUILDER_METHODS. At top level it
+      // stays the sandbox closure (no prefix), which routes through the active
+      // build builder.
+      if (name === 'get' && ctx.insideLoop) {
+        return '__b.get'
       }
 
       return name

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -174,6 +174,12 @@ export class VirtualTimeScheduler {
   private syncWaiters = new Map<string, Array<{
     taskId: string
     resolve: (payload: SyncPayload) => void
+    /**
+     * Virtual time at which this waiter began syncing. A cue is delivered only
+     * if it fires STRICTLY AFTER this (desktop SK15 wake-phase semantic) — see
+     * fireCue.
+     */
+    waiterVt: number
   }>>()
   /** One-shot audio-time-bound callbacks (SV41 — backs scheduleAtVirtualTime). */
   private pendingCallbacks: PendingCallback[] = []
@@ -419,15 +425,29 @@ export class VirtualTimeScheduler {
     for (const [pattern, waiters] of this.syncWaiters) {
       if (waiters.length === 0) continue
       if (!cueGlobMatch(pattern, name)) continue
+      // Desktop wake-phase semantic (SK15): deliver a cue only to waiters that
+      // began syncing STRICTLY BEFORE the cue fired. A cue at the same virtual
+      // instant a waiter registered (e.g. a cuer's first `cue` at vt=0 vs a
+      // synced loop that registered its sync at vt=0) is NOT delivered — the
+      // synced loop misses it and catches the NEXT cue. This reproduces
+      // desktop's "a freshly-started synced loop waits a cycle" behavior
+      // (#351 note-0, #350 every-other-tick). The 1e-9 epsilon guards against
+      // float noise so genuinely-simultaneous events compare equal.
+      const kept: typeof waiters = []
       for (const waiter of waiters) {
-        const waiterTask = this.tasks.get(waiter.taskId)
-        if (waiterTask) {
-          // Inherit cue's virtual time (SV5)
-          waiterTask.virtualTime = cueVirtualTime
+        if (cueVirtualTime > waiter.waiterVt + 1e-9) {
+          const waiterTask = this.tasks.get(waiter.taskId)
+          if (waiterTask) {
+            // Inherit cue's virtual time (SV5)
+            waiterTask.virtualTime = cueVirtualTime
+          }
+          waiter.resolve({ args, bpm: cueBpm })
+        } else {
+          kept.push(waiter)
         }
-        waiter.resolve({ args, bpm: cueBpm })
       }
-      this.syncWaiters.delete(pattern)
+      if (kept.length > 0) this.syncWaiters.set(pattern, kept)
+      else this.syncWaiters.delete(pattern)
     }
   }
 
@@ -443,9 +463,14 @@ export class VirtualTimeScheduler {
     // get(:name) returns existing values; sync waits for the next one.
     // Without this, loops synced to met1 start at vt=0 instead of waiting
     // for met1's first beat (met1's auto-cue fires before synced loops run).
+    // Capture the virtual time at which this waiter starts syncing. fireCue
+    // only delivers cues that fire strictly after this instant, reproducing
+    // desktop's "a freshly-started synced loop misses a simultaneous cue and
+    // waits for the next one" wake-phase (SK15; #351 note-0 / #350).
+    const waiterVt = this.tasks.get(taskId)?.virtualTime ?? 0
     return new Promise<SyncPayload>((resolve) => {
       const waiters = this.syncWaiters.get(name) ?? []
-      waiters.push({ taskId, resolve })
+      waiters.push({ taskId, resolve, waiterVt })
       this.syncWaiters.set(name, waiters)
     })
   }

--- a/src/engine/__tests__/ReorderInvariance.test.ts
+++ b/src/engine/__tests__/ReorderInvariance.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Reorder-invariance HARD gate (SV47 / #350 slice 2 task 6).
+ *
+ * Decision Q2: correctness rests on (i) causation (the cuer applies its eager
+ * `set` before it yields; the syncer's post-sync `get` is a microtask after the
+ * yield) and (ii) the inclusive "last ≤ t" time-index. It does NOT rest on the
+ * scheduler's same-vt wake order — which is insertionOrder-keyed
+ * (VirtualTimeScheduler.ts:194-196, the v1 plan's FAIL-1 was the false
+ * `(time, taskId)` total-order claim).
+ *
+ * The reorder-invariance probe: declare the player (reader) BEFORE the director
+ * (writer) in source. Insertion order now favors the player; if the fix had
+ * leaked a source-order dependence, the player would resume first and read a
+ * stale 52. The test demands identical {55, 59} prefixes for BOTH declaration
+ * orders — proving the design depends on causation, not on which asyncFn the
+ * scheduler resumes first.
+ *
+ * Companion Level-3 reproducers (Task 7): /tmp/s8/r1_director_section.rb +
+ * /tmp/s8/r1_director_section_reversed.rb.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+import type { SoundEvent } from '../SoundEventStream'
+
+type SchedulerLike = { tick: (t: number) => void }
+
+async function drive(engine: SonicPiEngine, targetVt = 6, steps = 6) {
+  const scheduler = (engine as unknown as { scheduler: SchedulerLike | null }).scheduler
+  if (!scheduler) return
+  for (let i = 1; i <= steps; i++) {
+    scheduler.tick((targetVt * i) / steps)
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+const DIRECTOR_FIRST = `
+  use_bpm 120
+  live_loop :director do
+    set :root, (ring 52, 55, 57, 59).tick
+    sleep 1
+  end
+  live_loop :player do
+    sync :director
+    play get(:root), release: 0.4
+    sleep 1
+  end
+`
+
+const PLAYER_FIRST = `
+  use_bpm 120
+  live_loop :player do
+    sync :director
+    play get(:root), release: 0.4
+    sleep 1
+  end
+  live_loop :director do
+    set :root, (ring 52, 55, 57, 59).tick
+    sleep 1
+  end
+`
+
+async function playerPrefix(src: string, n = 2): Promise<number[]> {
+  delete (globalThis as Record<string, unknown>).SuperSonic
+  const engine = new SonicPiEngine()
+  await engine.init()
+  const events: SoundEvent[] = []
+  engine.components.streaming!.eventStream.on((e) => events.push(e))
+  await engine.evaluate(src)
+  engine.play()
+  await drive(engine, 6, 6)
+  const notes = events
+    .filter((e) => typeof e.midiNote === 'number' && e.trackId === 'player')
+    .map((e) => e.midiNote as number)
+  engine.dispose()
+  return notes.slice(0, n)
+}
+
+describe('Reorder-invariance HARD gate (SV47 / #350)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('director-first and player-first produce the IDENTICAL prefix {55, 59}', async () => {
+    const a = await playerPrefix(DIRECTOR_FIRST, 2)
+    const b = await playerPrefix(PLAYER_FIRST, 2)
+    // Each individually matches desktop's {55, 59} — the value-phase fix.
+    expect(a).toEqual([55, 59])
+    expect(b).toEqual([55, 59])
+    // And they match each other — the reorder-invariance gate. If either side
+    // leaks a source-order / insertionOrder dependence, they diverge here.
+    expect(b).toEqual(a)
+  })
+})

--- a/src/engine/__tests__/ReorderInvariance.test.ts
+++ b/src/engine/__tests__/ReorderInvariance.test.ts
@@ -1,22 +1,31 @@
 /**
- * Reorder-invariance HARD gate (SV47 / #350 slice 2 task 6).
+ * Web self-consistency under loop-declaration reorder (SV47 / #350 slice 2).
  *
- * Decision Q2: correctness rests on (i) causation (the cuer applies its eager
- * `set` before it yields; the syncer's post-sync `get` is a microtask after the
- * yield) and (ii) the inclusive "last ≤ t" time-index. It does NOT rest on the
- * scheduler's same-vt wake order — which is insertionOrder-keyed
- * (VirtualTimeScheduler.ts:194-196, the v1 plan's FAIL-1 was the false
- * `(time, taskId)` total-order claim).
+ * WHAT THIS PROVES: our engine reads the SAME cross-loop set/get value
+ * regardless of the source order in which the two live_loops are declared —
+ * {55, 59} for both director-first and player-first. The #350 value-phase fix
+ * (eager `b.set` at build + inclusive "last ≤ reader-vt" time-index) does NOT
+ * leak a source-order / insertionOrder dependence (our scheduler ties same-vt
+ * wakes on insertionOrder, VirtualTimeScheduler.ts:194-196 — NOT a desktop-style
+ * total order; the `(time, taskId)` docstring at :152 is aspirational).
  *
- * The reorder-invariance probe: declare the player (reader) BEFORE the director
- * (writer) in source. Insertion order now favors the player; if the fix had
- * leaked a source-order dependence, the player would resume first and read a
- * stale 52. The test demands identical {55, 59} prefixes for BOTH declaration
- * orders — proving the design depends on causation, not on which asyncFn the
- * scheduler resumes first.
+ * WHAT THIS DOES *NOT* CLAIM: desktop parity on the reversed order. Grounded +
+ * reproduced ×3 (2026-05-28), DESKTOP IS declaration-order-DEPENDENT here:
+ * director-first → {55,59}, player-first → {52,57}. Root: desktop `sync` =
+ * get_next "next cue strictly AFTER my time t" (event_history.rb:215,542) over
+ * the full CueEvent total order (t, p, i, d…); at equal vt the (p=priority,
+ * i=thread_id, d=thread_delta) thread-identity fields (core.rb:114-119, assigned
+ * at thread spawn = declaration order) break the tie, so player-first catches the
+ * t=0 cue (index 0 = 52). We do NOT implement that (t,p,i,d) total order — our
+ * strict-vt-after wake-phase (Slice 1) collapses the equal-vt case, making web
+ * self-consistent instead. Matching desktop's order-dependence is a separate
+ * wake-phase/event-ordering parity feature (Slice 3, deferred — see GitHub issue
+ * + memory sp95_350_reversed_order_total_order_gap). r1 NORMAL order is the #350
+ * gate and is a stable Tier-1 PITCH-MATCH ×3.
  *
- * Companion Level-3 reproducers (Task 7): /tmp/s8/r1_director_section.rb +
- * /tmp/s8/r1_director_section_reversed.rb.
+ * Companion Level-3 reproducers: /tmp/s8/r1_director_section.rb (normal — desktop
+ * PITCH-MATCH) + /tmp/s8/r1_director_section_reversed.rb (reversed — desktop
+ * diverges to {52,57} BY DESIGN, web stays {55,59}).
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -76,19 +85,22 @@ async function playerPrefix(src: string, n = 2): Promise<number[]> {
   return notes.slice(0, n)
 }
 
-describe('Reorder-invariance HARD gate (SV47 / #350)', () => {
+describe('Web self-consistency under loop reorder (SV47 / #350)', () => {
   beforeEach(() => {
     delete (globalThis as Record<string, unknown>).SuperSonic
   })
 
-  it('director-first and player-first produce the IDENTICAL prefix {55, 59}', async () => {
+  it('director-first and player-first produce the IDENTICAL web prefix {55, 59}', async () => {
     const a = await playerPrefix(DIRECTOR_FIRST, 2)
     const b = await playerPrefix(PLAYER_FIRST, 2)
-    // Each individually matches desktop's {55, 59} — the value-phase fix.
+    // director-first matches desktop's {55, 59} — the #350 value-phase fix
+    // (Level-3 PITCH-MATCH ×3). player-first is web's self-consistent result;
+    // desktop diverges to {52,57} here BY DESIGN (the (t,p,i,d) total-order gap,
+    // Slice 3) — NOT asserted against desktop. See file header.
     expect(a).toEqual([55, 59])
     expect(b).toEqual([55, 59])
-    // And they match each other — the reorder-invariance gate. If either side
-    // leaks a source-order / insertionOrder dependence, they diverge here.
+    // The two web prefixes match each other — web does NOT leak a source-order /
+    // insertionOrder dependence. If it did, they would diverge here.
     expect(b).toEqual(a)
   })
 })

--- a/src/engine/__tests__/SonicPiEngineTimeState.test.ts
+++ b/src/engine/__tests__/SonicPiEngineTimeState.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Engine-level Time State tests (SV47 / #350 / SP95(d) slice 2).
+ *
+ * Companion to TimeState.test.ts (pure store) and SyncCue.test.ts (sync/cue
+ * scheduler primitives). These tests assert the SAME-VT cross-loop set/get
+ * contract at the SonicPiEngine level — exercising the full pipeline
+ * (Sandbox → transpile → ProgramBuilder.set/get → eager TimeState write →
+ * scheduler causation → microtask-ordered get read) in one shot.
+ *
+ * The pre-mortem (e) gate (PLAN-350-timestate.md): the cross-loop reader's
+ * post-sync get must read the writer's same-vt set FOR BOTH declaration
+ * orders — proving correctness rests on causation (cuer applies its set
+ * before yielding; syncer's get is a microtask after the yield) + the
+ * time-index, NOT on insertionOrder / source order / which asyncFn the
+ * scheduler resumes first. The reorder-invariant variant is the HARD gate
+ * the v1 plan lacked.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+import type { SoundEvent } from '../SoundEventStream'
+
+type SchedulerLike = { tick: (t: number) => void }
+
+/**
+ * Drive the scheduler through `targetVt` seconds of virtual time across
+ * several tick passes. `tick(t)` is ABSOLUTE (resolves sleeps with
+ * entry.time ≤ t) — using one big target lets a fresh microtask queue between
+ * passes so cross-loop microtask races have time to interleave. The interval
+ * (`steps`) mirrors the existing #336/SK14 tests.
+ */
+async function drive(engine: SonicPiEngine, targetVt = 5, steps = 5) {
+  const scheduler = (engine as unknown as { scheduler: SchedulerLike | null }).scheduler
+  if (!scheduler) return
+  for (let i = 1; i <= steps; i++) {
+    scheduler.tick((targetVt * i) / steps)
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+function midiNotes(events: SoundEvent[], trackId?: string): number[] {
+  return events
+    .filter((e) => typeof e.midiNote === 'number' && (trackId === undefined || e.trackId === trackId))
+    .map((e) => e.midiNote as number)
+}
+
+describe('Time State — engine-level cross-loop set/get (SV47 / #350)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  // -------------------------------------------------------------------------
+  // The pre-mortem (e) catch — write-not-yet-applied at read time. The two
+  // tests below are the SAME musical program with the two live_loops in
+  // OPPOSITE source order. Reorder-invariance is asserted by both reading the
+  // same {55,59} prefix from the cuer's eager set at vt 0.5.
+  // -------------------------------------------------------------------------
+
+  it('(e) director-first: player\'s post-sync get reads the director\'s same-vt set ({55,59})', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    await engine.evaluate(`
+      use_bpm 120
+      live_loop :director do
+        set :root, (ring 52, 55, 57, 59).tick
+        sleep 1
+      end
+      live_loop :player do
+        sync :director
+        play get(:root), release: 0.4
+        sleep 1
+      end
+    `)
+    engine.play()
+    // Drive enough virtual time for two cuer cycles (director iter 1 cues at
+    // vt 0, iter 2 at vt 1, etc.) plus the player's sync/play.
+    await drive(engine, 6, 6)
+
+    const played = midiNotes(events, 'player')
+    // The cuer's iteration N writes (ring 52,55,57,59).tick[N-1] then sleeps;
+    // the player wakes on the cuer's auto-cue at the cuer's iteration boundary
+    // and reads the value the cuer JUST set at that vt. Desktop-matching
+    // prefix is {55, 59, 55, 59, ...} (the cuer's tick-1, tick-3, ... values,
+    // because the player wakes from sync AFTER the cuer's first sleep).
+    expect(played.length).toBeGreaterThanOrEqual(2)
+    expect(played[0]).toBe(55)
+    expect(played[1]).toBe(59)
+
+    engine.dispose()
+  })
+
+  it('(e) reversed: player declared BEFORE director — STILL reads {55,59} (reorder-invariant)', async () => {
+    // The HARD gate. If this reads {52,57} or anything else, the design has
+    // leaked a source-order dependence — eager-apply by causation is broken.
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    await engine.evaluate(`
+      use_bpm 120
+      live_loop :player do
+        sync :director
+        play get(:root), release: 0.4
+        sleep 1
+      end
+      live_loop :director do
+        set :root, (ring 52, 55, 57, 59).tick
+        sleep 1
+      end
+    `)
+    engine.play()
+    await drive(engine, 6, 6)
+
+    const played = midiNotes(events, 'player')
+    expect(played.length).toBeGreaterThanOrEqual(2)
+    expect(played[0]).toBe(55)
+    expect(played[1]).toBe(59)
+
+    engine.dispose()
+  })
+
+  // -------------------------------------------------------------------------
+  // SV20: per-set timestamp keeps the intra-loop timeline correct. A
+  // set-after-sleep records at the post-sleep vt; a get at an earlier vt
+  // must still read the pre-set value. Asserted at the engine level (the
+  // store-level guard lives in TimeState.test.ts).
+  // -------------------------------------------------------------------------
+
+  it('SV20: set-after-sleep records at the post-sleep vt (not iteration start)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    // A writer loop that does `set :y, 1; sleep 2; set :y, 2; sleep 999`.
+    // At bpm=60, `sleep 2` advances current_time() by 2s — so the two sets
+    // land at distinct vt values (iteration-start vt and iteration-start vt +
+    // 2). The sleep 999 parks the loop so iteration 2 never starts within the
+    // test window, leaving exactly two timestamped entries for :y.
+    await engine.evaluate(`
+      use_bpm 60
+      live_loop :writer do
+        set :y, 1
+        sleep 2
+        set :y, 2
+        sleep 999
+      end
+    `)
+    engine.play()
+    await drive(engine, 5, 5)
+
+    const store = (engine as unknown as {
+      globalStore: { get: (k: string, t?: number) => unknown }
+    }).globalStore
+
+    // Iteration 1 starts at vt=0 (initial sleep(0) wake), so the per-set
+    // timestamps are 0 (set :y, 1) and 2 (set :y, 2 — after sleep 2).
+    expect(store.get('y', -0.5)).toBeNull() // before any write
+    expect(store.get('y', 0)).toBe(1) // at the first set's vt
+    expect(store.get('y', 1)).toBe(1) // between the two sets
+    expect(store.get('y', 1.99)).toBe(1) // just before the second set
+    expect(store.get('y', 2)).toBe(2) // at the second set's vt (inclusive)
+    expect(store.get('y', 10)).toBe(2) // long after — latest stays visible
+
+    engine.dispose()
+  })
+
+  // -------------------------------------------------------------------------
+  // Same-loop set+get (the canonical no-warn case, never broken). Confirms
+  // the eager write + builder-routed get path doesn't regress the basic idiom.
+  // -------------------------------------------------------------------------
+
+  it('same-loop set/get: play get(:n) reads the current iteration\'s set', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    await engine.evaluate(`
+      use_bpm 120
+      live_loop :solo do
+        set :n, (ring 60, 64, 67).tick
+        play get(:n), release: 0.4
+        sleep 1
+      end
+    `)
+    engine.play()
+    // At bpm=120 each iteration is 0.5s; 4s of vt → ~8 iterations.
+    await drive(engine, 4, 4)
+
+    const played = midiNotes(events, 'solo')
+    // The first three iterations write 60, 64, 67 and immediately read them.
+    expect(played.length).toBeGreaterThanOrEqual(3)
+    expect(played[0]).toBe(60)
+    expect(played[1]).toBe(64)
+    expect(played[2]).toBe(67)
+
+    engine.dispose()
+  })
+
+  // -------------------------------------------------------------------------
+  // SK14: store survives Stop, cleared on dispose. Mirrors the existing #336
+  // test but uses the time-indexed contract directly to guard against a
+  // regression where dispose-only clear is moved back to stop().
+  // -------------------------------------------------------------------------
+
+  it('SK14: Time State persists across Stop, cleared only on dispose', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    await engine.evaluate('set :section, 41')
+    engine.stop()
+
+    const store = (engine as unknown as {
+      globalStore: { get: (k: string) => unknown; size: number }
+    }).globalStore
+    // Survives Stop (no clear).
+    expect(store.get('section')).toBe(41)
+    expect(store.size).toBeGreaterThan(0)
+
+    engine.dispose()
+    // Cleared on dispose.
+    expect(store.size).toBe(0)
+  })
+})

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -9,8 +9,15 @@
 import { describe, it, expect } from 'vitest'
 import { detectSp95Limitations } from '../Sp95Lint'
 
-describe('Sp95Lint — cross-loop set/get (#350)', () => {
-  it('warns on the canonical director/section pattern (different loops)', () => {
+// The #350 cross-loop set/get detector was retired 2026-05-28 (SV47 / commit
+// 73a4475): the time-indexed Time State + eager b.set + post-sync vt bump
+// make the idiom read the cuer's same-vt value. The block below flips the
+// former positives to NEGATIVE CONTROLS — the pattern must NOT emit a warning
+// any more — and keeps the original negative controls in place (SV50
+// negative-control discipline: false positives are strictly worse than the
+// silent failure they replaced).
+describe('Sp95Lint — cross-loop set/get is supported (#350, NOT a warning)', () => {
+  it('does NOT warn on the canonical director/section pattern (NOW supported)', () => {
     const src = `
       live_loop :director do
         set :root, (ring 52, 55, 57, 59).tick
@@ -23,9 +30,8 @@ describe('Sp95Lint — cross-loop set/get (#350)', () => {
       end
     `
     const w = detectSp95Limitations(src)
-    expect(w.length).toBeGreaterThan(0)
-    expect(w[0].pattern).toBe('cross-loop-set-get')
-    expect(w[0].title).toMatch(/Cross-loop set\/get/)
+    // No SP95 warning at all on this pattern — it now reads {55,59} desktop-match.
+    expect(w).toEqual([])
   })
 
   it('does NOT warn when set + get are in the SAME loop (works on web)', () => {
@@ -37,11 +43,10 @@ describe('Sp95Lint — cross-loop set/get (#350)', () => {
       end
     `
     const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+    expect(w).toEqual([])
   })
 
-  it('does NOT warn on get without any matching set', () => {
-    // get with no producer — different bug class, not SP95.
+  it('does NOT warn on get without any matching set (different bug class)', () => {
     const src = `
       live_loop :reader do
         play get(:never_set), release: 0.4
@@ -49,7 +54,7 @@ describe('Sp95Lint — cross-loop set/get (#350)', () => {
       end
     `
     const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+    expect(w).toEqual([])
   })
 
   it('does NOT warn on set without any matching get', () => {
@@ -60,25 +65,25 @@ describe('Sp95Lint — cross-loop set/get (#350)', () => {
       end
     `
     const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'cross-loop-set-get')).toEqual([])
+    expect(w).toEqual([])
   })
 
-  it('catches the function-call form: get(:k)', () => {
+  it('does NOT warn on cross-loop function-call form: get(:k) — NOW supported', () => {
     const src = `
       live_loop :a do; set :x, 1; sleep 1; end
       live_loop :b do; play get(:x); sleep 1; end
     `
     const w = detectSp95Limitations(src)
-    expect(w.some(x => x.pattern === 'cross-loop-set-get')).toBe(true)
+    expect(w).toEqual([])
   })
 
-  it('catches the bareword form: get :k', () => {
+  it('does NOT warn on cross-loop bareword form: get :k — NOW supported', () => {
     const src = `
       live_loop :a do; set :x, 1; sleep 1; end
       live_loop :b do; play get :x; sleep 1; end
     `
     const w = detectSp95Limitations(src)
-    expect(w.some(x => x.pattern === 'cross-loop-set-get')).toBe(true)
+    expect(w).toEqual([])
   })
 })
 
@@ -203,8 +208,8 @@ describe('Sp95Lint — empty / unrelated programs', () => {
   })
 })
 
-describe('Sp95Lint — multiple patterns coexist', () => {
-  it('emits all three when the program contains all three', () => {
+describe('Sp95Lint — #351 patterns still coexist (#350 retired)', () => {
+  it('emits BOTH #351 patterns when the program contains both — and the #350 pattern does NOT contribute', () => {
     const src = `
       live_loop :director do
         set :root, 60
@@ -217,8 +222,10 @@ describe('Sp95Lint — multiple patterns coexist', () => {
       end
     `
     const patterns = new Set(detectSp95Limitations(src).map(w => w.pattern))
-    expect(patterns).toContain('cross-loop-set-get')
+    // #351 detectors are intact:
     expect(patterns).toContain('cue-payload-via-sync-return')
     expect(patterns).toContain('sync-return-indexed')
+    // #350 detector is gone:
+    expect(patterns.size).toBe(2)
   })
 })

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -1,24 +1,25 @@
 /**
- * Sp95Lint — pattern detector tests.
+ * Sp95Lint — RETIRED detector, negative-control suite (SP95(d) Slices 1 & 2).
  *
- * Three positive patterns, plus the critical negative cases. False positives
- * on these would erode trust in the lint and warn users about idioms that
- * actually work — strictly worse than the silent failure we're replacing.
+ * All three SP95 patterns the lint used to warn about now produce correct,
+ * desktop-matching audio (see Sp95Lint.ts header + SV47 IMPLEMENTED):
+ *   • #350 cross-loop set/get   → time-indexed TimeState (Slice 2)
+ *   • #351 cue-payload-via-sync → build-time sync await (Slice 1)
+ *   • #351 sync-return-indexed  → build-time sync await (Slice 1)
+ *
+ * `detectSp95Limitations` therefore returns `[]` for every input. These tests
+ * are the SV50 negative-control guard: the canonical reproducers — which are
+ * Level-3 PITCH-MATCH against desktop — must NEVER re-introduce a warning. A
+ * false positive on a working idiom is strictly worse than no lint at all.
  */
 
 import { describe, it, expect } from 'vitest'
 import { detectSp95Limitations } from '../Sp95Lint'
 
-// The #350 cross-loop set/get detector was retired 2026-05-28 (SV47 / commit
-// 73a4475): the time-indexed Time State + eager b.set + post-sync vt bump
-// make the idiom read the cuer's same-vt value. The block below flips the
-// former positives to NEGATIVE CONTROLS — the pattern must NOT emit a warning
-// any more — and keeps the original negative controls in place (SV50
-// negative-control discipline: false positives are strictly worse than the
-// silent failure they replaced).
-describe('Sp95Lint — cross-loop set/get is supported (#350, NOT a warning)', () => {
-  it('does NOT warn on the canonical director/section pattern (NOW supported)', () => {
+describe('Sp95Lint — all SP95 idioms supported, lint retired (NO warnings)', () => {
+  it('does NOT warn on the #350 cross-loop director/section pattern (r1, PITCH-MATCH ×3)', () => {
     const src = `
+      use_bpm 120
       live_loop :director do
         set :root, (ring 52, 55, 57, 59).tick
         sleep 1
@@ -29,67 +30,12 @@ describe('Sp95Lint — cross-loop set/get is supported (#350, NOT a warning)', (
         sleep 1
       end
     `
-    const w = detectSp95Limitations(src)
-    // No SP95 warning at all on this pattern — it now reads {55,59} desktop-match.
-    expect(w).toEqual([])
+    expect(detectSp95Limitations(src)).toEqual([])
   })
 
-  it('does NOT warn when set + get are in the SAME loop (works on web)', () => {
+  it('does NOT warn on the #351 cue-payload-via-sync pattern (r3, PITCH-MATCH)', () => {
     const src = `
-      live_loop :solo do
-        set :note, 60
-        play get(:note), release: 0.4
-        sleep 1
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w).toEqual([])
-  })
-
-  it('does NOT warn on get without any matching set (different bug class)', () => {
-    const src = `
-      live_loop :reader do
-        play get(:never_set), release: 0.4
-        sleep 1
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w).toEqual([])
-  })
-
-  it('does NOT warn on set without any matching get', () => {
-    const src = `
-      live_loop :writer do
-        set :unused, 1
-        sleep 1
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w).toEqual([])
-  })
-
-  it('does NOT warn on cross-loop function-call form: get(:k) — NOW supported', () => {
-    const src = `
-      live_loop :a do; set :x, 1; sleep 1; end
-      live_loop :b do; play get(:x); sleep 1; end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w).toEqual([])
-  })
-
-  it('does NOT warn on cross-loop bareword form: get :k — NOW supported', () => {
-    const src = `
-      live_loop :a do; set :x, 1; sleep 1; end
-      live_loop :b do; play get :x; sleep 1; end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w).toEqual([])
-  })
-})
-
-describe('Sp95Lint — cue payload via sync return-value (#351)', () => {
-  it('warns on cue :x, kw: val + sync :x', () => {
-    const src = `
+      use_bpm 120
       live_loop :sender do
         cue :beat, val: (ring 60, 64, 67, 71).tick
         sleep 1
@@ -99,133 +45,69 @@ describe('Sp95Lint — cue payload via sync return-value (#351)', () => {
         play e[:val], release: 0.4
       end
     `
-    const w = detectSp95Limitations(src)
-    const hit = w.find(x => x.pattern === 'cue-payload-via-sync-return')
-    expect(hit).toBeDefined()
-    expect(hit!.title).toMatch(/cue payload via sync/)
-    expect(hit!.message).toMatch(/:beat/)
+    expect(detectSp95Limitations(src)).toEqual([])
   })
 
-  it('also catches function-call form: cue(:beat, val: x)', () => {
+  it('does NOT warn on the #351 sync-return-indexed conditional pattern (r4, PITCH-MATCH)', () => {
     const src = `
-      live_loop :s do; cue(:beat, val: 60); sleep 1; end
-      live_loop :r do; sync :beat; end
+      use_bpm 120
+      live_loop :sender do
+        cue :beat, n: (ring 55, 67).tick
+        sleep 1
+      end
+      live_loop :receiver do
+        e = sync :beat
+        if e[:n] > 60
+          play 90, release: 0.4
+        else
+          play 50, release: 0.4
+        end
+      end
     `
-    const w = detectSp95Limitations(src)
-    expect(w.some(x => x.pattern === 'cue-payload-via-sync-return')).toBe(true)
+    expect(detectSp95Limitations(src)).toEqual([])
   })
 
-  it('does NOT warn on payload-less cue + sync (works on web)', () => {
+  it('does NOT warn on cue(:beat, val: x) function-call form', () => {
     const src = `
-      live_loop :s do; cue :beat; sleep 1; end
-      live_loop :r do; sync :beat; play 60; end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'cue-payload-via-sync-return')).toEqual([])
-  })
-
-  it('does NOT warn on cue with payload but no matching sync (no receiver)', () => {
-    const src = `
-      live_loop :s do; cue :beat, val: 60; sleep 1; end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'cue-payload-via-sync-return')).toEqual([])
-  })
-})
-
-describe('Sp95Lint — sync return-value indexed (#351 — broader)', () => {
-  it('warns on e = sync :x; e[:k] (even when cue is missing or in another file)', () => {
-    const src = `
+      live_loop :s do
+        cue(:beat, val: 60)
+        sleep 1
+      end
       live_loop :r do
         e = sync :beat
         play e[:val]
       end
     `
-    const w = detectSp95Limitations(src)
-    const hit = w.find(x => x.pattern === 'sync-return-indexed')
-    expect(hit).toBeDefined()
-    expect(hit!.message).toMatch(/:beat/)
+    expect(detectSp95Limitations(src)).toEqual([])
   })
 
-  it('also catches e.field accesses', () => {
+  it('does NOT warn on same-loop set/get (always worked)', () => {
     const src = `
-      live_loop :r do
-        e = sync :beat
-        play e.val
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w.some(x => x.pattern === 'sync-return-indexed')).toBe(true)
-  })
-
-  it('does NOT warn on plain sync without assignment', () => {
-    const src = `
-      live_loop :r do
-        sync :beat
-        play 60
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'sync-return-indexed')).toEqual([])
-  })
-
-  it('does NOT warn on sync return assigned but never indexed', () => {
-    // Assigning the return for logging is harmless; warn only when the user
-    // tries to dig data out of it.
-    const src = `
-      live_loop :r do
-        e = sync :beat
-        puts e  # treats it as opaque — fine
-      end
-    `
-    const w = detectSp95Limitations(src)
-    expect(w.filter(x => x.pattern === 'sync-return-indexed')).toEqual([])
-  })
-})
-
-describe('Sp95Lint — empty / unrelated programs', () => {
-  it('returns no warnings on a trivial play loop', () => {
-    expect(detectSp95Limitations('live_loop :foo do; play 60; sleep 1; end')).toEqual([])
-  })
-
-  it('returns no warnings on the empty string', () => {
-    expect(detectSp95Limitations('')).toEqual([])
-  })
-
-  it('returns no warnings on a piece with set/get/cue/sync but all SP95-safe', () => {
-    // Same-loop set/get + bare cue+sync. The director/section anti-pattern's
-    // "safe twin": the same primitives, just used inside one loop.
-    const src = `
-      live_loop :solo do
-        cue :tick                       # no payload
-        sync :tick                      # plain sync, no return-value use
-        set :n, 60
-        play get(:n)                    # same-loop set+get is OK
+      live_loop :a do
+        set :k, 60
+        play get(:k)
         sleep 1
       end
     `
     expect(detectSp95Limitations(src)).toEqual([])
   })
-})
 
-describe('Sp95Lint — #351 patterns still coexist (#350 retired)', () => {
-  it('emits BOTH #351 patterns when the program contains both — and the #350 pattern does NOT contribute', () => {
+  it('does NOT warn on payload-less cue + sync', () => {
     const src = `
-      live_loop :director do
-        set :root, 60
-        cue :beat, val: 64
+      live_loop :s do
+        cue :beat
+        sleep 1
       end
-      live_loop :player do
-        e = sync :beat
-        play e[:val]
-        play get(:root)
+      live_loop :r do
+        sync :beat
+        play 60
       end
     `
-    const patterns = new Set(detectSp95Limitations(src).map(w => w.pattern))
-    // #351 detectors are intact:
-    expect(patterns).toContain('cue-payload-via-sync-return')
-    expect(patterns).toContain('sync-return-indexed')
-    // #350 detector is gone:
-    expect(patterns.size).toBe(2)
+    expect(detectSp95Limitations(src)).toEqual([])
+  })
+
+  it('returns [] for arbitrary unrelated code', () => {
+    expect(detectSp95Limitations('play 60\nsleep 1\nsample :bd_haus')).toEqual([])
+    expect(detectSp95Limitations('')).toEqual([])
   })
 })

--- a/src/engine/__tests__/SyncCue.test.ts
+++ b/src/engine/__tests__/SyncCue.test.ts
@@ -50,12 +50,12 @@ describe('sync/cue', () => {
       await runProgram(metroProgram, makeAudioCtx(scheduler, 'metro', eventStream, nodeRefMap))
     })
 
-    // Player loop: sync on 'tick', play 72 (proof sync resolved), then park
-    const playerProgram = new ProgramBuilder(0)
-      .sync('tick')
-      .play(72)
-      .sleep(999999)
-      .build()
+    // Player loop: sync on 'tick', play 72 (proof sync resolved), then park.
+    // Manual builder (no scheduler wired) → sync uses the legacy runtime-step
+    // path; call it as a statement since its return type is now a union (SP95d).
+    const playerBuilder = new ProgramBuilder(0)
+    playerBuilder.sync('tick')
+    const playerProgram = playerBuilder.play(72).sleep(999999).build()
 
     scheduler.registerLoop('player', async () => {
       await runProgram(playerProgram, makeAudioCtx(scheduler, 'player', eventStream, nodeRefMap))
@@ -101,23 +101,19 @@ describe('sync/cue', () => {
       await runProgram(sourceProgram, makeAudioCtx(scheduler, 'source', eventStream, nodeRefMap))
     })
 
-    // Waiter 1: sync on 'go', play 60 (proof), park
-    const waiter1Program = new ProgramBuilder(0)
-      .sync('go')
-      .play(60)
-      .sleep(999999)
-      .build()
+    // Waiter 1: sync on 'go', play 60 (proof), park (legacy runtime-step path)
+    const waiter1Builder = new ProgramBuilder(0)
+    waiter1Builder.sync('go')
+    const waiter1Program = waiter1Builder.play(60).sleep(999999).build()
 
     scheduler.registerLoop('waiter1', async () => {
       await runProgram(waiter1Program, makeAudioCtx(scheduler, 'waiter1', eventStream, nodeRefMap))
     })
 
-    // Waiter 2: sync on 'go', play 72 (proof), park
-    const waiter2Program = new ProgramBuilder(0)
-      .sync('go')
-      .play(72)
-      .sleep(999999)
-      .build()
+    // Waiter 2: sync on 'go', play 72 (proof), park (legacy runtime-step path)
+    const waiter2Builder = new ProgramBuilder(0)
+    waiter2Builder.sync('go')
+    const waiter2Program = waiter2Builder.play(72).sleep(999999).build()
 
     scheduler.registerLoop('waiter2', async () => {
       await runProgram(waiter2Program, makeAudioCtx(scheduler, 'waiter2', eventStream, nodeRefMap))
@@ -325,5 +321,72 @@ describe('sync/cue', () => {
     await flushMicrotasks()
 
     expect(followerTask.bpm).toBe(200)
+  })
+})
+
+describe('sync/cue — SP95(d) build-time payload + wake-phase (#350/#351)', () => {
+  it('build-time sync returns the cue payload map; e[:val] reads it', async () => {
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    scheduler.registerLoop('receiver', async () => {})
+    scheduler.registerLoop('sender', async () => {})
+    const receiver = scheduler.getTask('receiver')!
+    const sender = scheduler.getTask('sender')!
+    receiver.virtualTime = 0
+
+    // Builder wired with scheduler (audio build path) → sync awaits + returns payload.
+    const b = new ProgramBuilder(0)
+    b.setSyncContext(scheduler, 'receiver')
+    const pending = b.sync('beat')
+    expect(pending).toBeInstanceOf(Promise)
+
+    // Cue fires strictly later (vt=1) carrying a kwargs payload.
+    sender.virtualTime = 1
+    scheduler.fireCue('beat', 'sender', [{ val: 64 }])
+    const payload = (await pending) as Record<string, unknown>
+    // Ruby `e = sync :beat; e[:val]` → e is the kwargs map, e["val"] === 64.
+    expect(payload).toEqual({ val: 64 })
+    expect(payload['val']).toBe(64)
+  })
+
+  it('a freshly-started sync misses a SIMULTANEOUS cue and catches the next (wake-phase, SK15)', async () => {
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    scheduler.registerLoop('receiver', async () => {})
+    scheduler.registerLoop('sender', async () => {})
+    const receiver = scheduler.getTask('receiver')!
+    const sender = scheduler.getTask('sender')!
+    receiver.virtualTime = 0
+
+    let resolved: unknown = 'PENDING'
+    scheduler.waitForSync('beat', 'receiver').then((p) => { resolved = p })
+
+    // Cue at the SAME virtual instant the receiver registered (vt=0) — desktop's
+    // sender fires its first cue before the receiver is ready, so this is missed.
+    sender.virtualTime = 0
+    scheduler.fireCue('beat', 'sender', [{ val: 60 }])
+    await flushMicrotasks()
+    expect(resolved).toBe('PENDING') // simultaneous cue NOT delivered
+
+    // Next cue, strictly later (vt=0.5) — this one is caught.
+    sender.virtualTime = 0.5
+    scheduler.fireCue('beat', 'sender', [{ val: 64 }])
+    await flushMicrotasks()
+    expect(resolved).toEqual({ args: [{ val: 64 }], bpm: sender.bpm })
+  })
+
+  it('manual builder sync (no scheduler) keeps the legacy runtime-step path + returns this', () => {
+    const b = new ProgramBuilder(0)
+    const ret = b.sync('x')
+    expect(ret).toBe(b) // chainable; runtime sync STEP, not a Promise
+    expect(b.build()).toEqual([{ tag: 'sync', name: 'x' }])
+  })
+
+  it('sync_bpm always uses the runtime step (never build-time await), even with scheduler wired', () => {
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    scheduler.registerLoop('r', async () => {})
+    const b = new ProgramBuilder(0)
+    b.setSyncContext(scheduler, 'r')
+    const ret = b.sync_bpm('beat')
+    expect(ret).toBe(b)
+    expect(b.build()).toEqual([{ tag: 'sync', name: 'beat', bpmSync: true }])
   })
 })

--- a/src/engine/__tests__/TimeState.test.ts
+++ b/src/engine/__tests__/TimeState.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { TimeState } from '../TimeState'
+
+describe('TimeState — virtual-time-indexed store (SV47 / #350)', () => {
+  it('(i) get returns the last entry ≤ t, not a later one', () => {
+    const ts = new TimeState()
+    ts.set('k', 'a', 0)
+    ts.set('k', 'b', 2)
+    // Reader at vt 1 sees the vt-0 value, NOT the future vt-2 value.
+    expect(ts.get('k', 1)).toBe('a')
+    // Reader at vt 2 sees the vt-2 value.
+    expect(ts.get('k', 2)).toBe('b')
+    // Reader at vt 5 still sees the latest ≤ 5.
+    expect(ts.get('k', 5)).toBe('b')
+  })
+
+  it('(ii) inclusive same-vt visibility: set(k,v,T) then get(k,T) === v', () => {
+    const ts = new TimeState()
+    ts.set('root', 55, 0.5)
+    // A set recorded at vt 0.5 IS visible to a get at exactly vt 0.5.
+    expect(ts.get('root', 0.5)).toBe(55)
+  })
+
+  it('(iii) negative control: get(k, T-ε) reads the pre-T value', () => {
+    const ts = new TimeState()
+    ts.set('root', 52, 0)
+    ts.set('root', 55, 0.5)
+    // Just before the vt-0.5 write, the reader sees the vt-0 value.
+    expect(ts.get('root', 0.5 - 1e-9)).toBe(52)
+    // No entry at or before a vt earlier than the first write → null.
+    expect(ts.get('root', -1)).toBeNull()
+  })
+
+  it('(iv) facade: get(key) latest value, size, clear', () => {
+    const ts = new TimeState()
+    expect(ts.get('note')).toBeUndefined()
+    expect(ts.size).toBe(0)
+    ts.set('note', 60, 0)
+    ts.set('note', 64, 1)
+    // No-vt facade returns the latest value (Map-compatible).
+    expect(ts.get('note')).toBe(64)
+    expect(ts.size).toBe(1)
+    ts.set('other', 1, 0)
+    expect(ts.size).toBe(2)
+    ts.clear()
+    expect(ts.size).toBe(0)
+    expect(ts.get('note')).toBeUndefined()
+  })
+
+  it('(v) set-after-sleep timeline: per-set timestamps keep intra-loop order (SV20)', () => {
+    const ts = new TimeState()
+    // Models `set :x,1; sleep 2; set :x,2` — recorded at T and T+2.
+    ts.set('x', 1, 0)
+    ts.set('x', 2, 2)
+    expect(ts.get('x', 1)).toBe(1) // before the second set
+    expect(ts.get('x', 3)).toBe(2) // after the second set
+  })
+
+  it('(vi) idempotent re-apply: same (key,value,t) does not create a shadow entry', () => {
+    const ts = new TimeState()
+    ts.set('x', 7, 0.5)
+    ts.set('x', 7, 0.5) // deferred interpreter re-apply at the same build vt
+    // Only one effective entry: a later reader still sees 7, and an earlier
+    // write at the same key remains visible at its own vt (no phantom shadow).
+    expect(ts.get('x', 0.5)).toBe(7)
+    // A subsequent distinct write must still register normally.
+    ts.set('x', 9, 1)
+    expect(ts.get('x', 0.5)).toBe(7)
+    expect(ts.get('x', 1)).toBe(9)
+  })
+
+  it('symbol keys are supported (set/get use string|symbol keys)', () => {
+    const ts = new TimeState()
+    const sym = Symbol('root')
+    ts.set(sym, 42, 0)
+    expect(ts.get(sym, 0)).toBe(42)
+    expect(ts.get(sym)).toBe(42)
+  })
+
+  it('out-of-order write is inserted in ascending-t order', () => {
+    const ts = new TimeState()
+    ts.set('k', 'late', 2)
+    ts.set('k', 'early', 1) // arrives after but is timestamped earlier
+    expect(ts.get('k', 1)).toBe('early')
+    expect(ts.get('k', 2)).toBe('late')
+    expect(ts.get('k', 0.5)).toBeNull()
+  })
+})

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Program } from '../Program'
+import { TimeState } from '../TimeState'
 import { normalizePlayParams, normalizeControlParams, normalizeFxParams, resolveSynthName } from '../SoundLayer'
 import { noteToMidi } from '../NoteToFreq'
 
@@ -50,8 +51,16 @@ export interface AudioContext {
    * stacking from overlapping echo/delay/reverb nodes. See issue #70.
    */
   reusableFx: Map<string, ReusableFxState>
-  /** Global store for set/get — deferred set steps write here at runtime. */
-  globalStore?: Map<string | symbol, unknown>
+  /**
+   * Global store for set/get. SP95(d) #350 slice 2: now a virtual-time-indexed
+   * TimeState. The write is applied EAGERLY at build (ProgramBuilder.set), so
+   * the deferred `case 'set'` is a no-op on the TimeState path (Decision Q3 /
+   * option a) — re-applying at interpret vt would write a phantom shadow entry
+   * at a near-but-different vt and reintroduce the stale read #350 closes.
+   * Still typed to permit a plain Map for any non-engine caller; only the
+   * TimeState path is no-op'd.
+   */
+  globalStore?: TimeState | Map<string | symbol, unknown>
   /** Host-provided OSC send handler. If not set, osc_send is a silent no-op. */
   oscHandler?: (host: string, port: number, path: string, ...args: unknown[]) => void
   /** MIDI bridge for deferred midi-out steps (issue #195). */
@@ -253,8 +262,15 @@ export async function runProgram(
         break
 
       case 'set':
-        // Deferred set — fires at runtime, interleaved with sleeps
-        if (ctx.globalStore) {
+        // SP95(d) #350 slice 2: on the TimeState path the write was already
+        // applied EAGERLY at build (ProgramBuilder.set) timestamped by
+        // current_time(); re-applying here at the interpret vt would create a
+        // phantom shadow entry at a near-but-different vt (build vs interpret
+        // arithmetic differ) and reintroduce the stale read (Decision Q3,
+        // option a) — so the deferred apply is a no-op for TimeState. The step
+        // is retained only for SV20/SP41 contract + event-stream/capture. A
+        // plain Map (any non-engine caller) keeps the legacy blind-overwrite.
+        if (ctx.globalStore && !(ctx.globalStore instanceof TimeState)) {
           ctx.globalStore.set(step.key, step.value)
         }
         break


### PR DESCRIPTION
## Summary

Closes the SP95 family — the build-once-vs-async-state boundary where a `live_loop` body could not consume values produced by async steps in the same iteration. Two grounded slices, both Level-3 verified against desktop Sonic Pi:

- **Slice 1 (#351, `402f691`)** — build-time `sync` resolution. `sync` awaits the scheduler-resolved cue payload *during build* (live_loop bodies transpiled `async`) and returns the payload map, so `e = sync :beat; play e[:val]` and arbitrary post-sync logic run with the real value. Grounded in SK15: desktop `sync` is a blocking Promise (which we already have for `sleep`), **not** `wait_for_threads` (a 1ms stub) — which refuted the earlier continuation-split / lazy-thunk guesses.
- **Slice 2 (#350, `e5e13e8`→`0fe871c`)** — time-indexed Time State. The plain-`Map` `globalStore` is replaced with `TimeState.ts`, mirroring desktop's `event_history.rb` (`set` stamps the writer's vt; `get` = "last set whose vt ≤ reader's vt"). Two load-bearing mechanisms: **eager `b.set` apply at build** (causal write-before-read happens-before — the cuer applies its set before yielding) **+ the inclusive time-index** (a cross-loop reader never sees a future write). `get` routed through `b.get` to learn reader vt.

## Verification (Level-3 — `compare-desktop-vs-web.ts --bpm 120`, the verdict)

| reproducer | desktop | web | verdict |
|---|---|---|---|
| r1 director/section (`set`/`sync`/`get`) | `55,59,55,59…` | `55,59,55,59…` | ✅ PITCH-MATCH (×3) |
| r2 same-loop syncgate+crossset | — | — | ✅ PITCH-MATCH (22 notes) |
| r3 cue payload (`cue :x, val:`; `e=sync; play e[:val]`) | `64,67,71,60…` | same | ✅ PITCH-MATCH (22) |
| r4 post-sync conditional (`if e[:n]>60`) | `90,50…` | same | ✅ PITCH-MATCH (22) |

`npx tsc --noEmit` clean · `npx vitest run` **1062** pass (incl. new `TimeState`, `SonicPiEngineTimeState`, `ReorderInvariance`, `SyncCue` suites).

## Invariants & catalogues
- **SV47** → IMPLEMENTED. **SK16** (sync) + new **SK17** (set/get lifecycle). **SP95** / dharana **§26** → RESOLVED. **SV20/SP41** preserved (eager write stamped by `current_time()`, which advances with intra-iteration `sleep`; deferred `{tag:'set'}` step retained, interpreter `case 'set'` no-ops on the TimeState path). **SK14** preserved (store cleared only on dispose). **SV28** (per-body `b.get`, no shared-builder leak).
- **SP95-loud lint retired** — all three patterns now produce correct audio, so the detectors became false positives (SV50 negative-control discipline). The generic warning channel is kept for future lints; `Sp95Lint.test.ts` is now a negative-control suite over the canonical reproducers.

## Known limitation (deferred → #400, Slice 3)
When the two loops are declared in **reversed order**, desktop reads `{52,57}` (declaration-order-dependent **by design** via the `(t,p,i,d)` thread-identity total order at equal virtual time — `event_history.rb:215,542` + `core.rb:114-119`), while web stays self-consistent at `{55,59}` (our wake-phase uses strict-vt-after, which collapses the equal-vt tie). This is a separate wake-phase/event-ordering parity feature, **not** a value-phase defect — grounded + reproduced ×3. `ReorderInvariance.test.ts` documents this and asserts web self-consistency, not desktop parity on the reversed order.

EPIC #392 · closes #350, #351 · defers #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)