### PR TITLE
🐛 fix(engine): play_pattern_timed sleeps after final note (#404)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -1258,11 +1258,13 @@ export class ProgramBuilder {
     opts?: Record<string, unknown>
   ): this {
     const timeArr = Array.isArray(times) ? times : [times]
+    // Desktop sound.rb:1281-1287 sleeps after EVERY note, including the last
+    // (`notes.each_with_index { play(note); sleep(duration) }`). Omitting the
+    // final sleep advances (n-1)·dt instead of n·dt — a single-note pattern
+    // would advance zero beats, collapsing the timeline (#404).
     for (let i = 0; i < notes.length; i++) {
       this.play(notes[i], opts)
-      if (i < notes.length - 1) {
-        this.sleep(timeArr[i % timeArr.length])
-      }
+      this.sleep(timeArr[i % timeArr.length])
     }
     return this
   }

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -550,18 +550,27 @@ describe('Pattern helpers (#211 Tier A)', () => {
     expect(steps.filter(s => s.tag === 'sleep').length).toBe(0)
   })
 
-  it('play_pattern_timed cycles through times array', () => {
+  it('play_pattern_timed cycles through times array (sleeps after every note, #404)', () => {
     const b = new ProgramBuilder()
     b.play_pattern_timed([60, 64, 67, 72], [0.25, 0.5])
     const sleeps = b.build().filter(s => s.tag === 'sleep')
-    expect(sleeps.map(s => (s as { tag: 'sleep'; beats: number }).beats)).toEqual([0.25, 0.5, 0.25])
+    // Desktop sound.rb:1281-1287 sleeps after EVERY note (times.ring): n=4 → 4 sleeps
+    expect(sleeps.map(s => (s as { tag: 'sleep'; beats: number }).beats)).toEqual([0.25, 0.5, 0.25, 0.5])
   })
 
-  it('play_pattern_timed accepts scalar time', () => {
+  it('play_pattern_timed accepts scalar time (sleeps after every note, #404)', () => {
     const b = new ProgramBuilder()
     b.play_pattern_timed([60, 64, 67], 0.5)
     const sleeps = b.build().filter(s => s.tag === 'sleep')
-    expect(sleeps.map(s => (s as { tag: 'sleep'; beats: number }).beats)).toEqual([0.5, 0.5])
+    expect(sleeps.map(s => (s as { tag: 'sleep'; beats: number }).beats)).toEqual([0.5, 0.5, 0.5])
+  })
+
+  it('play_pattern_timed single note advances time by its duration (#404 regression)', () => {
+    const b = new ProgramBuilder()
+    b.play_pattern_timed([60], [1.0])
+    const sleeps = b.build().filter(s => s.tag === 'sleep')
+    // Single-note pattern ≡ `play 60; sleep 1.0` — must advance 1.0 beat, not 0
+    expect(sleeps.map(s => (s as { tag: 'sleep'; beats: number }).beats)).toEqual([1.0])
   })
 })
 

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -1413,11 +1413,11 @@ end`)
   sleep 1
 end`)
       expect(error).toBeUndefined()
-      // 3 notes with 2 sleeps between them
+      // 3 notes, a sleep after each (#404), plus the trailing `sleep 1`
       const playSteps = steps.filter((s: any) => s.tag === 'play')
       const sleepSteps = steps.filter((s: any) => s.tag === 'sleep')
       expect(playSteps.length).toBe(3)
-      expect(sleepSteps.length).toBeGreaterThanOrEqual(2)
+      expect(sleepSteps.length).toBeGreaterThanOrEqual(3)
     })
 
     // --- Issue #95: Runtime semantic gap tests ---


### PR DESCRIPTION
## Problem
`play_pattern_timed(notes, times)` sleeps *between* notes but omitted the sleep *after the last* note (`if (i < notes.length - 1)` guard). It advanced virtual time by `(n-1)·dt` instead of `n·dt` — a single-note pattern `play_pattern_timed [60],[1.0]` advanced **zero** beats.

Compositions built from many patterns lost a trailing sleep per call. `sorcerer/bach.rb` (74 `play_pattern_timed` calls) collapsed its 95.5s score to ~57s of web audio, and its right-hand (main thread) vs bass (`in_thread`) parts drifted out of bar-alignment.

This was the real engine defect behind `sorcerer__bach` on the desktop↔web parity gate — previously masked as INCONCL because the onset detector is blind on sustained `:beep` polyphony (#368).

## Root cause
`src/engine/ProgramBuilder.ts` — the `if (i < notes.length - 1)` guard skipped the final sleep.

## Reference (ground truth)
Desktop `sound.rb:1281-1287` loops `play(note); sleep(duration)` over **every** note, no final-note exception. So `play_pattern_timed [60],[1.0]` ≡ `play 60; sleep 1.0`.

## Fix
Sleep after every note (guard removed). `play_pattern` (untimed) was already correct, so the bug was isolated to the timed variant.

## Verification
- **Level-2** reproducer `2.times { ppt [60],[1.0]; ppt [62],[1.0] }` — notes now fire at t=0,1,2,3 (was all four at one instant).
- **Level-3** — bach is deterministic (no PRNG), so the event-log timeline is ground truth for note scheduling. Post-fix it spans **95.2s** (≈ 95.5s score) and section-2 RH start (`note 83`) lands at **t=48.0 / t=72.0** — the exact score anchors (was t=24 pre-fix). Full 95s audio rendered.
- **1064/1064** vitest, tsc clean. Two tests that had codified the off-by-one corrected to desktop semantics; one single-note regression test added.
- **No gate regression** — none of the 3 passing gate rows (reich_phase, driving_pulse, mod_303_phade) use `play_pattern_timed`; bach is the only affected gate row.

## Known non-blocker
bach still reports comparator-INCONCL: the onset detector finds ~3 onsets on desktop's sustained-`:beep` polyphony (#368), and the web capture renders the full composition rather than the 8s window. Both are instrument limitations, not engine defects — filed as follow-up considerations, not part of this fix.

Catalogue: hetvabhasa **SP105**. Closes #404.