### PR TITLE
📝 docs: correct false cross-engine PRNG-parity claim (#412)

### DIFF
--- a/docs/DSL-REFERENCE.md
+++ b/docs/DSL-REFERENCE.md
@@ -821,7 +821,7 @@ end
 
 ## 11. Random
 
-All random functions use a seeded Mersenne Twister (MT19937), matching desktop Sonic Pi's deterministic behavior.
+All random functions use a seeded Mersenne Twister (MT19937). They are **deterministic and seed-stable within SonicPi.js** — the same seed always produces the same sequence here. The values are **not** identical to desktop Sonic Pi, though: desktop replays a frozen random-number table rather than a live PRNG, so `choose` / `rrand_i` / etc. draw different elements cross-engine — a randomness-driven piece sounds different from desktop (same shape, different notes). Matching desktop's exact random stream is a deliberate v1 non-goal.
 
 ### `rrand(min, max)`
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -541,7 +541,6 @@ SonicPi.js aims to be compatible with the desktop version's Ruby DSL. Here is wh
 - `play`, `sleep`, `sample`, `live_loop`, `in_thread`
 - `use_synth`, `with_fx`, `use_bpm`
 - `chord`, `scale`, `ring`, `tick`
-- `rrand`, `choose`, `one_in`, `use_random_seed`
 - `sync`, `cue`, `at`, `density`
 - `spread` (Euclidean rhythms)
 - Ruby-style syntax (`:symbols`, `do...end` blocks, `.times`, `.each`)
@@ -549,6 +548,7 @@ SonicPi.js aims to be compatible with the desktop version's Ruby DSL. Here is wh
 **Different:**
 - Runs in the browser using WebAudio + SuperSonic (scsynth compiled to WebAssembly), not a native SuperCollider server.
 - Synth and sample sets are limited to those listed above. Desktop Sonic Pi has a larger library.
+- **Random values differ from desktop.** `rrand`, `choose`, `one_in`, `use_random_seed` etc. are fully deterministic and seed-stable *within* SonicPi.js — the same seed always produces the same sequence here. But the actual values are **not** identical to desktop Sonic Pi: desktop replays a frozen random-number table, while SonicPi.js computes a live Mersenne Twister (MT19937). So a randomness-driven piece (e.g. `play scale(:c, :minor).choose`) sounds *different* from desktop — same shape, different notes. Matching desktop's exact random stream is a deliberate non-goal for v1.
 - Audio latency depends on your browser. Chrome typically performs best.
 - MIDI and OSC output are not yet supported.
 - `run_file` and `load_sample` from disk are not available in the browser.


### PR DESCRIPTION
The 'Differences from Desktop Sonic Pi' docs (launch honesty co-gate) claimed `rrand`/`choose`/`use_random_seed` work the same as desktop. False (SV49/SP98): desktop replays a frozen random table while SonicPi.js computes a live MT19937, so randomness-driven pieces sound different (same shape, different notes). Fix: random is deterministic + seed-stable *within* SonicPi.js but values differ from desktop; matching desktop's exact stream is a deliberate v1 non-goal. Docs-only. Closes #412.