### PR TITLE
🐛 fix(engine): mono samples play centered, not left-channel-only (#414)

### DIFF
--- a/src/engine/SoundLayer.ts
+++ b/src/engine/SoundLayer.ts
@@ -661,15 +661,37 @@ const SIMPLE_SAMPLER_ARGS = new Set([
 
 /**
  * Select the appropriate sample player synthdef.
- * Matches Desktop SP's complex_sampler_args? logic (sound.rb:3462):
- * basic_stereo_player if ALL keys are simple, stereo_player if ANY key is complex.
+ *
+ * Mirrors Desktop SP's `resolve_specific_sampler(num_chans, args_h)`
+ * (sound.rb:3470-3478) — TWO independent axes:
+ *   - opt complexity (complex_sampler_args?, sound.rb:3462): basic vs envelope player
+ *   - sample channel count: mono (1-ch) vs stereo (2-ch) player
+ *
+ *       num_chans == 1                 num_chans == 2 (default)
+ *   ┌─────────────────────────────┬──────────────────────────────┐
+ *   simple │ basic_mono_player     │ basic_stereo_player          │
+ *   complex│ mono_player           │ stereo_player                │
+ *   └─────────────────────────────┴──────────────────────────────┘
+ *
+ * A mono sample MUST use a mono player: the mono players Pan2-center the
+ * 1-channel buffer to both output channels, whereas basic_stereo_player
+ * reads a 2-channel buffer and leaves the right channel silent for a mono
+ * buffer (SP107 / #414 — mono samples played left-channel-only on web).
+ *
+ * numChans defaults to 2 (stereo) so a caller that doesn't yet know the
+ * channel count falls back to today's behavior (no regression).
+ * REF: sound.rb:3470-3478 resolve_specific_sampler, :3462 complex_sampler_args?,
+ * :3498 buf_info.num_chans. synthinfo.rb:5013/5031 — mono/stereo players share
+ * identical arg signatures (inheritance), so this is a pure synthdef-name swap.
  */
-export function selectSamplePlayer(opts?: Record<string, number>): string {
-  if (!opts) return 'sonic-pi-basic_stereo_player'
-  for (const key of Object.keys(opts)) {
-    if (!SIMPLE_SAMPLER_ARGS.has(key)) {
-      return 'sonic-pi-stereo_player'
-    }
+export function selectSamplePlayer(
+  opts?: Record<string, number>,
+  numChans: number = 2,
+): string {
+  const complex = opts !== undefined &&
+    Object.keys(opts).some((key) => !SIMPLE_SAMPLER_ARGS.has(key))
+  if (complex) {
+    return numChans === 1 ? 'sonic-pi-mono_player' : 'sonic-pi-stereo_player'
   }
-  return 'sonic-pi-basic_stereo_player'
+  return numChans === 1 ? 'sonic-pi-basic_mono_player' : 'sonic-pi-basic_stereo_player'
 }

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -1262,6 +1262,7 @@ export class SuperSonicBridge {
   freeSample(name: string): boolean {
     const had = this.loadedSamples.delete(name)
     this.sampleDurations.delete(name)
+    this.sampleChannels.delete(name)
     return had
   }
 
@@ -1270,6 +1271,7 @@ export class SuperSonicBridge {
     const count = this.loadedSamples.size
     this.loadedSamples.clear()
     this.sampleDurations.clear()
+    this.sampleChannels.clear()
     return count
   }
 
@@ -1357,5 +1359,8 @@ export class SuperSonicBridge {
     }
     this.loadedSynthDefs.clear()
     this.loadedSamples.clear()
+    this.sampleDurations.clear()
+    this.sampleChannels.clear()
+    this.pendingSampleChannels.clear()
   }
 }

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -109,7 +109,9 @@ const COMMON_SYNTHDEFS = [
   'sonic-pi-pretty_bell',
   'sonic-pi-piano',
   'sonic-pi-basic_stereo_player',
-  // Note: sonic-pi-stereo_player is NOT in the CDN (404). Loaded lazily on demand.
+  // The other sample players load lazily on first use (cached in loadedSynthDefs):
+  // sonic-pi-stereo_player (complex stereo), and — for mono samples (SP107/#414) —
+  // sonic-pi-basic_mono_player / sonic-pi-mono_player.
 ]
 
 
@@ -129,6 +131,15 @@ export class SuperSonicBridge {
   private pendingSampleLoads = new Map<string, Promise<number>>()
   /** Sample duration cache — populated asynchronously on first load via Web Audio decode. */
   private sampleDurations = new Map<string, number>()
+  /**
+   * Sample channel-count cache — populated by the same Web Audio decode that
+   * fills sampleDurations. Drives mono-vs-stereo player selection (SP107/#414):
+   * a 1-channel sample MUST use a mono player or it plays left-channel-only.
+   * Mirrors Desktop SP's buf_info.num_chans (sound.rb:3498).
+   */
+  private sampleChannels = new Map<string, number>()
+  /** In-flight channel-count decodes — dedup so concurrent plays don't double-fetch. */
+  private pendingSampleChannels = new Map<string, Promise<number>>()
   // Pinned to @0.57.0 to match the runtime SuperSonic version (SV22:
   // CDN packages must pin together). The init() override at line 213
   // sets this from options or to the same pinned URL — this default
@@ -644,15 +655,58 @@ export class SuperSonicBridge {
    * Decode the sample via Web Audio to get its exact duration in seconds.
    * Fires once per sample name and caches the result.
    * Used by beat_stretch / pitch_stretch to apply Sonic Pi's exact formula.
+   *
+   * Side effect: also caches the channel count (sampleChannels), which drives
+   * mono-vs-stereo player selection. The single decode populates both maps.
    */
   private async fetchSampleDuration(name: string): Promise<void> {
     if (this.sampleDurations.has(name)) return
-    if (!this.sonic) return
+    await this.decodeSampleMetadata(name)
+  }
+
+  /**
+   * Fetch + decode a sample once, caching BOTH its duration and channel count.
+   * Deduped via pendingSampleChannels so concurrent first-plays don't double-fetch.
+   * Returns the channel count (the value the player-selection path needs).
+   */
+  private decodeSampleMetadata(name: string): Promise<number> {
+    const cached = this.sampleChannels.get(name)
+    if (cached !== undefined) return Promise.resolve(cached)
+    const inflight = this.pendingSampleChannels.get(name)
+    if (inflight) return inflight
+    if (!this.sonic) return Promise.resolve(2)
+
     const url = `${this.resolvedSampleBaseURL}${name}.flac`
-    const response = await fetch(url)
-    const arrayBuffer = await response.arrayBuffer()
-    const audioBuffer = await this.sonic.audioContext.decodeAudioData(arrayBuffer)
-    this.sampleDurations.set(name, audioBuffer.duration)
+    const p = fetch(url)
+      .then((response) => response.arrayBuffer())
+      .then((arrayBuffer) => this.sonic!.audioContext.decodeAudioData(arrayBuffer))
+      .then((audioBuffer) => {
+        this.sampleDurations.set(name, audioBuffer.duration)
+        this.sampleChannels.set(name, audioBuffer.numberOfChannels)
+        return audioBuffer.numberOfChannels
+      })
+      .finally(() => {
+        // SV43: clear the in-flight dedup entry on resolve OR reject so a
+        // later play can re-attempt rather than replay a dead rejection.
+        this.pendingSampleChannels.delete(name)
+      })
+    this.pendingSampleChannels.set(name, p)
+    return p
+  }
+
+  /**
+   * Resolve the sample's channel count for player selection, mirroring
+   * Desktop SP's buf_info.num_chans (sound.rb:3498) which is known
+   * synchronously before resolve_specific_sampler runs.
+   *
+   * Defaults to 2 (stereo) if the decode fails — same as today's behavior,
+   * so a CORS/404/decode error never breaks playback (it just keeps the
+   * pre-#414 stereo-player path). REF: SP107/#414.
+   */
+  private ensureSampleChannels(name: string): Promise<number> {
+    const cached = this.sampleChannels.get(name)
+    if (cached !== undefined) return Promise.resolve(cached)
+    return this.decodeSampleMetadata(name).catch(() => 2)
   }
 
   /**
@@ -744,16 +798,22 @@ export class SuperSonicBridge {
   ): Promise<number> {
     if (!this.sonic) throw new Error('SuperSonic not initialized')
 
-    const playerName = selectSamplePlayer(opts)
     const bufNum = this.loadedSamples.get(sampleName)
+    const numChans = this.sampleChannels.get(sampleName)
 
-    // Fast path: sample loaded + synthdef loaded — skip async entirely
-    if (bufNum !== undefined && this.loadedSynthDefs.has(playerName)) {
-      return Promise.resolve(this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm))
+    // Fast path: sample loaded + channel count known + player synthdef loaded.
+    // Player selection needs the channel count (mono vs stereo, SP107/#414),
+    // so both bufNum AND numChans must be cached to skip async.
+    if (bufNum !== undefined && numChans !== undefined) {
+      const playerName = selectSamplePlayer(opts, numChans)
+      if (this.loadedSynthDefs.has(playerName)) {
+        return Promise.resolve(this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm))
+      }
     }
 
-    // Slow path: load sample/synthdef first (only happens once per sample name)
-    return this.playSampleSlow(sampleName, playerName, audioTime, opts, bpm)
+    // Slow path: load sample + decode channel count + load synthdef first
+    // (only happens once per sample name / player synthdef).
+    return this.playSampleSlow(sampleName, audioTime, opts, bpm)
   }
 
   private playSampleImmediate(
@@ -828,13 +888,23 @@ export class SuperSonicBridge {
 
   private async playSampleSlow(
     sampleName: string,
-    playerName: string,
     audioTime: number,
     opts?: Record<string, number>,
     bpm?: number,
   ): Promise<number> {
-    const bufNum = await this.ensureSampleLoaded(sampleName)
-    if (playerName !== 'sonic-pi-basic_stereo_player') {
+    // Load the buffer and decode its channel count before selecting the
+    // player — mirrors Desktop SP, which knows buf_info.num_chans before
+    // resolve_specific_sampler runs (sound.rb:3496-3498). Without the channel
+    // count, a mono sample would route through basic_stereo_player and play
+    // left-channel-only (SP107/#414).
+    const [bufNum, numChans] = await Promise.all([
+      this.ensureSampleLoaded(sampleName),
+      this.ensureSampleChannels(sampleName),
+    ])
+    const playerName = selectSamplePlayer(opts, numChans)
+    // basic_stereo_player is pre-loaded at bootstrap; mono players and the
+    // complex stereo_player load lazily on first use (cached in loadedSynthDefs).
+    if (!this.loadedSynthDefs.has(playerName)) {
       await this.ensureSynthDefLoaded(playerName)
     }
     return this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm)

--- a/src/engine/__tests__/SoundLayer.test.ts
+++ b/src/engine/__tests__/SoundLayer.test.ts
@@ -516,6 +516,37 @@ describe('selectSamplePlayer', () => {
   it('returns stereo_player for norm', () => {
     expect(selectSamplePlayer({ norm: 1 })).toBe('sonic-pi-stereo_player')
   })
+
+  // Channel-count axis (SP107 / #414) — mirrors Desktop SP resolve_specific_sampler
+  // (sound.rb:3470-3478). A mono (1-ch) sample MUST use a mono player or it plays
+  // left-channel-only. numChans defaults to 2 (no regression for callers that omit it).
+  describe('channel-count axis (mono vs stereo player)', () => {
+    it('mono + simple opts → basic_mono_player', () => {
+      expect(selectSamplePlayer({ rate: 0.8 }, 1)).toBe('sonic-pi-basic_mono_player')
+    })
+
+    it('mono + no opts → basic_mono_player', () => {
+      expect(selectSamplePlayer(undefined, 1)).toBe('sonic-pi-basic_mono_player')
+    })
+
+    it('mono + complex opts → mono_player', () => {
+      expect(selectSamplePlayer({ pitch: 2 }, 1)).toBe('sonic-pi-mono_player')
+      expect(selectSamplePlayer({ start: 0.2, finish: 0.8 }, 1)).toBe('sonic-pi-mono_player')
+    })
+
+    it('stereo + simple opts → basic_stereo_player', () => {
+      expect(selectSamplePlayer({ rate: 0.8 }, 2)).toBe('sonic-pi-basic_stereo_player')
+    })
+
+    it('stereo + complex opts → stereo_player', () => {
+      expect(selectSamplePlayer({ pitch: 2 }, 2)).toBe('sonic-pi-stereo_player')
+    })
+
+    it('defaults to stereo when numChans is omitted (back-compat, no regression)', () => {
+      expect(selectSamplePlayer({ rate: 0.8 })).toBe('sonic-pi-basic_stereo_player')
+      expect(selectSamplePlayer({ pitch: 2 })).toBe('sonic-pi-stereo_player')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Mono samples (e.g. `:drum_heavy_kick`) rendered to the **left channel only** on web — the right channel was silent. `selectSamplePlayer` chose the player by opt-complexity alone and never by the sample's channel count, so a 1-channel buffer went through `basic_stereo_player` (which expects a 2-channel buffer) and left the right output empty.

A/B vs desktop (kick isolated): web **L=0.109 / R=0.000** vs desktop **L=R=0.2265** (centered). When downstream analysis mono-averages, a left-only mono kick is halved relative to centered synth layers — tilting the spectral balance of any mono-sample-dominated material. This was the real root cause of SP107 (`monday_blues` sub-share collapse 84.7% → 30.2%); both previously-hypothesised candidates (uniform gain, sub-band rendering/filter) were refuted by the per-channel measurement.

## Fix

Mirrors Desktop SP's `resolve_specific_sampler(num_chans, args_h)` (`sound.rb:3470-3478`) — adds the **channel-count axis** that was missing:

- `selectSamplePlayer(opts, numChans = 2)` → `basic_mono_player`/`mono_player` for 1-channel samples, `basic_stereo_player`/`stereo_player` for 2-channel. `numChans` defaults to 2 so callers that omit it keep today's behavior (**no regression**).
- `SuperSonicBridge` caches `audioBuffer.numberOfChannels` from the **existing** `decodeAudioData` (new `sampleChannels` map, deduped via `pendingSampleChannels`) and resolves it **before** player selection — matching desktop's buf_info.num_chans-known-before-resolve ordering (`sound.rb:3496-3498`).
- Mono synthdefs lazy-load via the existing `ensureSynthDefLoaded` (both confirmed present in CDN `@0.57.0`).
- On decode failure, `ensureSampleChannels` falls back to stereo (= pre-fix behavior — degrades to left-only, never to no-audio).

`basic_mono_player` and `basic_stereo_player` share identical arg signatures (`synthinfo.rb:5013` inheritance), so this is a **pure synthdef-name swap** with zero param-translation change.

## Test plan

- **Unit:** `1073/1073` vitest (+6 new channel-axis tests on `selectSamplePlayer`), `tsc --noEmit` clean.
- **Level-3 (audio observation):**
  - Web kick R-channel **0.000 → 0.1090** (centered, matches desktop L=R); per-band shape **83.7% sub** ≈ desktop 82.5%; kick MFCC **200.4 → 161.3**.
  - `monday_blues`: **L2 31.17 → 9.34**, **MFCC 259.75 → 106.21**; same-run per-band sub-share gap desktop↔web **54pt → 4.6pt** (web 30.2% → 46.3% tracking desktop 50.9%).
  - Launch gate stays **5/7 = 71.4% PASS** (no regression).

The remaining per-channel 0.48× level is the separate, deliberate global WASM/native gain gap (#268), not this bug.

Catalogues: hetvabhasa **SP107** (OPEN → IMPLEMENTED), vyapti **SV54** (new invariant — player selection must account for channel count).

closes #414