### PR TITLE
🐛 fix(engine): with_fx kill_delay waits for inner play release (mod_303_phade)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -125,7 +125,7 @@ export class SonicPiEngine {
    *  dropping the map entries, otherwise the stale callback fires later and
    *  calls freeBus/freeGroup on what are by then NEW live FX resources —
    *  corrupting the bus pool and silently killing groups (issue #290, SP82). */
-  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: { cancel: () => void } }>()
+  private reusableFx = new Map<string, { bus: number; groupId: number; nodeId: number; outBus: number; killTimer?: { cancel: () => void }; aliveUntil: number }>()
   /** Pending volume to apply when bridge initializes */
   private pendingVolume: number | null = null
   /** Stored builder functions for capture/query path */

--- a/src/engine/__tests__/WithFx.test.ts
+++ b/src/engine/__tests__/WithFx.test.ts
@@ -101,6 +101,53 @@ describe('with_fx', () => {
     expect(bridge.calls).toContain('free:16')
   })
 
+  it('with_fx kill_delay waits for inner play release (mod_303_phade — vt-aware aliveUntil)', async () => {
+    // Regression test for the `with_fx { play release: N>1 }` truncation class
+    // (mod_303_phade, official roster). The FX kill was hardcoded at
+    // `vt + killDelay` (default 1.0s) AFTER the block exits — ignoring inner
+    // play's envelope. Desktop SP waits for `tracker.block_until_finished` THEN
+    // sleeps kill_delay (sound.rb:1817-1822). Fix: track `aliveUntil` per FX
+    // scope, extended by each inner play to `vt + attack + decay + sustain +
+    // release`. killAt = max(vt_at_block_exit, aliveUntil) + killDelay.
+    //
+    // Program: with_fx :reverb { play 60, attack:0 decay:0 sustain:0 release:5 }
+    // Expected: aliveUntil = 0 + 0+0+0+5 = 5. killAt = max(0,5) + 1 = 6.
+    // Pre-fix: killAt = 0 + 1 = 1. Assertions at cbHorizon=3 distinguish the two.
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+    })
+    const eventStream = new SoundEventStream()
+    const nodeRefMap = new Map<number, number>()
+    const bridge = createMockBridge()
+
+    const program = new ProgramBuilder(0)
+      .with_fx('reverb', (b) =>
+        b.play(60, { attack: 0, decay: 0, sustain: 0, release: 5 })
+      )
+      .build()
+
+    scheduler.registerLoop('test', async () => {
+      await runProgram(program, makeAudioCtx(scheduler, 'test', eventStream, nodeRefMap, bridge))
+    })
+
+    scheduler.tick(100); await flushMicrotasks()
+    scheduler.tick(100); await flushMicrotasks()
+    expect(bridge.calls).toContain('fx:reverb:in16:out0')
+
+    // cbHorizon=3 — past the BUGGY 1s kill horizon, before the CORRECT 6s one.
+    // Pre-fix this fires the kill (calls.contains 'free:16'); post-fix it does NOT.
+    scheduler.tick(103); await flushMicrotasks()
+    expect(bridge.calls.find(c => c.startsWith('freeNode:'))).toBeUndefined()
+    expect(bridge.calls.find(c => c.startsWith('freeGroup:'))).toBeUndefined()
+    expect(bridge.calls.find(c => c === 'free:16')).toBeUndefined()
+
+    // cbHorizon=100 — well past the 6s correct horizon. FX should be freed now.
+    scheduler.tick(200); await flushMicrotasks()
+    expect(bridge.calls).toContain('freeGroup:5000')
+    expect(bridge.calls).toContain('free:16')
+  })
+
   it('nested FX chains buses correctly', async () => {
     const scheduler = new VirtualTimeScheduler({
       getAudioTime: () => 0,

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -34,6 +34,17 @@ interface ReusableFxState {
    * the setTimeout-based reuse logic).
    */
   killTimer?: { cancel: () => void }
+  /**
+   * Latest virtual time at which any synth dispatched inside this FX scope's
+   * inner block will still be audible (= max over plays/samples of
+   *   playStartVt + attack + decay + sustain + release).
+   * Used to delay FX bus teardown until inner audio has finished, mirroring
+   * desktop SP's `tracker.block_until_finished` THEN `Kernel.sleep(kill_delay)`
+   * sequence in sound.rb:1817-1822. Without this, `with_fx :reverb { play
+   * release: 60 }` truncated web audio at vt + 1 (the killDelay default) while
+   * desktop sustained ~61s — the mod_303_phade regression class.
+   */
+  aliveUntil: number
 }
 
 export interface AudioContext {
@@ -51,6 +62,14 @@ export interface AudioContext {
    * stacking from overlapping echo/delay/reverb nodes. See issue #70.
    */
   reusableFx: Map<string, ReusableFxState>
+  /**
+   * Stack of currently-active with_fx scopes (innermost last), keyed by
+   * `${taskId}:fx${fxIndex}` matching `reusableFx`. Lazily initialised in
+   * `case 'fx'`; absent in paths that never enter an FX. When a play/sample
+   * fires, every enclosing FX's `aliveUntil` is extended so the FX bus
+   * outlives the audible synth (mirrors desktop sound.rb:1817-1822).
+   */
+  currentFxStack?: string[]
   /**
    * Global store for set/get. SP95(d) #350 slice 2: now a virtual-time-indexed
    * TimeState. The write is applied EAGERLY at build (ProgramBuilder.set), so
@@ -162,6 +181,22 @@ export async function runProgram(
             .catch((err: Error) => {
               ctx.printHandler?.(`Synth '${synth}' failed: ${err.message}`)
             })
+
+          // Extend enclosing FX scopes' aliveUntil so the FX bus outlives this
+          // synth's audible envelope. Mirrors desktop sound.rb:1817-1822
+          // (`tracker.block_until_finished` THEN `Kernel.sleep(kill_delay)`).
+          // Uses post-normalization envelope values (BPM-scaled).
+          if (ctx.currentFxStack && ctx.currentFxStack.length > 0) {
+            const a = (params.attack as number | undefined) ?? 0
+            const d = (params.decay as number | undefined) ?? 0
+            const s = (params.sustain as number | undefined) ?? 0
+            const r = (params.release as number | undefined) ?? 1
+            const playEnd = task.virtualTime + a + d + s + r
+            for (const key of ctx.currentFxStack) {
+              const fx = ctx.reusableFx.get(key)
+              if (fx && playEnd > fx.aliveUntil) fx.aliveUntil = playEnd
+            }
+          }
         }
 
         // Emit sound event
@@ -193,6 +228,25 @@ export async function runProgram(
             .catch((err: Error) => {
               ctx.printHandler?.(`Sample '${step.name}' failed: ${err.message}`)
             })
+
+          // Extend enclosing FX scopes' aliveUntil — same rationale as `case 'play'`.
+          // Samples don't go through normalizePlayParams, so we read opts directly.
+          // Without per-sample duration info the estimate is best-effort: env opts
+          // if present, fallback release=1.0 (matches prior behaviour). A long-loop
+          // sample inside with_fx could still be truncated; a richer estimate is a
+          // follow-up.
+          if (ctx.currentFxStack && ctx.currentFxStack.length > 0) {
+            const o = step.opts as Record<string, number> | undefined
+            const a = (o?.attack as number | undefined) ?? 0
+            const d = (o?.decay as number | undefined) ?? 0
+            const s = (o?.sustain as number | undefined) ?? 0
+            const r = (o?.release as number | undefined) ?? 1
+            const playEnd = task.virtualTime + a + d + s + r
+            for (const key of ctx.currentFxStack) {
+              const fx = ctx.reusableFx.get(key)
+              if (fx && playEnd > fx.aliveUntil) fx.aliveUntil = playEnd
+            }
+          }
         }
 
         const audioCtxTime = ctx.bridge?.audioContext?.currentTime ?? 0
@@ -304,6 +358,10 @@ export async function runProgram(
         // Subsequent iterations: reuse the same node — inner synths write
         // to the same bus, FX processes a continuous stream.
         // This prevents additive signal stacking from overlapping echo nodes.
+        // Lazy-init the FX scope stack so non-FX paths pay nothing. Each entry
+        // is a key into `ctx.reusableFx` and lives only for this block's body.
+        const fxStack = (ctx.currentFxStack ??= [])
+
         const existing = ctx.reusableFx.get(fxKey)
         if (existing) {
           // Reuse — cancel pending kill timer, route through existing FX bus
@@ -315,9 +373,16 @@ export async function runProgram(
             ctx.nodeRefMap.set(step.nodeRef, existing.nodeId)
           }
           task.outBus = existing.bus
+          // Reset aliveUntil for THIS iteration's plays/samples; the prior
+          // iteration's value is no longer load-bearing (we just cancelled
+          // that kill timer above). aliveUntil is a floor — `case 'play'`
+          // bumps it up as inner synths dispatch.
+          existing.aliveUntil = task.virtualTime
+          fxStack.push(fxKey)
           try {
             for (let rep = 0; rep < reps; rep++) await runProgram(step.body, ctx, fxCounter)
           } finally {
+            fxStack.pop()
             task.outBus = prevOutBus
             ctx.bridge.flushMessages()
             // Schedule kill in VIRTUAL TIME (SV41) — cancelled if next iter
@@ -333,7 +398,12 @@ export async function runProgram(
             // CREATE branch and own the new state's killTimer.
             if (ctx.reusableFx.get(fxKey) === existing) {
               const killDelay = (step.opts.kill_delay as number) ?? 1.0
-              const killAt = task.virtualTime + killDelay
+              // Wait for inner audio to finish (aliveUntil) THEN add kill_delay —
+              // matches desktop sound.rb:1817-1822 (tracker.block_until_finished
+              // then Kernel.sleep(kill_delay)). Without this, a sustained synth
+              // inside this FX (e.g. `play release: 60`) was truncated to ~1s
+              // (mod_303_phade).
+              const killAt = Math.max(task.virtualTime, existing.aliveUntil) + killDelay
               existing.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
                 // /n_free the FX synth itself — applyFxImmediate puts it in
                 // root group 101 (not the container group), so freeGroup
@@ -362,23 +432,32 @@ export async function runProgram(
             }
             task.outBus = newBus
             ctx.bridge.flushMessages()
-            // Store for reuse — with pending kill timer as safety net
+            // Store for reuse — with pending kill timer as safety net.
+            // aliveUntil starts at the current vt (no plays yet); `case 'play'`
+            // bumps it as inner synths dispatch.
             const state: ReusableFxState = {
               bus: newBus,
               groupId: fxGroupId,
               nodeId: fxNodeId!,
               outBus: prevOutBus,
+              aliveUntil: task.virtualTime,
             }
             ctx.reusableFx.set(fxKey, state)
-            for (let rep = 0; rep < reps; rep++) await runProgram(step.body, ctx, fxCounter)
+            fxStack.push(fxKey)
+            try {
+              for (let rep = 0; rep < reps; rep++) await runProgram(step.body, ctx, fxCounter)
+            } finally {
+              fxStack.pop()
+            }
           } finally {
             task.outBus = prevOutBus
             ctx.bridge.flushMessages()
-            // Schedule kill in VIRTUAL TIME (SV41) — if next iter reuses, cancelled
+            // Schedule kill in VIRTUAL TIME (SV41) — if next iter reuses, cancelled.
+            // killAt = max(vt_at_block_exit, aliveUntil) + killDelay — see reuse branch.
             const killDelay = (step.opts.kill_delay as number) ?? 1.0
             const state = ctx.reusableFx.get(fxKey)
             if (state) {
-              const killAt = task.virtualTime + killDelay
+              const killAt = Math.max(task.virtualTime, state.aliveUntil) + killDelay
               state.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
                 ctx.bridge!.freeNode(state.nodeId)
                 ctx.bridge!.freeGroup(state.groupId)


### PR DESCRIPTION
## Summary

Fixes a class-level bug: `with_fx { play release: N>1 }` truncated web audio at vt+1s while desktop sustained the full envelope. Surfaced today as the **mod_303_phade** roster regression (INCONCL → now ✅ PITCH-MATCH at Level-3). Any sustained synth inside `with_fx` was affected.

## Root cause (grounded)

`AudioInterpreter.ts:378-385` scheduled the FX kill at `task.virtualTime + killDelay` (default 1.0s) when the `with_fx` block exited — **ignoring the inner play's envelope**. Once the FX bus was freed, the synth's audio routed nowhere.

Desktop SP `sound.rb:1817-1822` does the opposite: `tracker.block_until_finished` (waits for ALL inner synth audio to finish), **then** `Kernel.sleep(kill_delay)`, **then** `fx_container_group.kill(true)`. Ours had the "kill_delay" half but was missing the "wait for inner audio" half.

## Fix (approach A — mirror desktop's tracker)

- `ReusableFxState.aliveUntil: number` — virtual-time floor, initialized at FX entry, reset on reuse.
- `InterpreterContext.currentFxStack?: string[]` — lazy stack of active FX scopes (innermost last). Push/pop in `case 'fx'` around the inner `runProgram`.
- `case 'play'` (post `normalizePlayParams`) and `case 'sample'` extend each enclosing FX's `aliveUntil = max(aliveUntil, vt + attack + decay + sustain + release)`.
- Kill scheduling now uses `Math.max(task.virtualTime, state.aliveUntil) + killDelay` in **both** create and reuse branches.

Nested FX scopes propagate correctly because every active key in the stack gets bumped. Play uses post-BPM-normalize params; sample reads opts directly with `release: 1.0` fallback (preserves prior behaviour when envelope opts are absent — a richer per-sample-duration estimate is a follow-up).

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` **1063/1063** (1062 baseline + 1 new `WithFx.test.ts` case: `play release: 5` inside `with_fx`, asserts no `freeNode`/`freeGroup`/`freeBus` at cbHorizon=3 (past buggy 1s horizon, before correct 6s); asserts all three freed at cbHorizon=100). The new test is **red pre-fix** (verified — `freeNode:5001` fires at vt=1).
- **Level-3 mod_303_phade:** INCONCL → ✅ Tier-1 PITCH-MATCH. Desktop 22 onsets / web 21 onsets, all `45` (slicer pulsing a sustained note correctly on both sides). RMS 0.49× ratio is the known web gain-staging, unrelated to this fix.
- **Level-3 isolation reproducer** (`with_fx :reverb { play 50-24, release: 60 }`, no slicer): web RMS profile per 1s shifted from `0.027 0.001 0.000 0.000 0.000…` (dead-at-1s) to `0.027 0.029 0.029 0.029 0.028…` (sustained 11s). Matches desktop's sustain shape.

## Impact on the official launch gate

Re-scoped gate is "≥70% MATCH-or-PRNG-VARIANT on PRNG-free non-heavy official." Before this fix: 2/8 = 25% (`reich_phase`, `driving_pulse`). After: **3/8 = 37.5%** (adds `mod_303_phade`). Still below 70%, but the trend is real-engine-fixes — not instrument leverage — and mod_303_phade was the only one of the 6 INCONCL gate-blockers that we'd identified as a likely real engine bug.

## Follow-ups (not blockers)

- Catalogue update — add a `vyapti` invariant: "FX bus lifetime must outlive its longest inner synth's audible envelope" (deferred until after merge for clean diff).
- Sample envelope estimate is conservative (`release: 1.0` fallback for samples without opts). A long-loop sample inside `with_fx` could still be truncated by ~1s; a per-sample-duration estimate (e.g. reading bridge metadata) would be a small follow-up if anyone hits it.