### PR TITLE
🐛 fix(engine): note(name, octave: N) honors the octave: opt (#408)

### DIFF
--- a/src/engine/ChordScale.ts
+++ b/src/engine/ChordScale.ts
@@ -279,8 +279,19 @@ export function chord_invert(notes: Ring<number> | number[], inversion: number):
  *
  * note(:c4) → 60
  */
-export function note(n: string | number): number {
-  return noteToMidi(n)
+export function note(n: string | number, opts?: Record<string, unknown>): number {
+  const base = noteToMidi(n)
+  // The `octave:` opt SETS the absolute octave (desktop parity, #408): it
+  // overrides any octave in the name. `note(:F, octave: 2)` → F2 = 41,
+  // identical to the `:F2` literal. C4=60 convention: octave N's C = (N+1)*12.
+  // Without this the opt was silently dropped (note(:F, octave:2) === note(:F)),
+  // playing 2 octaves too high — surfaced by the monday_blues gate reproducer.
+  const octave = opts?.octave
+  if (typeof octave === 'number' && Number.isFinite(octave)) {
+    const pitchClass = ((base % 12) + 12) % 12
+    return (octave + 1) * 12 + pitchClass
+  }
+  return base
 }
 
 /**

--- a/src/engine/__tests__/ChordScale.test.ts
+++ b/src/engine/__tests__/ChordScale.test.ts
@@ -179,6 +179,24 @@ describe('note', () => {
   it('passes through MIDI numbers', () => {
     expect(note(60)).toBe(60)
   })
+
+  // #408 — octave: opt SETS the absolute octave (desktop parity). Without this
+  // the opt was silently dropped, playing 2 octaves too high.
+  it('octave: opt sets the absolute octave', () => {
+    expect(note('F', { octave: 2 })).toBe(41) // F2, identical to :F2 literal
+    expect(note('F')).toBe(65) // F4 default unchanged
+    expect(note('c', { octave: 4 })).toBe(60) // middle C
+    expect(note('c', { octave: 5 })).toBe(72)
+  })
+
+  it('octave: opt overrides an octave already in the name', () => {
+    expect(note('F5', { octave: 2 })).toBe(41) // name octave 5 overridden → F2
+  })
+
+  it('no octave: opt leaves the note unchanged', () => {
+    expect(note('a4', {})).toBe(69)
+    expect(note('a4')).toBe(69)
+  })
 })
 
 describe('note_range', () => {


### PR DESCRIPTION
## Problem
`note(:F, octave: 2)` ignored the `octave:` option — it returned the same as `note(:F)` (65, F4), so web played **2 octaves too high** whenever `note()` was called with `octave:`.

**Directly observed** (desktop↔web sustained-tone probe, onset conf 1 both sides):
```
              note(:F,octave:2)   note(:F)   41
desktop SP:        41 (F2)          65        41
web (before):      65 (F4)  ← BUG   65        41
web (after):       41 (F2)  ✓       65        41
```

## Root cause
`ChordScale.ts` `note(n: string | number)` took **no opts**, so the transpiled `note("F", {octave: 2})` silently dropped the second argument.

## Fix
`note()` accepts opts; when `octave:` is a finite number, resolve to the absolute octave `(octave+1)*12 + (baseMidi % 12)` (C4=60 convention). The opt overrides any octave in the name — `note(:F, octave: 2) == :F2 == 41`.

## Verification
- **Level-3**: desktop↔web probe → PITCH-MATCH (both `41,65,41`). Confirmed via `/s_new` that the full ring (F,C,D,D,G,C,D,D) at octave 2 emits exactly `41,36,38,38,43,...` (F2,C2,D2,D2,G2).
- **1066/1066** vitest (+3 ChordScale tests: octave set, name-octave override, no-opt unchanged). tsc clean.

## How it was found
Surfaced by the monday_blues gate reproducer (#407): both engines produced the exact same melodic contour + rhythm but web was uniformly +24 semitones. The original monday_blues hid this behind a method-asymmetry INCONCL (#376) — the comparator never graded it, so the octave bug shipped silently. Same class as #404/#405 (INCONCL/instrument-blindness masking a real engine defect).

Closes #408.