### PR TITLE
🐛 fix(transpiler): top-level use_synth honored by live_loop with trailing bare code (#419)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ test_results/e2e.html
 test_results/community/
 test_results/community.html
 test_results/raw-lpf/
+# SP107 mono-sample investigation captures (≈10 MB WAVs + PNGs). The viewer
+# mono-sample-sp107.html is checked in; the recordings regenerate via
+# tools/compare-desktop-vs-web.ts. See the page footer for the commands.
+test_results/sp107/
 
 # Playwright
 playwright-report/

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -944,6 +944,19 @@ const BARE_DSL_CALLS = new Set([
 // collapse all plays to the last use_synth value (#164).
 const TOP_LEVEL_SETTINGS = new Set(['use_bpm', 'use_random_seed', 'use_debug', 'use_arg_bpm_scaling'])
 
+// #419/SV55: extract a literal synth name from a `use_synth :X` / `use_synth "X"`
+// call. Returns the bare name for a literal symbol/string arg, or null for a
+// non-literal (runtime expression) arg — in which case the synth cannot be
+// known at build time and NO eager prefix may be emitted (do not guess).
+function extractLiteralSynthArg(callNode: any): string | null {
+  const argsNode = callNode.childForFieldName('arguments')
+  const argNode = argsNode?.namedChildren?.[0]
+  if (!argNode) return null
+  if (argNode.type === 'simple_symbol') return argNode.text.slice(1)
+  if (argNode.type === 'string') return argNode.text.replace(/['"]/g, '')
+  return null
+}
+
 function transpileProgram(node: any, ctx: TranspileContext): string {
   const children = node.namedChildren
 
@@ -988,6 +1001,14 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   const bareCode: any[] = []
   const blocks: any[] = []
 
+  // #419/SV55: track the top-level `use_synth` in SOURCE ORDER so each block
+  // inherits the synth in effect at its definition point (desktop fork-snapshot
+  // parity, runtime.rb:1067). `blockSynth` tags each registration-capturing
+  // block with the synth that was current when it appeared. use_synth still
+  // flows to bareCode (deferred) for bare-play interleave — this only records.
+  let currentTopSynth: string | null = null
+  const blockSynth = new Map<any, string | null>()
+
   for (const child of children) {
     if (child.type === 'comment') {
       bareCode.push(child)
@@ -996,6 +1017,12 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     const method = (child.type === 'call' || child.type === 'method_call')
       ? (child.childForFieldName('method')?.text ?? child.namedChildren[0]?.text)
       : null
+
+    // #419/SV55: a top-level `use_synth` advances the source-order synth. A
+    // non-literal arg yields null (unknowable at build time → no eager prefix).
+    if (method === 'use_synth') {
+      currentTopSynth = extractLiteralSynthArg(child)
+    }
 
     // Bare with_fx (no live_loop inside) should be treated as bare code, not a block
     const isBareFxNode = method === 'with_fx' && !/live_loop/.test(child.text ?? '')
@@ -1014,6 +1041,7 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     } else if (method && !isBareFxNode && (method === 'live_loop' || method === 'define' || method === 'ndefine' || method === 'defonce' || method === 'with_fx' ||
                           method === 'in_thread' || isBareLoopNode)) {
       blocks.push(child)
+      blockSynth.set(child, currentTopSynth)
     } else {
       bareCode.push(child)
     }
@@ -1055,20 +1083,36 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   // (SV16 — bare code runs once, not forever; `loop do` is its own forever
   // live_loop, not fall-through-to-`__run_once` bare code).
   let topLoopCounter = 0
+  // #419/SV55: tracks the last EAGER use_synth value emitted, so a run of
+  // loops sharing the same source-order synth emits the prefix only once
+  // (defaultSynth persists across registrations at runtime).
+  let lastEagerSynth: string | null = null
   const blockJS = blocks.map(c => {
     const m = (c.type === 'call' || c.type === 'method_call')
       ? (c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text)
       : null
+    // #419/SV55: emit an eager top-level `use_synth("X")` (→ topLevelUseSynth →
+    // defaultSynth) immediately before registration-capturing blocks so the
+    // loop registers with the source-order synth (SonicPiEngine.ts:879).
+    // Restricted to live_loop / auto-named bare loop — in_thread inheritance is
+    // owned by SP72's parentBuilder path (SV28), not the eager prefix. Skipped
+    // for non-literal args (tagged === null) and when the value is unchanged.
+    const tagged = blockSynth.get(c) ?? null
+    let eagerPrefix = ''
+    if (tagged !== null && (m === 'live_loop' || m === 'loop') && tagged !== lastEagerSynth) {
+      eagerPrefix = `use_synth(${JSON.stringify(tagged)})\n`
+      lastEagerSynth = tagged
+    }
     if (m === 'loop') {
       const body = c.namedChildren.find((x: any) => x.type === 'do_block' || x.type === 'block')
       if (body) {
         const bodyCtx: TranspileContext = { ...ctx, insideLoop: true, asyncBody: true }
         const bodyStr = transpileBlockBody(body, bodyCtx)
         const name = `__loop_${topLoopCounter++}`
-        return `live_loop("${name}", async (__b) => {\n${bodyStr}\n${ctx.indent}})`
+        return `${eagerPrefix}live_loop("${name}", async (__b) => {\n${bodyStr}\n${ctx.indent}})`
       }
     }
-    return transpileNode(c, ctx)
+    return eagerPrefix + transpileNode(c, ctx)
   }).filter(Boolean)
 
   const parts: string[] = []

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest'
-import { initTreeSitter, treeSitterTranspile, isTreeSitterReady } from '../TreeSitterTranspiler'
+import { initTreeSitter, treeSitterTranspile, isTreeSitterReady, autoTranspile } from '../TreeSitterTranspiler'
 import { ProgramBuilder } from '../ProgramBuilder'
 import { ring } from '../Ring'
 import { spread } from '../EuclideanRhythm'
@@ -129,6 +129,160 @@ end`)
       expect(result.code).toContain('use_synth("prophet")')
       // Inside the loop, play gets b. prefix
       expect(result.code).toContain('b.play(60')
+    })
+
+    // #419 / SV55 — a top-level `use_synth :X` placed BEFORE a `live_loop`
+    // must make that loop register with synth :X, even when bare top-level
+    // code FOLLOWS the loop (which triggers the __run_once split and defers
+    // use_synth into the wrapper, leaving the loop to register with :beep).
+    // Desktop parity: in_thread/live_loop snapshots `current_synth` at its
+    // source position in sequential order (runtime.rb:1067). The transpiler
+    // restores this by emitting an EAGER top-level use_synth("X") (routes to
+    // topLevelUseSynth → defaultSynth) immediately before the loop registers.
+    describe('#419 / SV55: top-level use_synth honored by live_loop with trailing bare code', () => {
+      // Helper: index of an eager (no `__b.`/`b.` prefix) top-level call.
+      const eagerIdx = (code: string, call: string) => {
+        const re = new RegExp(`(^|[^.\\w])${call.replace(/[()]/g, '\\$&')}`, 'm')
+        const m = re.exec(code)
+        return m ? m.index : -1
+      }
+
+      it('T-A: emits eager use_synth("saw") before live_loop("s") (the bug)', () => {
+        const result = treeSitterTranspile(`use_synth :saw
+live_loop :s do
+  play :E3
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const loopIdx = result.code.indexOf('live_loop("s"')
+        const sawIdx = eagerIdx(result.code, 'use_synth("saw")')
+        expect(sawIdx).toBeGreaterThanOrEqual(0)
+        expect(loopIdx).toBeGreaterThanOrEqual(0)
+        // Eager (top-level) use_synth must precede the loop registration.
+        expect(sawIdx).toBeLessThan(loopIdx)
+      })
+
+      it('T-B: multi-loop — each loop prefixed with its source-order synth', () => {
+        const result = treeSitterTranspile(`use_synth :saw
+live_loop :a do
+  play 60
+  sleep 1
+end
+use_synth :tb303
+live_loop :b do
+  play 64
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const aIdx = result.code.indexOf('live_loop("a"')
+        const bIdx = result.code.indexOf('live_loop("b"')
+        const sawIdx = result.code.indexOf('use_synth("saw")\nlive_loop("a"')
+        const tbIdx = result.code.indexOf('use_synth("tb303")\nlive_loop("b"')
+        // saw prefixes loop a, tb303 prefixes loop b (in source order).
+        expect(sawIdx).toBeGreaterThanOrEqual(0)
+        expect(tbIdx).toBeGreaterThanOrEqual(0)
+        expect(sawIdx).toBeLessThan(aIdx)
+        expect(tbIdx).toBeLessThan(bIdx)
+        expect(aIdx).toBeLessThan(tbIdx)
+      })
+
+      it('T-C: loop BEFORE use_synth is NOT prefixed (snapshot is forward-only)', () => {
+        const result = treeSitterTranspile(`live_loop :a do
+  play 60
+  sleep 1
+end
+use_synth :saw
+sleep 5`)
+        expect(result.ok).toBe(true)
+        // No eager use_synth("saw") should precede live_loop("a").
+        expect(result.code).not.toContain('use_synth("saw")\nlive_loop("a"')
+        const loopIdx = result.code.indexOf('live_loop("a"')
+        const sawEager = eagerIdx(result.code, 'use_synth("saw")')
+        // Either no eager use_synth at all, or it comes AFTER the loop.
+        expect(sawEager === -1 || sawEager > loopIdx).toBe(true)
+      })
+
+      it('T-D: non-literal use_synth arg → no eager prefix, no crash', () => {
+        const result = treeSitterTranspile(`use_synth foo
+live_loop :a do
+  play 60
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        // foo is not a literal symbol/string — cannot resolve at build time.
+        expect(result.code).not.toContain('use_synth("foo")')
+        expect(result.code).not.toContain('use_synth(foo)\nlive_loop("a"')
+        // Output must still be valid JS.
+        expect(() => new Function(result.code)).not.toThrow()
+      })
+
+      it('T-E (engine): live_loop registers with currentSynth = source-order synth', () => {
+        const code = autoTranspile(`use_synth :saw
+live_loop :s do
+  play :E3
+  sleep 1
+end
+sleep 5`)
+        // Minimal harness mirroring SonicPiEngine: live_loop reads the synth
+        // in effect (defaultSynth) at registration time (SonicPiEngine.ts:879).
+        const registrations: Record<string, string> = {}
+        let defaultSynth = 'beep'
+        const use_synth = (name: string) => { defaultSynth = name }
+        const use_bpm = (_n: number) => {}
+        const live_loop = (name: string, _fn: unknown) => {
+          // Capture synth at registration — do NOT invoke the body (the real
+          // builderFn runs per-iteration, not at registration).
+          registrations[name] = defaultSynth
+        }
+        const fn = new Function('use_synth', 'use_bpm', 'live_loop',
+          `return (async () => {\n${code}\n})();`)
+        return fn(use_synth, use_bpm, live_loop).then(() => {
+          expect(registrations['s']).toBe('saw')
+        })
+      })
+
+      it('T-F (regression SP36/#164): bare-play interleave preserved inside __run_once', () => {
+        const result = treeSitterTranspile(`use_synth :saw
+play 60
+use_synth :beep
+play 64
+sleep 1`)
+        expect(result.ok).toBe(true)
+        // No live_loop blocks here → no eager hoist; both use_synth stay
+        // inline (as __b.use_synth) in source order inside __run_once.
+        const code = result.code
+        const s1 = code.indexOf('__b.use_synth("saw")')
+        const p1 = code.indexOf('__b.play(60')
+        const s2 = code.indexOf('__b.use_synth("beep")')
+        const p2 = code.indexOf('__b.play(64')
+        expect(s1).toBeGreaterThanOrEqual(0)
+        expect(s1).toBeLessThan(p1)
+        expect(p1).toBeLessThan(s2)
+        expect(s2).toBeLessThan(p2)
+        // And no eager top-level use_synth hoisted above the wrapper.
+        const wrapperStart = code.indexOf('live_loop("__run_once"')
+        expect(eagerIdx(code.slice(0, wrapperStart), 'use_synth(')).toBe(-1)
+      })
+
+      it('T-G (regression SP72): use_synth inside in_thread does NOT leak to eager top-level', () => {
+        const result = treeSitterTranspile(`in_thread do
+  use_synth :tb303
+  live_loop :inner do
+    play 60
+    sleep 1
+  end
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        // use_synth is inside the in_thread body (emitted as __b.use_synth),
+        // not top-level → no EAGER top-level use_synth("tb303") emitted (the
+        // SP72 parentBuilder path owns this inheritance, not the eager prefix).
+        const eagerTb = eagerIdx(result.code, 'use_synth("tb303")')
+        expect(eagerTb).toBe(-1)
+      })
     })
 
     // Regression for #163 — `synth :NAME, note: 60` used to transpile to

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -571,7 +571,7 @@
       <a href="community.html">community + forum <span class="count">48</span></a>
       <a href="launch-gate.html">🚦 Launch Gate <span class="count">5/7</span></a>
       <span class="spacer"></span>
-      <span class="meta"><a href="raw-lpf.html">raw-lpf investigation</a></span>
+      <span class="meta"><a href="mono-sample-sp107.html">SP107 mono-sample investigation</a> · <a href="raw-lpf.html">raw-lpf investigation</a></span>
     </nav>
     <div class="app">
       <aside class="sidebar">
@@ -598,7 +598,7 @@
             <br>
             <a href="community.html">community.html</a> — <b>48 community + forum compositions</b> (28 community, 20 in-thread-forum); 46/48 captured, median RMS× 0.78 / peak× 0.94 / MFCC 161. Outliers cluster into two upstream-WASM classes: feedback-FX over-amplification (e.g. <code>19_ambient_lead</code> 10.8×, <code>47_fibonacci_zoomies</code> 4.7×) and heavy-filter-chain attenuation (e.g. <code>43_exploring_tb303</code> 0.09×, <code>33_dub_reverb</code> 0.10×).
             <br>
-            <b>Investigation:</b> <a href="raw-lpf.html">raw-lpf.html</a> — 7-pass empirical evidence page (SP72 / SP74 / SP75 lineage).
+            <b>Investigations:</b> <a href="raw-lpf.html">raw-lpf.html</a> — 7-pass empirical evidence page (SP72 / SP74 / SP75 lineage); <a href="mono-sample-sp107.html">mono-sample-sp107.html</a> — SP107 end-to-end (mono samples played left-channel-only → centered; PR #415), with before/after recordings + per-channel waveforms.
           </div>
           <div class="controls">
             <input

--- a/test_results/launch-gate.html
+++ b/test_results/launch-gate.html
@@ -29,6 +29,7 @@
     <a href="e2e.html">E2E suite</a>
     <a href="community.html">community + forum</a>
     <a href="launch-gate.html" data-active="1">🚦 Launch Gate</a>
+    <a href="mono-sample-sp107.html" style="margin-left:auto">SP107 mono-sample fix →</a>
   </nav>
   <div class="wrap">
     <h1>Launch Gate — PRNG-free non-heavy official roster</h1>

--- a/test_results/mono-sample-sp107.html
+++ b/test_results/mono-sample-sp107.html
@@ -156,7 +156,7 @@
           <li><b>The measurement trap:</b> the prior session's "0.24× attenuated kick" was an artifact of mono-averaging a left-only signal. Reading L and R <em>separately</em> revealed <code>R=0</code> — a channel bug masquerading as a gain bug.</li>
           <li><b>Root cause:</b> <code>selectSamplePlayer(opts)</code> branched only on opt-complexity; it never read the sample's channel count. Desktop's <code>resolve_specific_sampler(num_chans, args_h)</code> (sound.rb:3470-3478) picks <code>basic_mono_player</code> for 1-channel samples (which Pan2-centers).</li>
           <li><b>The fix (PR #415):</b> add the channel-count axis — cache <code>audioBuffer.numberOfChannels</code> from the existing decode, resolve it before player selection, use mono players for mono samples. Pure synthdef-name swap; zero param-translation change; defaults to stereo (no regression).</li>
-          <li><b>Verified Level-3:</b> web kick R-channel <b class="ratio-good">0.000 → 0.1090</b> (centered); <code>monday_blues</code> <b class="ratio-good">L2 31.2→9.3, MFCC 260→106</b>; launch gate stays <b>5/7 = 71.4% PASS</b>.</li>
+          <li><b>Verified Level-3:</b> web kick R-channel <b class="ratio-good">0.000 → 0.1090</b> (centered, deterministic); full <code>monday_blues</code> <b class="ratio-good">L2 31.2→14.0, MFCC 260→119</b>; launch gate stays <b>5/7 = 71.4% PASS</b>.</li>
         </ol>
       </div>
 
@@ -269,16 +269,22 @@
           <tr><td>MFCC dist (vs desktop)</td><td class="num">—</td><td class="num ratio-mid">200.4</td><td class="num ratio-good">161.3</td></tr>
         </tbody>
       </table>
-      <p class="col-label" style="margin-top:18px">monday_blues — the original symptom</p>
+      <p class="col-label" style="margin-top:18px">monday_blues — the original symptom (full composition, the code below)</p>
       <table class="metrics">
         <thead><tr><th>Metric</th><th class="num">Before fix</th><th class="num">After fix</th></tr></thead>
         <tbody>
-          <tr><td>L2 (mel-dB) vs desktop</td><td class="num ratio-bad">31.17</td><td class="num ratio-good">9.34</td></tr>
-          <tr><td>MFCC dist vs desktop</td><td class="num ratio-bad">259.75</td><td class="num ratio-good">106.21</td></tr>
-          <tr><td>Sub-share gap (desktop↔web, same run)</td><td class="num ratio-bad">54 pt</td><td class="num ratio-good">4.6 pt</td></tr>
-          <tr><td>Web sub &lt;80 Hz share</td><td class="num ratio-bad">30.2%</td><td class="num ratio-good">46.3%</td></tr>
+          <tr><td>L2 (mel-dB) vs desktop</td><td class="num ratio-bad">31.17</td><td class="num ratio-good">13.99</td></tr>
+          <tr><td>MFCC dist vs desktop</td><td class="num ratio-bad">259.75</td><td class="num ratio-good">119.02</td></tr>
+          <tr><td>Sub-share gap (desktop↔web, same run)</td><td class="num ratio-bad">54 pt</td><td class="num ratio-good">1.6 pt</td></tr>
+          <tr><td>Web sub &lt;80 Hz share (vs desktop, same run)</td><td class="num ratio-bad">30.2%</td><td class="num ratio-good">40.2% (vs 38.6%)</td></tr>
         </tbody>
       </table>
+      <div class="lede" style="margin-top:8px; font-size:12.5px">
+        <b>Honesty note:</b> the kick-isolated R-channel (0.000→0.1090) is the <em>deterministic</em> proof — exact, repeatable.
+        The full-composition L2/MFCC and per-band absolutes are <em>run-to-run noisy</em> (three live_loops at 0.5/1.0/1.0&nbsp;beat
+        periods phase differently against the 8&nbsp;s capture window), so read them as corroborating direction, not exact deltas.
+        The "before" figures are the 2026-05-29 full-composition capture; "after" is the run traced below.
+      </div>
 
       <h2 id="mb-audio">monday_blues — after the fix (A/B)</h2>
       <div class="sync-bar">
@@ -298,7 +304,87 @@
       </div>
       <div class="png-block" style="margin-top:12px">
         <img src="sp107/monday-blues-spectrogram.png" alt="monday_blues spectrogram desktop vs web after fix" />
-        <div class="png-cap">monday_blues spectrogram — desktop vs web (after fix). L2 9.34 / MFCC 106.21.</div>
+        <div class="png-cap">Full monday_blues spectrogram — desktop vs web (after fix). L2 13.99 / MFCC 119.02; both channels centered (L=R).</div>
+      </div>
+
+      <!-- ================= FULL CODE END-TO-END ================= -->
+      <h2 id="endtoend">Full code, end to end — how the engine runs this composition</h2>
+      <div class="lede">
+        The fix is one line of selection logic, but it sits inside a full pipeline. Here is the exact
+        <code>monday_blues</code> source and how every construct in it flows from Ruby text to scsynth audio —
+        each claim below is read straight from the web engine's event log for this run (Level&nbsp;2 inference),
+        with the audio confirmed at Level&nbsp;3 above.
+      </div>
+
+      <pre class="code"><span class="key">use_debug</span> false
+
+<span class="key">live_loop</span> :drums <span class="key">do</span>
+  puts <span class="str">"slow drums"</span>
+  <span class="num">6</span>.times <span class="key">do</span>
+    sample :drum_heavy_kick, rate: <span class="num">0.8</span>
+    sleep <span class="num">0.5</span>
+  <span class="key">end</span>
+  puts <span class="str">"fast drums"</span>
+  <span class="num">8</span>.times <span class="key">do</span>
+    sample :drum_heavy_kick, rate: <span class="num">0.8</span>
+    sleep <span class="num">0.125</span>
+  <span class="key">end</span>
+<span class="key">end</span>
+
+<span class="key">live_loop</span> :synths <span class="key">do</span>
+  use_synth :mod_saw
+  use_synth_defaults amp: <span class="num">0.5</span>, attack: <span class="num">0</span>, sustain: <span class="num">1</span>, release: <span class="num">0.25</span>, mod_range: <span class="num">12</span>, mod_phase: <span class="num">0.5</span>, mod_invert_wave: <span class="num">1</span>
+  notes = (ring :F, :C, :D, :D, :G, :C, :D, :D)
+  notes.each <span class="key">do</span> |n|
+    tick
+    play note(n, octave: <span class="num">1</span>), cutoff: (line <span class="num">90</span>, <span class="num">130</span>, steps: <span class="num">16</span>).look
+    play note(n, octave: <span class="num">2</span>), cutoff: (line <span class="num">90</span>, <span class="num">130</span>, steps: <span class="num">32</span>).look
+    sleep <span class="num">1</span>
+  <span class="key">end</span>
+<span class="key">end</span>
+
+<span class="key">live_loop</span> :snare <span class="key">do</span>
+  sample :drum_snare_soft
+  sleep <span class="num">1</span>
+<span class="key">end</span></pre>
+
+      <p class="col-label" style="margin-top:18px">The pipeline — Ruby text → audio</p>
+      <ul class="probes">
+        <li><b>1 · Transpile</b> <code>Transpiler.ts</code> — tree-sitter partial fold over the Sonic-Pi Ruby subset turns the source into JS. <code>6.times do…end</code>, <code>notes.each do |n|…end</code>, blocks, and the <code>(ring …)</code> / <code>(line …)</code> paren-call forms are all recognised; bare <code>notes = …</code> is emitted as a bare assignment so the sandbox Proxy can capture it. Falls back to the regex transpiler if tree-sitter fails.</li>
+        <li><b>2 · Sandbox</b> <code>createIsolatedExecutor()</code> — user JS runs inside <code>with(__scope__)</code>; the Proxy's <code>has()</code> returns true for everything so <code>notes = …</code> writes into scope-isolated storage. <code>use_synth</code> / <code>use_synth_defaults</code> set thread-local state read by later <code>play</code> calls.</li>
+        <li><b>3 · ProgramBuilder</b> builds <code>Step[]</code> (the free monad) — one <code>live_loop</code> registration per loop; inside, each <code>sample</code> / <code>play</code> / <code>sleep</code> is a Step. <code>tick</code>/<code>look</code> advance and read a per-loop counter; <code>(line 90,130,steps:N).look</code> resolves to a concrete <code>cutoff</code> at build time per iteration.</li>
+        <li><b>4 · VirtualTimeScheduler</b> — the core innovation: each <code>sleep</code> returns a Promise that only the scheduler resolves. The three live_loops run as cooperative coroutines in virtual time — drums advancing 0.5/0.125&nbsp;beats, synths 1&nbsp;beat, snare 1&nbsp;beat — interleaved deterministically, no thread blocking.</li>
+        <li><b>5 · AudioInterpreter</b> walks the <code>Step[]</code> and dispatches each <code>play</code>/<code>sample</code> to <code>SuperSonicBridge</code> at its virtual-time-mapped audio time.</li>
+        <li><b>6 · SoundLayer</b> normalises params: <code>note(:F, octave:1)</code>→MIDI <code>29</code> (the #409 fix), symbol resolution, <code>cutoff</code> kept for synths / aliased to <code>lpf</code> for samples, BPM time-scaling. <b>It also decides nothing about channels — that is the player layer (the SP107 fix).</b></li>
+        <li class="key"><b>7 · SuperSonicBridge</b> <code>selectSamplePlayer(opts, numChans)</code> — reads the cached channel count and routes each sample to its player. <b>Both <code>:drum_heavy_kick</code> and <code>:drum_snare_soft</code> are mono → <code>basic_mono_player</code></b> (post-fix, centered). Emits <code>/s_new</code> to the per-loop track bus.</li>
+        <li><b>8 · scsynth (WASM)</b> renders each node; per-loop track buses (16/18/20) mix to the master and out to Web Audio.</li>
+      </ul>
+
+      <p class="col-label" style="margin-top:18px">Construct → what the engine actually did (read from this run's event log)</p>
+      <table class="metrics">
+        <thead><tr><th>Source construct</th><th>Observed in <code>/s_new</code></th></tr></thead>
+        <tbody>
+          <tr><td><code>sample :drum_heavy_kick, rate: 0.8</code></td><td><code>"…basic_mono_player" {buf:0, rate:0.8, out_bus:16}</code> — mono player, centered ✓</td></tr>
+          <tr><td><code>sample :drum_snare_soft</code></td><td><code>"…basic_mono_player" {buf:1, out_bus:20}</code> — also mono, also centered ✓</td></tr>
+          <tr><td><code>play note(:F, octave: 1)</code></td><td><code>note: 29</code> (F1) — octave: honored (#409)</td></tr>
+          <tr><td><code>play note(:F, octave: 2)</code></td><td><code>note: 41</code> (F2) — emitted at the same virtual time → polyphony</td></tr>
+          <tr><td><code>note(:C/:D, octave: 1/2)</code></td><td><code>24/36</code> (C1/C2), <code>26/38</code> (D1/D2) — ring + octave resolution correct</td></tr>
+          <tr><td><code>cutoff: (line 90,130, steps:16).look</code></td><td><code>cutoff: 90 → 92.67 → 95.33 → 98 …</code> — line ramp + tick/look advancing</td></tr>
+          <tr><td><code>cutoff: (line 90,130, steps:32).look</code></td><td><code>cutoff: 90 → 91.29 → 92.58 …</code> — independent 32-step ramp on the octave-2 voice</td></tr>
+          <tr><td>3 × <code>live_loop</code></td><td>drums→<code>out_bus 16</code>, synths→<code>18</code>, snare→<code>20</code> — concurrent, independent virtual-time periods</td></tr>
+        </tbody>
+      </table>
+
+      <p class="col-label" style="margin-top:18px">Event-log excerpt — one synth tick + its drums (verbatim)</p>
+      <pre class="code">[t:1.7240] /s_new <span class="str">"sonic-pi-mod_saw"</span>          {… cutoff: <span class="num">90</span>,      note: <span class="num">29</span>, out_bus: <span class="num">18</span>}  <span class="cmt"># note(:F, octave:1)</span>
+[t:1.7240] /s_new <span class="str">"sonic-pi-mod_saw"</span>          {… cutoff: <span class="num">90</span>,      note: <span class="num">41</span>, out_bus: <span class="num">18</span>}  <span class="cmt"># note(:F, octave:2) — polyphony</span>
+[t:1.7240] /s_new <span class="str">"sonic-pi-basic_mono_player"</span> {buf: <span class="num">0</span>, rate: <span class="num">0.8</span>,        out_bus: <span class="num">16</span>}  <span class="cmt"># :drum_heavy_kick — mono, centered</span>
+[t:1.7240] /s_new <span class="str">"sonic-pi-basic_mono_player"</span> {buf: <span class="num">1</span>,                   out_bus: <span class="num">20</span>}  <span class="cmt"># :drum_snare_soft — mono, centered</span>
+[t:2.2240] /s_new <span class="str">"sonic-pi-basic_mono_player"</span> {buf: <span class="num">0</span>, rate: <span class="num">0.8</span>,        out_bus: <span class="num">16</span>}  <span class="cmt"># slow-drum kick @ +0.5 beat</span>
+[t:2.7240] /s_new <span class="str">"sonic-pi-mod_saw"</span>          {… cutoff: <span class="num">92.67</span>,   note: <span class="num">24</span>, out_bus: <span class="num">18</span>}  <span class="cmt"># note(:C, octave:1), cutoff ramp .look</span></pre>
+      <div class="lede" style="margin-top:8px; font-size:12.5px">
+        Both samples now carry <code>basic_mono_player</code> (49 sample triggers in the 9&nbsp;s window, all mono-centered);
+        before the fix every one of them was left-channel-only. That is the SP107 fix doing its job inside the real composition.
       </div>
 
       <div class="footer-note">

--- a/test_results/mono-sample-sp107.html
+++ b/test_results/mono-sample-sp107.html
@@ -167,7 +167,7 @@
         The right channel is <b>flat at zero</b> before the fix; populated and equal to the left after.
       </div>
       <div class="png-block">
-        <img src="sp107/kick-channels.png" alt="per-channel waveform: before fix R silent, after fix R=L, desktop R=L" />
+        <img src="sp107/kick-channels.png?v=2" alt="per-channel waveform: before fix R silent, after fix R=L, desktop R=L" />
         <div class="png-cap">Top (red): web before fix — R channel silent. Middle (green): web after fix — R = L = 0.109. Bottom (blue): desktop reference — R = L = 0.2265 (centered). The 0.48× per-channel level is the separate global WASM/native gain gap (#268), not this bug.</div>
       </div>
 
@@ -176,22 +176,22 @@
       <div class="sync-bar">
         <button class="sync-btn" data-group="kick" data-act="play">▶ Play all three</button>
         <button class="sync-btn sec" data-group="kick" data-act="stop">■ Stop</button>
-        <span class="sync-hint">Use headphones / a stereo setup — the "before" plays only in your left ear.</span>
+        <span class="sync-hint">Use headphones — the "before" plays only in your left ear. <em>Audio boosted ×3.75 for listening (shared across the three, so relative levels hold); raw capture peaks are in the L/R labels.</em></span>
       </div>
       <div class="audio-grid">
         <div class="card before">
           <h3>Web — before <span>basic_stereo_player</span></h3>
-          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-before.wav"></audio>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-before.wav?v=2"></audio>
           <div class="lr">L <b>0.109</b> &nbsp; R <span class="silent">0.000 ✖ silent</span></div>
         </div>
         <div class="card after">
           <h3>Web — after <span>basic_mono_player</span></h3>
-          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-after.wav"></audio>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-after.wav?v=2"></audio>
           <div class="lr">L <b>0.109</b> &nbsp; R <span class="ok">0.109 ✓ centered</span></div>
         </div>
         <div class="card ref">
           <h3>Desktop Sonic Pi <span>reference</span></h3>
-          <audio data-group="kick" controls preload="metadata" src="sp107/kick-desktop.wav"></audio>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-desktop.wav?v=2"></audio>
           <div class="lr">L <b>0.2265</b> &nbsp; R <span class="ok">0.2265 ✓ centered</span></div>
         </div>
       </div>
@@ -290,20 +290,20 @@
       <div class="sync-bar">
         <button class="sync-btn" data-group="mb" data-act="play">▶ Play both</button>
         <button class="sync-btn sec" data-group="mb" data-act="stop">■ Stop</button>
-        <span class="sync-hint">kick (<code>:drums</code>) + <code>mod_saw</code> synth (delay 6) + snare (delay 12.5)</span>
+        <span class="sync-hint">drums (<code>:drum_heavy_kick</code>) + <code>mod_saw</code> synths + <code>:drum_snare_soft</code>. <em>Boosted ×1.72 for listening (shared desktop+web); raw peaks web 0.28 / desktop 0.49 in the table above.</em></span>
       </div>
       <div class="audio-grid" style="grid-template-columns: 1fr 1fr">
         <div class="card ref">
           <h3>Desktop Sonic Pi <span>reference</span></h3>
-          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-desktop.wav"></audio>
+          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-desktop.wav?v=2"></audio>
         </div>
         <div class="card after">
           <h3>Web — after fix <span>centered kick</span></h3>
-          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-web-after.wav"></audio>
+          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-web-after.wav?v=2"></audio>
         </div>
       </div>
       <div class="png-block" style="margin-top:12px">
-        <img src="sp107/monday-blues-spectrogram.png" alt="monday_blues spectrogram desktop vs web after fix" />
+        <img src="sp107/monday-blues-spectrogram.png?v=2" alt="monday_blues spectrogram desktop vs web after fix" />
         <div class="png-cap">Full monday_blues spectrogram — desktop vs web (after fix). L2 13.99 / MFCC 119.02; both channels centered (L=R).</div>
       </div>
 

--- a/test_results/mono-sample-sp107.html
+++ b/test_results/mono-sample-sp107.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>SP107 — mono samples play centered (not left-only)</title>
+    <style>
+      :root {
+        --bg: #1a1b26;
+        --bg-elev: #1f2335;
+        --bg-row: #16161e;
+        --border: #2a2e46;
+        --text: #c0caf5;
+        --text-dim: #7a85b3;
+        --text-mute: #565f89;
+        --accent: #ff1493;
+        --accent-2: #7aa2f7;
+        --pass: #9ece6a;
+        --flag: #e0af68;
+        --fail: #f7768e;
+        --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+          "Liberation Mono", monospace;
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        font-size: 13px;
+      }
+      .wrap { max-width: 1300px; margin: 0 auto; padding: 24px 32px 64px; }
+      h1 { font-size: 22px; margin: 0 0 4px; font-weight: 700; }
+      h1 small { color: var(--text-dim); font-weight: 400; font-size: 14px; margin-left: 12px; }
+      h2 {
+        font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+        color: var(--text-dim); margin: 32px 0 10px;
+        border-top: 1px solid var(--border); padding-top: 18px;
+      }
+      .lede { color: var(--text-dim); font-size: 14px; line-height: 1.6; margin: 8px 0 0; }
+      .lede b { color: var(--text); }
+      code { font-family: var(--mono); background: var(--bg-row); padding: 1px 5px; border-radius: 3px; font-size: 0.92em; }
+      .question-card {
+        background: var(--bg-elev); border: 1px solid var(--border);
+        border-left: 4px solid var(--accent-2); border-radius: 6px;
+        padding: 14px 18px; margin: 18px 0;
+      }
+      .question-card .q { font-weight: 600; color: var(--text); margin-bottom: 6px; }
+      .question-card .a { color: var(--text-dim); font-size: 13px; line-height: 1.6; }
+      .question-card .a b { color: var(--text); }
+      .verdict {
+        display: inline-block; font-size: 11px; font-weight: 700; text-transform: uppercase;
+        letter-spacing: 0.06em; padding: 3px 8px; border-radius: 3px; margin-right: 8px; vertical-align: middle;
+      }
+      .verdict.fixed { background: rgba(158, 206, 106, 0.16); color: var(--pass); }
+      .tldr {
+        margin: 18px 0; padding: 16px 18px; background: var(--bg-elev);
+        border-left: 4px solid var(--pass); border-radius: 6px; line-height: 1.7; color: var(--text-dim);
+      }
+      .tldr b { color: var(--text); }
+      .tldr ol { margin: 8px 0 0; padding-left: 20px; }
+      .tldr li { margin: 6px 0; }
+
+      .png-block { background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 10px; margin: 10px 0; }
+      .png-block img { max-width: 100%; display: block; border-radius: 4px; margin: 0 auto; }
+      .png-cap { color: var(--text-mute); font-size: 12px; margin-top: 8px; text-align: center; }
+
+      .audio-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; margin: 6px 0 4px; }
+      .card { background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px; }
+      .card.before { border-top: 3px solid var(--fail); }
+      .card.after  { border-top: 3px solid var(--pass); }
+      .card.ref    { border-top: 3px solid var(--accent-2); }
+      .card h3 {
+        margin: 0 0 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+        color: var(--text-dim); display: flex; justify-content: space-between; align-items: baseline;
+      }
+      .card h3 span { font-family: var(--mono); text-transform: none; letter-spacing: 0; color: var(--text-mute); font-size: 11px; font-weight: 400; }
+      .card audio { width: 100%; height: 34px; }
+      .card .lr { font-family: var(--mono); font-size: 11.5px; margin-top: 8px; color: var(--text-dim); }
+      .card .lr b { color: var(--text); }
+      .card .lr .silent { color: var(--fail); font-weight: 700; }
+      .card .lr .ok { color: var(--pass); }
+
+      table.metrics { border-collapse: collapse; width: 100%; font-size: 12.5px; font-family: var(--mono); margin: 4px 0; }
+      table.metrics th, table.metrics td { padding: 6px 12px; border-bottom: 1px solid var(--border); text-align: left; }
+      table.metrics th { background: var(--bg-elev); color: var(--text-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+      table.metrics td.num { text-align: right; font-variant-numeric: tabular-nums; }
+      .ratio-good { color: var(--pass); }
+      .ratio-mid { color: var(--flag); }
+      .ratio-bad { color: var(--fail); }
+
+      pre.code {
+        background: var(--bg-row); border: 1px solid var(--border); border-radius: 6px;
+        padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12px;
+        line-height: 1.55; color: var(--text); margin: 8px 0;
+      }
+      pre.code .cmt { color: var(--text-mute); font-style: italic; }
+      pre.code .key { color: var(--accent-2); }
+      pre.code .str { color: var(--pass); }
+      pre.code .num { color: var(--flag); }
+      .two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+      .col-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim); margin: 0 0 4px; }
+
+      .probes { margin: 0; padding: 6px 0; list-style: none; }
+      .probes li { padding: 9px 13px; margin: 5px 0; background: var(--bg-row); border-left: 3px solid var(--border); border-radius: 4px; line-height: 1.55; }
+      .probes li.fail { border-left-color: var(--fail); }
+      .probes li.pass { border-left-color: var(--pass); }
+      .probes li.key  { border-left-color: var(--accent); }
+      .probes li b { color: var(--text); font-weight: 600; }
+      .probes li code { font-size: 11.5px; }
+
+      .sync-bar { display: flex; gap: 8px; margin: 12px 0 6px; align-items: center; }
+      .sync-btn { background: var(--accent); color: #fff; border: 0; padding: 8px 14px; border-radius: 6px; font: inherit; font-weight: 600; cursor: pointer; }
+      .sync-btn.sec { background: transparent; color: var(--text-dim); border: 1px solid var(--border); }
+      .sync-btn:hover { filter: brightness(1.1); }
+      .sync-hint { color: var(--text-mute); font-size: 12px; }
+
+      .footer-note { font-size: 12px; color: var(--text-mute); line-height: 1.6; margin-top: 40px; padding-top: 18px; border-top: 1px solid var(--border); }
+      .footer-note b { color: var(--text-dim); }
+      .footer-note ul { padding-left: 20px; }
+      .footer-note a, .nav a, .lede a { color: var(--accent-2); text-decoration: none; }
+      .footer-note a:hover, .nav a:hover, .lede a:hover { text-decoration: underline; }
+      .nav { color: var(--text-dim); font-size: 12px; margin-bottom: 8px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="nav"><a href="index.html">← FX A/B Inspector</a> &nbsp;·&nbsp; <a href="launch-gate.html">🚦 Launch Gate</a></div>
+      <h1>SP107 — mono samples play <em>centered</em>, not left-channel-only
+        <small>diagnosis → fix → verification · PR #415</small></h1>
+      <div class="lede">
+        A real-example parity investigation. <code>monday_blues</code> read with a large spectral diff
+        (L2 mel-dB <b>31.2</b>, MFCC <b>260</b>) on kick-dominated material. The pre-written hypothesis
+        was a "sub-bass-deficient kick" — a gain-vs-rendering fork. <b>Both candidates were refuted.</b>
+        The real cause was a one-axis-missing player-selection bug: <b>mono samples rendered to the
+        left channel only</b>, the right channel silent. Read top-to-bottom for the chronology.
+      </div>
+
+      <div class="question-card">
+        <div class="q">Question — why does kick-dominated material (<code>:drum_heavy_kick</code>) read a large spectral diff vs desktop, with no wrong notes?</div>
+        <div class="a">
+          <span class="verdict fixed">Resolved</span>
+          Because <code>selectSamplePlayer</code> chose the sample player by opt-complexity <em>alone</em> and
+          never by the sample's <b>channel count</b>. A 1-channel (mono) buffer routed through
+          <code>basic_stereo_player</code> (which expects a 2-channel buffer) left the right output channel
+          <b>silent</b>. When the comparator mono-averages <code>(L+R)/2</code>, a left-only kick is halved
+          relative to centered synth layers — collapsing the sub-band share and inflating MFCC. Fixed by adding
+          the channel-count axis, mirroring Desktop SP's <code>resolve_specific_sampler</code>.
+        </div>
+      </div>
+
+      <div class="tldr">
+        <b>TL;DR</b>
+        <ol>
+          <li><b>The bug:</b> mono samples were left-channel-only on web. Kick A/B: web <code>L=0.109 / R=0.000</code> vs desktop centered <code>L=R=0.2265</code>.</li>
+          <li><b>The measurement trap:</b> the prior session's "0.24× attenuated kick" was an artifact of mono-averaging a left-only signal. Reading L and R <em>separately</em> revealed <code>R=0</code> — a channel bug masquerading as a gain bug.</li>
+          <li><b>Root cause:</b> <code>selectSamplePlayer(opts)</code> branched only on opt-complexity; it never read the sample's channel count. Desktop's <code>resolve_specific_sampler(num_chans, args_h)</code> (sound.rb:3470-3478) picks <code>basic_mono_player</code> for 1-channel samples (which Pan2-centers).</li>
+          <li><b>The fix (PR #415):</b> add the channel-count axis — cache <code>audioBuffer.numberOfChannels</code> from the existing decode, resolve it before player selection, use mono players for mono samples. Pure synthdef-name swap; zero param-translation change; defaults to stereo (no regression).</li>
+          <li><b>Verified Level-3:</b> web kick R-channel <b class="ratio-good">0.000 → 0.1090</b> (centered); <code>monday_blues</code> <b class="ratio-good">L2 31.2→9.3, MFCC 260→106</b>; launch gate stays <b>5/7 = 71.4% PASS</b>.</li>
+        </ol>
+      </div>
+
+      <!-- ================= HERO ================= -->
+      <h2 id="hero">The bug, in one picture — per-channel waveform</h2>
+      <div class="lede" style="margin-bottom: 10px">
+        <code>live_loop :k do; sample :drum_heavy_kick, rate: 0.8; sleep 0.5; end</code> — same code, three captures.
+        The right channel is <b>flat at zero</b> before the fix; populated and equal to the left after.
+      </div>
+      <div class="png-block">
+        <img src="sp107/kick-channels.png" alt="per-channel waveform: before fix R silent, after fix R=L, desktop R=L" />
+        <div class="png-cap">Top (red): web before fix — R channel silent. Middle (green): web after fix — R = L = 0.109. Bottom (blue): desktop reference — R = L = 0.2265 (centered). The 0.48× per-channel level is the separate global WASM/native gain gap (#268), not this bug.</div>
+      </div>
+
+      <!-- ================= AUDIO ================= -->
+      <h2 id="audio">Listen — <code>:drum_heavy_kick</code> isolated</h2>
+      <div class="sync-bar">
+        <button class="sync-btn" data-group="kick" data-act="play">▶ Play all three</button>
+        <button class="sync-btn sec" data-group="kick" data-act="stop">■ Stop</button>
+        <span class="sync-hint">Use headphones / a stereo setup — the "before" plays only in your left ear.</span>
+      </div>
+      <div class="audio-grid">
+        <div class="card before">
+          <h3>Web — before <span>basic_stereo_player</span></h3>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-before.wav"></audio>
+          <div class="lr">L <b>0.109</b> &nbsp; R <span class="silent">0.000 ✖ silent</span></div>
+        </div>
+        <div class="card after">
+          <h3>Web — after <span>basic_mono_player</span></h3>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-web-after.wav"></audio>
+          <div class="lr">L <b>0.109</b> &nbsp; R <span class="ok">0.109 ✓ centered</span></div>
+        </div>
+        <div class="card ref">
+          <h3>Desktop Sonic Pi <span>reference</span></h3>
+          <audio data-group="kick" controls preload="metadata" src="sp107/kick-desktop.wav"></audio>
+          <div class="lr">L <b>0.2265</b> &nbsp; R <span class="ok">0.2265 ✓ centered</span></div>
+        </div>
+      </div>
+
+      <!-- ================= MEASUREMENT TRAP ================= -->
+      <h2 id="trap">The measurement trap — why the first read was wrong</h2>
+      <div class="lede">
+        The prior session isolated the kick and reported it "0.24× attenuated / sub-bass-deficient," pointing at
+        gain or sample-player filtering. That number was an <b>artifact of the analysis</b>, not the engine:
+      </div>
+      <ul class="probes">
+        <li class="fail"><b>Symptom mismatch:</b> the comparison tool reported web kick peak <code>0.109</code>, but a per-hit script (which mono-averaged <code>(L+R)/2</code>) reported <code>0.0545</code> — a clean <b>2× disagreement on the same file</b>.</li>
+        <li class="key"><b>The witness check:</b> two measurements of the same WAV cannot disagree by 2× unless one is wrong. Reading L and R <em>separately</em> showed <code>L=0.109, R=0.0000</code> — the mono-average had halved a single-populated channel.</li>
+        <li class="pass"><b>Control 1:</b> the <code>mod_saw</code> synth alone is <code>L=R=0.1514</code> (centered) → the defect is <b>sample-specific</b>, not global.</li>
+        <li class="pass"><b>Control 2:</b> the kick at <code>rate: 1.0</code> is also left-only → not a <code>rate:</code> artifact.</li>
+        <li class="pass"><b>Per-channel truth:</b> the kick's per-channel gain (0.48×) and spectral shape (99% sub &lt;80&nbsp;Hz) match desktop exactly. The <em>only</em> defect is the missing right channel.</li>
+      </ul>
+      <div class="lede" style="margin-top:10px">
+        <b>The lesson (now vyapti SV54):</b> on stereo WAVs, read L and R separately <em>before</em> any mono-collapse — a channel-routing bug otherwise hides as a "gain" bug.
+      </div>
+
+      <!-- ================= ROOT CAUSE + GROUNDING ================= -->
+      <h2 id="root">Root cause — one axis missing vs the reference</h2>
+      <div class="lede">
+        Desktop Sonic Pi selects the sample player on <b>two</b> independent axes; our engine had only one.
+      </div>
+      <div class="two-col">
+        <div>
+          <p class="col-label">Desktop SP — sound.rb:3470-3478</p>
+          <pre class="code"><span class="key">def</span> resolve_specific_sampler(num_chans, args_h)
+  <span class="key">if</span> complex_sampler_args?(args_h)
+    (num_chans == <span class="num">1</span>) ? :mono_player : :stereo_player
+  <span class="key">else</span>
+    (num_chans == <span class="num">1</span>) ? :basic_mono_player : :basic_stereo_player
+  <span class="key">end</span>
+<span class="key">end</span>
+<span class="cmt"># num_chans read from the loaded buffer (buf_info.num_chans, :3498)</span>
+<span class="cmt"># BEFORE the player is resolved → mono samples get a mono player</span></pre>
+        </div>
+        <div>
+          <p class="col-label">Ours — before the fix (SoundLayer.ts)</p>
+          <pre class="code"><span class="key">function</span> selectSamplePlayer(opts) {
+  <span class="cmt">// opt-complexity axis ONLY — channel count never read</span>
+  <span class="key">if</span> (anyComplexOpt(opts)) <span class="key">return</span> <span class="str">'…stereo_player'</span>
+  <span class="key">return</span> <span class="str">'…basic_stereo_player'</span>  <span class="cmt">// ← mono buffer → R silent</span>
+}</pre>
+        </div>
+      </div>
+      <div class="lede" style="margin-top:6px">
+        A mono buffer played through <code>basic_stereo_player</code> (which reads a 2-channel buffer) writes audio to
+        the left bus channel and leaves the right empty. The mono players (<code>basic_mono_player</code>/<code>mono_player</code>)
+        <code>Pan2</code>-center a 1-channel <code>PlayBuf</code> to both channels. The basic mono and basic stereo players share
+        <b>identical arg signatures</b> (<code>synthinfo.rb:5013</code>, <code>BasicStereoPlayer&nbsp;&lt;&nbsp;BasicMonoPlayer</code>) — so the fix is a pure synthdef-name swap.
+      </div>
+
+      <!-- ================= THE FIX ================= -->
+      <h2 id="fix">The fix — add the channel-count axis (PR #415)</h2>
+      <ul class="probes">
+        <li class="pass"><b>Selection:</b> <code>selectSamplePlayer(opts, numChans = 2)</code> → <code>basic_mono_player</code>/<code>mono_player</code> when <code>numChans === 1</code>; stereo variants otherwise. <code>numChans</code> defaults to 2, so callers that omit it keep today's behavior (<b>no regression</b>).</li>
+        <li class="pass"><b>Ordering:</b> <code>SuperSonicBridge</code> caches <code>audioBuffer.numberOfChannels</code> from the <em>existing</em> <code>decodeAudioData</code> (new <code>sampleChannels</code> map) and resolves it <em>before</em> player selection — matching desktop's buf_info.num_chans-known-before-resolve ordering (sound.rb:3496-3498).</li>
+        <li class="pass"><b>Synthdefs:</b> mono players lazy-load via the existing <code>ensureSynthDefLoaded</code> (both confirmed in CDN @0.57.0).</li>
+        <li class="pass"><b>Failure mode:</b> on decode failure, falls back to stereo — degrades to pre-fix behavior, never to no-audio.</li>
+        <li class="key"><b>Self-review:</b> a follow-up commit clears <code>sampleChannels</code> in all three sample-teardown sites (SV38 hygiene), matching the sibling cache maps.</li>
+      </ul>
+
+      <!-- ================= VERIFICATION ================= -->
+      <h2 id="verify">Level-3 verification — observation, not inference</h2>
+      <p class="col-label">Kick isolated — per-channel + spectral shape</p>
+      <table class="metrics">
+        <thead><tr><th>Metric</th><th class="num">Desktop</th><th class="num">Web — before</th><th class="num">Web — after</th></tr></thead>
+        <tbody>
+          <tr><td>Left peak</td><td class="num">0.2265</td><td class="num">0.109</td><td class="num">0.109</td></tr>
+          <tr><td>Right peak</td><td class="num">0.2265</td><td class="num ratio-bad">0.0000 ✖</td><td class="num ratio-good">0.1090 ✓</td></tr>
+          <tr><td>Sub &lt;80 Hz share</td><td class="num">82.5%</td><td class="num">—</td><td class="num ratio-good">83.7%</td></tr>
+          <tr><td>MFCC dist (vs desktop)</td><td class="num">—</td><td class="num ratio-mid">200.4</td><td class="num ratio-good">161.3</td></tr>
+        </tbody>
+      </table>
+      <p class="col-label" style="margin-top:18px">monday_blues — the original symptom</p>
+      <table class="metrics">
+        <thead><tr><th>Metric</th><th class="num">Before fix</th><th class="num">After fix</th></tr></thead>
+        <tbody>
+          <tr><td>L2 (mel-dB) vs desktop</td><td class="num ratio-bad">31.17</td><td class="num ratio-good">9.34</td></tr>
+          <tr><td>MFCC dist vs desktop</td><td class="num ratio-bad">259.75</td><td class="num ratio-good">106.21</td></tr>
+          <tr><td>Sub-share gap (desktop↔web, same run)</td><td class="num ratio-bad">54 pt</td><td class="num ratio-good">4.6 pt</td></tr>
+          <tr><td>Web sub &lt;80 Hz share</td><td class="num ratio-bad">30.2%</td><td class="num ratio-good">46.3%</td></tr>
+        </tbody>
+      </table>
+
+      <h2 id="mb-audio">monday_blues — after the fix (A/B)</h2>
+      <div class="sync-bar">
+        <button class="sync-btn" data-group="mb" data-act="play">▶ Play both</button>
+        <button class="sync-btn sec" data-group="mb" data-act="stop">■ Stop</button>
+        <span class="sync-hint">kick (<code>:drums</code>) + <code>mod_saw</code> synth (delay 6) + snare (delay 12.5)</span>
+      </div>
+      <div class="audio-grid" style="grid-template-columns: 1fr 1fr">
+        <div class="card ref">
+          <h3>Desktop Sonic Pi <span>reference</span></h3>
+          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-desktop.wav"></audio>
+        </div>
+        <div class="card after">
+          <h3>Web — after fix <span>centered kick</span></h3>
+          <audio data-group="mb" controls preload="metadata" src="sp107/monday-blues-web-after.wav"></audio>
+        </div>
+      </div>
+      <div class="png-block" style="margin-top:12px">
+        <img src="sp107/monday-blues-spectrogram.png" alt="monday_blues spectrogram desktop vs web after fix" />
+        <div class="png-cap">monday_blues spectrogram — desktop vs web (after fix). L2 9.34 / MFCC 106.21.</div>
+      </div>
+
+      <div class="footer-note">
+        <b>Provenance</b>
+        <ul>
+          <li><b>Issue:</b> #414 &nbsp;·&nbsp; <b>PR:</b> #415 (merged) &nbsp;·&nbsp; commits <code>be92aab</code> (fix) + <code>8237794</code> (teardown hygiene)</li>
+          <li><b>Source (ours):</b> <code>src/engine/SoundLayer.ts</code> <code>selectSamplePlayer(opts, numChans)</code>; <code>src/engine/SuperSonicBridge.ts</code> <code>sampleChannels</code> / <code>decodeSampleMetadata</code> / <code>ensureSampleChannels</code> / <code>playSampleSlow</code></li>
+          <li><b>Source (reference):</b> Desktop SP <code>sound.rb:3470-3478</code> (resolve_specific_sampler), <code>:3496-3498</code> (load-before-resolve); <code>synthinfo.rb:5013/5031</code> (player arg-signature inheritance)</li>
+          <li><b>Catalogues:</b> hetvabhasa <b>SP107</b> (OPEN → ISOLATED → IMPLEMENTED); vyapti <b>SV54</b> (sample player selection must account for channel count)</li>
+          <li><b>Recordings on this page</b> are gitignored (<code>test_results/sp107/</code>, ≈10&nbsp;MB) — regenerate with <code>npx tsx tools/compare-desktop-vs-web.ts --file /tmp/kick.rb</code> (Chromium + SP.app @ 48&nbsp;kHz). If audio shows "could not load," serve the dir: <code>python3 -m http.server -d test_results 8080</code>.</li>
+          <li>The remaining per-channel <b>0.48×</b> level is the separate, deliberate global WASM/native gain gap (#268), out of scope for this fix.</li>
+        </ul>
+      </div>
+    </div>
+
+    <script>
+      // Group play/stop for the A/B audio cards.
+      document.querySelectorAll(".sync-btn").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const group = btn.dataset.group;
+          const act = btn.dataset.act;
+          const players = document.querySelectorAll(`audio[data-group="${group}"]`);
+          players.forEach((a) => {
+            if (act === "play") {
+              a.currentTime = 0;
+              a.play().catch(() => {});
+            } else {
+              a.pause();
+              a.currentTime = 0;
+            }
+          });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/tools/engine-saw-osc-probe.ts
+++ b/tools/engine-saw-osc-probe.ts
@@ -1,0 +1,93 @@
+/**
+ * Engine-path saw probe v2 (SP108 / #417) — FRESH single run, full OSC capture.
+ *
+ * Arms OSC capture + audio tap via the __spw_engine setter (before init), then
+ * does ONE fresh run of the code (no hot-swap). Reproduces the capture.ts sine
+ * while logging EVERY OSC message the engine sends — so we can diff what the
+ * real live_loop path does vs the manual replication that preserves harmonics.
+ *
+ * Usage: SAW_CODE="$(cat /tmp/iso_saw_hicut.rb)" npx tsx tools/engine-saw-osc-probe.ts
+ */
+import { chromium } from '@playwright/test'
+import { writeFileSync, mkdirSync } from 'fs'
+import { resolve } from 'path'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const OUT_DIR = '/tmp/sp108-raw-ugen'
+const CODE = process.env.SAW_CODE ?? 'use_synth :saw\nlive_loop :s do\n  play :E3, amp: 0.5, attack: 0, sustain: 1, release: 0.25, cutoff: 130\n  sleep 1\nend'
+const RUN_MS = Number(process.env.RUN_MS ?? 5000)
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+  const browser = await chromium.launch({ headless: false, args: ['--autoplay-policy=no-user-gesture-required'] })
+  const ctx = await browser.newContext()
+
+  // Arm OSC capture + tap via the __spw_engine setter, BEFORE the app inits.
+  await ctx.addInitScript({ content: `(function(){
+    window.__oscLog = [];
+    var _eng = null;
+    Object.defineProperty(window, '__spw_engine', {
+      configurable: true,
+      get: function(){ return _eng; },
+      set: function(e){
+        _eng = e;
+        try {
+          var bridge = e.bridge;
+          var prev = bridge.oscTraceHandler;
+          bridge.setOscTraceHandler(function(s){ window.__oscLog.push(s); if (prev) try { prev(s); } catch(_){} });
+          // install audio tap on masterOutputNode
+          var actx = bridge.audioContext, tap = bridge.masterOutputNode;
+          var CH = 2, BUF = 4096, chunks = [[], []];
+          var sp = actx.createScriptProcessor(BUF, CH, CH);
+          sp.onaudioprocess = function(ev){ var inp = ev.inputBuffer; var nc = Math.min(inp.numberOfChannels, CH); for (var ch=0; ch<nc; ch++) chunks[ch].push(new Float32Array(inp.getChannelData(ch))); };
+          var sink = actx.createGain(); sink.gain.value = 0;
+          tap.connect(sp); sp.connect(sink); sink.connect(actx.destination);
+          window.__probe = { chunks: chunks, sp: sp, sink: sink, tap: tap, ctx: actx };
+        } catch(err){ window.__probeErr = String(err); }
+      }
+    });
+  })()` })
+
+  const page = await ctx.newPage()
+  page.on('pageerror', (e) => console.log(`  [pageerror] ${e.message}`))
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(1500)
+
+  // Single fresh run of the code.
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await editor.fill(CODE)
+  await page.locator('.spw-btn-label:has-text("Run")').click()
+
+  // Wait for the probe to arm (engine inited) then run window.
+  await page.waitForFunction(() => Boolean((window as any).__probe), { timeout: 20000 })
+  await page.waitForTimeout(RUN_MS)
+
+  const out = await page.evaluate(`(function(){
+    var p = window.__probe; if (!p) return { err: window.__probeErr || 'no probe' };
+    var ctx = p.ctx, chunks = p.chunks, CH = 2, BUF = 4096;
+    try { p.tap.disconnect(p.sp); } catch(_){}
+    try { p.sp.disconnect(); } catch(_){}
+    try { p.sink.disconnect(); } catch(_){}
+    p.sp.onaudioprocess = null;
+    var len = chunks[0].reduce(function(a,c){ return a+c.length; }, 0);
+    var flat = chunks.map(function(cs){ var o=new Float32Array(len),q=0; for (var i=0;i<cs.length;i++){o.set(cs[i],q);q+=cs[i].length;} return o; });
+    var sr = ctx.sampleRate, blockAlign = CH*2, dataLen = len*blockAlign;
+    var buf = new ArrayBuffer(44+dataLen), dv = new DataView(buf);
+    var ws = function(off,s){ for (var i=0;i<s.length;i++) dv.setUint8(off+i, s.charCodeAt(i)); };
+    ws(0,'RIFF'); dv.setUint32(4,36+dataLen,true); ws(8,'WAVE'); ws(12,'fmt '); dv.setUint32(16,16,true);
+    dv.setUint16(20,1,true); dv.setUint16(22,CH,true); dv.setUint32(24,sr,true); dv.setUint32(28,sr*blockAlign,true);
+    dv.setUint16(32,blockAlign,true); dv.setUint16(34,16,true); ws(36,'data'); dv.setUint32(40,dataLen,true);
+    var off=44; for (var i=0;i<len;i++){ for (var ch=0; ch<CH; ch++){ var s=Math.max(-1,Math.min(1,flat[ch][i])); dv.setInt16(off, s<0?s*0x8000:s*0x7fff, true); off+=2; } }
+    var bin='', u8=new Uint8Array(buf); for (var i=0;i<u8.length;i++) bin+=String.fromCharCode(u8[i]);
+    return { b64: btoa(bin), len: len, sr: sr, osc: window.__oscLog };
+  })()`) as { b64?: string; len?: number; sr?: number; osc?: string[]; err?: string }
+
+  if (out.err) { console.log('PROBE ERROR:', out.err); await browser.close(); return }
+  writeFileSync(resolve(OUT_DIR, 'engine_saw_fresh.wav'), Buffer.from(out.b64!, 'base64'))
+  console.log(`saved engine_saw_fresh.wav (${out.len} frames @ ${out.sr}Hz)`)
+  console.log(`\n=== ALL OSC the engine sent (${out.osc!.length} msgs) ===`)
+  for (const line of out.osc!) console.log('  ' + line)
+  await browser.close()
+}
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/tools/harmonic-analysis.py
+++ b/tools/harmonic-analysis.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Harmonic content analysis for the SP108 raw-ugen test (issue #417).
+
+For each WAV: crest factor (peak/RMS) + the magnitude of the fundamental and its
+first N harmonics from an FFT of a steady mid-segment.
+
+A pure sine ⇒ crest ≈ 1.414, single peak at f0, harmonics << fundamental.
+A band-limited saw ⇒ crest ≈ 2.0+, harmonics following a ~1/n series.
+
+Usage: python3 tools/harmonic-analysis.py <f0> file1.wav [file2.wav ...]
+"""
+import sys, wave, struct
+import numpy as np
+
+
+def read_wav(path):
+    w = wave.open(path, 'rb')
+    n, ch, sr, sw = w.getnframes(), w.getnchannels(), w.getframerate(), w.getsampwidth()
+    raw = w.readframes(n)
+    w.close()
+    if sw != 2:
+        raise SystemExit(f'{path}: expected 16-bit PCM, got {sw*8}-bit')
+    data = np.frombuffer(raw, dtype='<i2').astype(np.float64) / 32768.0
+    data = data.reshape(-1, ch)
+    return data, sr, ch
+
+
+def analyze(path, f0):
+    data, sr, ch = read_wav(path)
+    # pick the louder channel (mono-left bug awareness, SP107)
+    rms_ch = [np.sqrt(np.mean(data[:, c] ** 2)) for c in range(ch)]
+    c = int(np.argmax(rms_ch))
+    x = data[:, c]
+    # steady mid-segment: middle 50%
+    s, e = int(len(x) * 0.25), int(len(x) * 0.75)
+    seg = x[s:e]
+    seg = seg[: (len(seg) // 2) * 2]
+    if len(seg) < sr // 4:
+        print(f'{path}: too short / silent (len={len(seg)})'); return
+    peak = float(np.max(np.abs(seg)))
+    rms = float(np.sqrt(np.mean(seg ** 2)))
+    crest = peak / rms if rms > 0 else float('nan')
+
+    # FFT magnitude spectrum (Hann window)
+    win = np.hanning(len(seg))
+    sp = np.abs(np.fft.rfft(seg * win))
+    freqs = np.fft.rfftfreq(len(seg), 1.0 / sr)
+    binhz = freqs[1] - freqs[0]
+
+    def mag_at(f):
+        if f >= sr / 2:
+            return 0.0
+        center = int(round(f / binhz))
+        lo, hi = max(0, center - 3), min(len(sp), center + 4)
+        return float(np.max(sp[lo:hi]))
+
+    fund = mag_at(f0)
+    print(f'\n{path}  (ch={c}, sr={sr})')
+    print(f'  crest factor (peak/RMS) = {crest:.3f}   [sine≈1.414, saw≈2.0+]   peak={peak:.3f} rms={rms:.4f}')
+    if fund <= 0:
+        print('  fundamental is zero — silent or wrong f0'); return
+    print(f'  harmonic series (relative to H1):')
+    energy_above = 0.0
+    for h in range(1, 13):
+        m = mag_at(f0 * h)
+        rel = m / fund
+        bar = '#' * int(min(40, rel * 40))
+        ideal = 1.0 / h  # ideal saw 1/n
+        print(f'   H{h:2d} {f0*h:7.1f}Hz  {rel:6.3f}  {bar:<40} (saw ideal {ideal:.3f})')
+        if h >= 2:
+            energy_above += m * m
+    thd_like = np.sqrt(energy_above) / fund
+    print(f'  sum(H2..H12)/H1 (harmonic richness) = {thd_like:.3f}   [pure sine≈0, saw≫0]')
+
+
+def main():
+    if len(sys.argv) < 3:
+        raise SystemExit('usage: harmonic-analysis.py <f0> file.wav ...')
+    f0 = float(sys.argv[1])
+    for p in sys.argv[2:]:
+        analyze(p, f0)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/monitor-path-probe.ts
+++ b/tools/monitor-path-probe.ts
@@ -1,0 +1,108 @@
+/**
+ * Monitor-path isolation probe (SP108 / #417 round 5).
+ *
+ * Replicates the live_loop routing WITHOUT a live_loop and WITHOUT a hot-swap:
+ *   real sonic-pi-saw (cutoff 130) → out_bus = freshly allocated bus B
+ *   sonic_pi_track_monitor: In.ar(B,2) → Out.ar(0) [+ track bus]
+ * then records masterOutputNode.
+ *
+ * Round 3 proved sonic-pi-saw → out_bus 0 (direct) = full harmonics.
+ * If routing through the monitor turns it into a sine, the per-loop monitor /
+ * In.ar path is the harmonic-stripping culprit.
+ *
+ * Variants:
+ *   A. direct  : saw → out_bus 0                       (control, expect harmonics)
+ *   B. monitor : saw → bus B ; monitor In.ar(B) → 0    (expect ??? )
+ *
+ * Usage: npx tsx tools/monitor-path-probe.ts
+ */
+import { chromium } from '@playwright/test'
+import { writeFileSync, mkdirSync } from 'fs'
+import { resolve } from 'path'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const OUT_DIR = '/tmp/sp108-raw-ugen'
+const REC_MS = 2500
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+  const browser = await chromium.launch({ headless: false, args: ['--autoplay-policy=no-user-gesture-required'] })
+  const page = await (await browser.newContext()).newPage()
+  page.on('pageerror', (e) => console.log(`  [pageerror] ${e.message}`))
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(1500)
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click(); await page.keyboard.press('Meta+a'); await page.keyboard.press('Backspace')
+  await editor.fill('sleep 0.1')
+  await page.locator('.spw-btn-label:has-text("Run")').click()
+  await page.waitForFunction(() => {
+    const e: any = (window as any).__spw_engine
+    return e && e.bridge && e.bridge.sonic && e.bridge.audioContext && e.bridge.audioContext.state === 'running' && e.bridge.masterOutputNode
+  }, { timeout: 20000 })
+  await page.waitForTimeout(500)
+
+  // Each variant returns {b64,len,sr,info}. `useMonitor` toggles the routing.
+  const variants = [
+    { label: 'mp_direct', useMonitor: false },
+    { label: 'mp_monitor', useMonitor: true },
+  ]
+  let nid = 9501
+  for (const v of variants) {
+    console.log(`\n── ${v.label} (monitor=${v.useMonitor}) ──`)
+    const arg = JSON.stringify({ useMonitor: v.useMonitor, durMs: REC_MS, nid })
+    const out = await page.evaluate(`(async (A) => {
+      var e = window.__spw_engine, bridge = e.bridge, sonic = bridge.sonic;
+      var ctx = bridge.audioContext, tap = bridge.masterOutputNode;
+      var info = {};
+      var sawOutBus = 0, monId = 0, loopBus = 0;
+      if (A.useMonitor) {
+        loopBus = bridge.allocateBus();          // same call createLoopMonitor uses
+        sawOutBus = loopBus;
+        monId = sonic.nextNodeId();
+        // monitor in group 102 (after synths group 100, before mixer)
+        sonic.send('/s_new', 'sonic_pi_track_monitor', monId, 1, 102,
+          'in_bus', loopBus, 'out_bus_master', 0, 'out_bus_track', 0, 'amp', 1);
+        info.loopBus = loopBus; info.monId = monId;
+        await new Promise(function(r){ setTimeout(r, 100); });
+      }
+      // start tap
+      var CH = 2, BUF = 4096, chunks = [[], []];
+      var sp = ctx.createScriptProcessor(BUF, CH, CH);
+      sp.onaudioprocess = function(ev){ var inp = ev.inputBuffer; var nc = Math.min(inp.numberOfChannels, CH); for (var ch=0; ch<nc; ch++) chunks[ch].push(new Float32Array(inp.getChannelData(ch))); };
+      var sink = ctx.createGain(); sink.gain.value = 0;
+      tap.connect(sp); sp.connect(sink); sink.connect(ctx.destination);
+
+      sonic.send('/s_new', 'sonic-pi-saw', A.nid, 0, 100,
+        'note', 52, 'amp', 1, 'attack', 0, 'sustain', 3, 'release', 0.2, 'cutoff', 130, 'out_bus', sawOutBus);
+      info.sawOutBus = sawOutBus;
+      await new Promise(function(r){ setTimeout(r, A.durMs); });
+      sonic.send('/n_free', A.nid);
+      if (monId) sonic.send('/n_free', monId);
+
+      await new Promise(function(r){ setTimeout(r, (BUF / ctx.sampleRate) * 1000 + 60); });
+      try { tap.disconnect(sp); } catch(_){}
+      try { sp.disconnect(); } catch(_){}
+      try { sink.disconnect(); } catch(_){}
+      sp.onaudioprocess = null;
+
+      var len = chunks[0].reduce(function(a,c){ return a+c.length; }, 0);
+      var flat = chunks.map(function(cs){ var o=new Float32Array(len),q=0; for (var i=0;i<cs.length;i++){o.set(cs[i],q);q+=cs[i].length;} return o; });
+      var sr = ctx.sampleRate, blockAlign = CH*2, dataLen = len*blockAlign;
+      var buf = new ArrayBuffer(44+dataLen), dv = new DataView(buf);
+      var ws = function(off,s){ for (var i=0;i<s.length;i++) dv.setUint8(off+i, s.charCodeAt(i)); };
+      ws(0,'RIFF'); dv.setUint32(4,36+dataLen,true); ws(8,'WAVE'); ws(12,'fmt '); dv.setUint32(16,16,true);
+      dv.setUint16(20,1,true); dv.setUint16(22,CH,true); dv.setUint32(24,sr,true); dv.setUint32(28,sr*blockAlign,true);
+      dv.setUint16(32,blockAlign,true); dv.setUint16(34,16,true); ws(36,'data'); dv.setUint32(40,dataLen,true);
+      var off=44; for (var i=0;i<len;i++){ for (var ch=0; ch<CH; ch++){ var s=Math.max(-1,Math.min(1,flat[ch][i])); dv.setInt16(off, s<0?s*0x8000:s*0x7fff, true); off+=2; } }
+      var bin='', u8=new Uint8Array(buf); for (var i=0;i<u8.length;i++) bin+=String.fromCharCode(u8[i]);
+      return { b64: btoa(bin), len: len, sr: sr, info: info };
+    })(${arg})`) as { b64: string; len: number; sr: number; info: any }
+    nid++
+    writeFileSync(resolve(OUT_DIR, `${v.label}.wav`), Buffer.from(out.b64, 'base64'))
+    console.log(`  saved ${v.label}.wav  routing=${JSON.stringify(out.info)}`)
+    await page.waitForTimeout(300)
+  }
+  await browser.close()
+}
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/tools/raw-ugen-test.ts
+++ b/tools/raw-ugen-test.ts
@@ -1,0 +1,261 @@
+/**
+ * Raw UGen test — the SP108 decisive fork (issue #417).
+ *
+ * Hand-builds minimal SCgf v1 synthdefs that contain ONLY one oscillator ugen
+ * (no LPF, no Normalizer, no envelope), sends them to the live WASM scsynth via
+ * raw /d_recv + /s_new through the SAME routing real synths use (group 100 →
+ * bus 0 → mixer → output), and records each via a masterOutputNode tap.
+ *
+ * This isolates the oscillator ugen from the `sonic-pi-saw` synthdef chain:
+ *   rawsaw = Out.ar(0, Saw.ar(220) * 0.3)      ← no LPF/Normalizer
+ *   rawsin = Out.ar(0, SinOsc.ar(220) * 0.3)   ← control (known-good)
+ *   rawpulse = Out.ar(0, Pulse.ar(220,0.5) * 0.3)
+ *
+ * If rawsaw renders as a sine (crest ≈ 1.414, single peak) → the WASM `Saw`
+ * ugen itself is broken (upstream / core build). If rawsaw shows the 1/n
+ * harmonic series → the culprit is downstream in sonic-pi-saw (LPF/Normalizer).
+ *
+ * SCgf v1 encoder mirrors src/engine/buildTrackMonitorSynthDef.ts.
+ * Browser plumbing mirrors tools/capture.ts.
+ *
+ * Usage: npx tsx tools/raw-ugen-test.ts
+ */
+
+import { chromium } from '@playwright/test'
+import { writeFileSync, mkdirSync } from 'fs'
+import { resolve } from 'path'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const OUT_DIR = process.env.OUT_DIR ?? '/tmp/sp108-raw-ugen'
+const REC_MS = 2500
+
+// ── SCgf v1 encoder ──────────────────────────────────────────────────────
+const R_SCALAR = 0, R_CONTROL = 1, R_AUDIO = 2
+const BINOP_MUL = 2
+
+interface UGen {
+  name: string
+  rate: number
+  inputs: Array<[number, number]> // [ugenIdx, outIdx] ; ugenIdx -1 ⇒ outIdx is constant index
+  numOut: number
+  outRate: number
+  special?: number
+}
+
+function f32be(n: number): number[] { const b = Buffer.alloc(4); b.writeFloatBE(n, 0); return [...b] }
+function i32be(n: number): number[] { const b = Buffer.alloc(4); b.writeInt32BE(n, 0); return [...b] }
+function i16be(n: number): number[] { const b = Buffer.alloc(2); b.writeInt16BE(n, 0); return [...b] } // handles negatives
+function pstr(s: string): number[] { return [s.length, ...[...s].map((c) => c.charCodeAt(0))] }
+
+function buildSynthDef(name: string, constants: number[], ugens: UGen[]): number[] {
+  const out: number[] = []
+  out.push(0x53, 0x43, 0x67, 0x66)        // "SCgf"
+  out.push(...i32be(1))                    // version 1
+  out.push(...i16be(1))                    // numDefs
+  out.push(...pstr(name))
+  out.push(...i16be(constants.length))
+  for (const c of constants) out.push(...f32be(c))
+  out.push(...i16be(0))                    // numParams
+  out.push(...i16be(0))                    // numParamNames
+  out.push(...i16be(ugens.length))
+  for (const u of ugens) {
+    out.push(...pstr(u.name))
+    out.push(u.rate & 0xff)                // i8 rate
+    out.push(...i16be(u.inputs.length))
+    out.push(...i16be(u.numOut))
+    out.push(...i16be(u.special ?? 0))
+    for (const [a, b] of u.inputs) { out.push(...i16be(a)); out.push(...i16be(b)) }
+    for (let i = 0; i < u.numOut; i++) out.push(u.outRate & 0xff)
+  }
+  out.push(...i16be(0))                    // numVariants
+  return out
+}
+
+// Out.ar(0, [sig, sig]) where sig is ugen index `sigIdx` output 0; bus is constant `busConstIdx`.
+function outStereo(sigIdx: number, busConstIdx: number): UGen {
+  return { name: 'Out', rate: R_AUDIO, inputs: [[-1, busConstIdx], [sigIdx, 0], [sigIdx, 0]], numOut: 0, outRate: R_AUDIO }
+}
+
+// Each def: constants laid out as [freq, zero/bus, mul, (extra)].
+const DEFS: Record<string, number[]> = {
+  // SinOsc.ar(220, 0) * 0.3 → Out.ar(0, [.,.])
+  sonic_pi_rawsin: buildSynthDef('sonic_pi_rawsin', [220, 0, 0.3], [
+    { name: 'SinOsc', rate: R_AUDIO, inputs: [[-1, 0], [-1, 1]], numOut: 1, outRate: R_AUDIO },      // freq, phase=0
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[0, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(1, 1),
+  ]),
+  // Saw.ar(220) * 0.3 → Out.ar(0, [.,.])  — NO LPF, NO Normalizer
+  sonic_pi_rawsaw: buildSynthDef('sonic_pi_rawsaw', [220, 0, 0.3], [
+    { name: 'Saw', rate: R_AUDIO, inputs: [[-1, 0]], numOut: 1, outRate: R_AUDIO },                  // freq
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[0, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(1, 1),
+  ]),
+  // Pulse.ar(220, 0.5) * 0.3 → Out.ar(0, [.,.])
+  sonic_pi_rawpulse: buildSynthDef('sonic_pi_rawpulse', [220, 0, 0.3, 0.5], [
+    { name: 'Pulse', rate: R_AUDIO, inputs: [[-1, 0], [-1, 3]], numOut: 1, outRate: R_AUDIO },       // freq, width=0.5
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[0, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(1, 1),
+  ]),
+  // LFSaw.ar(220) * 0.3 — the NAIVE (aliased, non-band-limited) saw, as a cross-check.
+  // If Saw==sine but LFSaw has harmonics, the band-limited family specifically is broken.
+  sonic_pi_rawlfsaw: buildSynthDef('sonic_pi_rawlfsaw', [220, 0, 0.3], [
+    { name: 'LFSaw', rate: R_AUDIO, inputs: [[-1, 0], [-1, 1]], numOut: 1, outRate: R_AUDIO },       // freq, iphase=0
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[0, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(1, 1),
+  ]),
+
+  // ── Round 2: isolate the downstream ugens unique to sonic-pi-saw ──
+  // Saw(220) → LPF(cutoff=18000, wide open) → *0.3 → Out. If this is a sine, LPF ugen is broken.
+  // constants: [freq, bus0, mul, cutoff]
+  sonic_pi_sawlpf: buildSynthDef('sonic_pi_sawlpf', [220, 0, 0.3, 18000], [
+    { name: 'Saw', rate: R_AUDIO, inputs: [[-1, 0]], numOut: 1, outRate: R_AUDIO },
+    { name: 'LPF', rate: R_AUDIO, inputs: [[0, 0], [-1, 3]], numOut: 1, outRate: R_AUDIO },          // in, freq=18000
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[1, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(2, 1),
+  ]),
+  // Saw(220) → Normalizer(level=1, dur=0.01) → *0.3 → Out. If this is a sine, Normalizer ugen is broken.
+  // constants: [freq, bus0, mul, level, dur]
+  sonic_pi_sawnorm: buildSynthDef('sonic_pi_sawnorm', [220, 0, 0.3, 1, 0.01], [
+    { name: 'Saw', rate: R_AUDIO, inputs: [[-1, 0]], numOut: 1, outRate: R_AUDIO },
+    { name: 'Normalizer', rate: R_AUDIO, inputs: [[0, 0], [-1, 3], [-1, 4]], numOut: 1, outRate: R_AUDIO }, // in, level, dur(ir)
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[1, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(2, 1),
+  ]),
+  // Full chain: Saw → LPF(18000) → Normalizer → *0.3 → Out. Should reproduce the real :saw bug.
+  sonic_pi_sawlpfnorm: buildSynthDef('sonic_pi_sawlpfnorm', [220, 0, 0.3, 18000, 1, 0.01], [
+    { name: 'Saw', rate: R_AUDIO, inputs: [[-1, 0]], numOut: 1, outRate: R_AUDIO },
+    { name: 'LPF', rate: R_AUDIO, inputs: [[0, 0], [-1, 3]], numOut: 1, outRate: R_AUDIO },
+    { name: 'Normalizer', rate: R_AUDIO, inputs: [[1, 0], [-1, 4], [-1, 5]], numOut: 1, outRate: R_AUDIO },
+    { name: 'BinaryOpUGen', rate: R_AUDIO, inputs: [[2, 0], [-1, 2]], numOut: 1, outRate: R_AUDIO, special: BINOP_MUL },
+    outStereo(3, 1),
+  ]),
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true })
+  console.log('Launching Chromium (headed, audio)...')
+  const browser = await chromium.launch({ headless: false, args: ['--autoplay-policy=no-user-gesture-required'] })
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  page.on('console', (m) => { const t = m.text(); if (/error|fail|not installed|warn|\[raw\]/i.test(t)) console.log(`  [page:${m.type()}] ${t}`) })
+  page.on('pageerror', (e) => console.log(`  [pageerror] ${e.message}`))
+
+  await page.goto(BASE_URL)
+  await page.waitForTimeout(1500)
+  if (!(await page.evaluate(() => Boolean(document.querySelector('#app'))))) {
+    throw new Error(`${BASE_URL} is not the SonicPi.js app (run npm run dev first).`)
+  }
+
+  // Boot the engine (init happens on first Run). Run a silent snippet.
+  const editor = page.locator('.cm-content, textarea').first()
+  await editor.click()
+  await page.keyboard.press('Meta+a')
+  await page.keyboard.press('Backspace')
+  await editor.fill('sleep 0.1')
+  await page.locator('.spw-btn-label:has-text("Run")').click()
+
+  // Wait for engine + bridge.sonic + running audio context.
+  await page.waitForFunction(() => {
+    const e: any = (window as any).__spw_engine
+    return e && e.bridge && e.bridge.sonic && e.bridge.audioContext && e.bridge.audioContext.state === 'running' && e.bridge.masterOutputNode
+  }, { timeout: 20000 })
+  console.log('Engine + scsynth ready.')
+  await page.waitForTimeout(500)
+
+  // ── Round 3: drive the REAL, already-loaded sonic-pi-saw via raw /s_new ──
+  // Bypasses the engine SoundLayer. params flattened [k,v,k,v,...].
+  // note 52 = E3. cutoff 130 ≈ 14.9kHz (wide open). out_bus 0.
+  const REAL_TESTS: Array<{ label: string; synth: string; params: (string | number)[] }> = [
+    { label: 'real_saw_cut130', synth: 'sonic-pi-saw', params: ['note', 52, 'amp', 1, 'attack', 0, 'decay', 0, 'sustain', 3, 'release', 0.2, 'cutoff', 130, 'env_curve', 1, 'out_bus', 0, 'pan', 0] },
+    { label: 'real_saw_cut140', synth: 'sonic-pi-saw', params: ['note', 52, 'amp', 1, 'attack', 0, 'decay', 0, 'sustain', 3, 'release', 0.2, 'cutoff', 140, 'env_curve', 1, 'out_bus', 0, 'pan', 0] },
+    { label: 'real_saw_default', synth: 'sonic-pi-saw', params: ['note', 52, 'amp', 1, 'sustain', 3, 'out_bus', 0] },
+  ]
+
+  // Unified job list: hand-built defs (need /d_recv) + real synths (params only).
+  const jobs: Array<{ label: string; name: string; bytes: number[] | null; params: (string | number)[] }> = [
+    ...Object.entries(DEFS).map(([name, bytes]) => ({ label: name, name, bytes, params: [] as (string | number)[] })),
+    ...REAL_TESTS.map((t) => ({ label: t.label, name: t.synth, bytes: null, params: t.params })),
+  ]
+
+  let nodeId = 9001
+  for (const job of jobs) {
+    const { label, name, bytes, params } = job
+    console.log(`\n── ${label}${bytes ? ` (${bytes.length} bytes)` : ` [real ${name}]`} ──`)
+    // In-page code passed as a STRING literal so esbuild/tsx does not inject
+    // its `__name` helper into the page (which has no such global) — same
+    // workaround capture.ts uses for its engine hook.
+    const arg = JSON.stringify({ name, bytes, params, durMs: REC_MS, nid: nodeId })
+    const b64 = await page.evaluate(`(async (A) => {
+      var e = window.__spw_engine;
+      var bridge = e.bridge, sonic = bridge.sonic;
+      var ctx = bridge.audioContext;
+      var tap = bridge.masterOutputNode;
+
+      if (A.bytes) {
+        sonic.send('/d_recv', new Uint8Array(A.bytes));
+        await new Promise(function(r){ setTimeout(r, 300); });
+      }
+
+      var CH = 2, BUF = 4096;
+      var chunks = [[], []];
+      var sp = ctx.createScriptProcessor(BUF, CH, CH);
+      sp.onaudioprocess = function(ev){
+        var inp = ev.inputBuffer;
+        var nc = Math.min(inp.numberOfChannels, CH);
+        for (var ch = 0; ch < nc; ch++) { chunks[ch].push(new Float32Array(inp.getChannelData(ch))); }
+      };
+      var sink = ctx.createGain(); sink.gain.value = 0;
+      tap.connect(sp); sp.connect(sink); sink.connect(ctx.destination);
+
+      sonic.send.apply(sonic, ['/s_new', A.name, A.nid, 1, 100].concat(A.params || []));
+      await new Promise(function(r){ setTimeout(r, A.durMs); });
+      sonic.send('/n_free', A.nid);
+
+      await new Promise(function(r){ setTimeout(r, (BUF / ctx.sampleRate) * 1000 + 60); });
+      try { tap.disconnect(sp); } catch(_) {}
+      try { sp.disconnect(); } catch(_) {}
+      try { sink.disconnect(); } catch(_) {}
+      sp.onaudioprocess = null;
+
+      var len = chunks[0].reduce(function(a,c){ return a + c.length; }, 0);
+      var flat = chunks.map(function(cs){
+        var o = new Float32Array(len), p = 0;
+        for (var i = 0; i < cs.length; i++) { o.set(cs[i], p); p += cs[i].length; }
+        return o;
+      });
+      var sr = ctx.sampleRate;
+      var blockAlign = CH * 2;
+      var dataLen = len * blockAlign;
+      var buf = new ArrayBuffer(44 + dataLen);
+      var dv = new DataView(buf);
+      var ws = function(off, s){ for (var i = 0; i < s.length; i++) dv.setUint8(off + i, s.charCodeAt(i)); };
+      ws(0, 'RIFF'); dv.setUint32(4, 36 + dataLen, true); ws(8, 'WAVE');
+      ws(12, 'fmt '); dv.setUint32(16, 16, true); dv.setUint16(20, 1, true); dv.setUint16(22, CH, true);
+      dv.setUint32(24, sr, true); dv.setUint32(28, sr * blockAlign, true);
+      dv.setUint16(32, blockAlign, true); dv.setUint16(34, 16, true);
+      ws(36, 'data'); dv.setUint32(40, dataLen, true);
+      var off = 44;
+      for (var i = 0; i < len; i++) {
+        for (var ch = 0; ch < CH; ch++) {
+          var s = Math.max(-1, Math.min(1, flat[ch][i]));
+          dv.setInt16(off, s < 0 ? s * 0x8000 : s * 0x7fff, true); off += 2;
+        }
+      }
+      var bin = '';
+      var u8 = new Uint8Array(buf);
+      for (var i = 0; i < u8.length; i++) bin += String.fromCharCode(u8[i]);
+      return { b64: btoa(bin), len: len, sr: sr };
+    })(${arg})`) as { b64: string; len: number; sr: number }
+
+    nodeId++
+    const wavPath = resolve(OUT_DIR, `${label}.wav`)
+    writeFileSync(wavPath, Buffer.from(b64.b64, 'base64'))
+    console.log(`  saved ${wavPath}  (${b64.len} frames @ ${b64.sr}Hz)`)
+    await page.waitForTimeout(300)
+  }
+
+  await browser.close()
+  console.log(`\nDone. WAVs in ${OUT_DIR}`)
+}
+
+main().catch((e) => { console.error(e); process.exit(1) })


### PR DESCRIPTION
## Summary

A top-level `use_synth :X` placed **before** a `live_loop` was silently dropped when **bare top-level code followed the loop** — the loop played `:beep` instead of `:X`. This was the true root of the SP108/#417 *"saw renders as a pure sine"* report (the WASM oscillators were always fine — the engine was simply dispatching `:beep`, a SinOsc), and it contaminated **every** `use_synth + live_loop` capture via `capture.ts`'s `with_bpm 60 { sleep N }` recording wrap (#418).

### Mechanism
`wrapBareCode` defers `use_synth` into the synthetic `live_loop :__run_once`, so when the user loop registers (`SonicPiEngine.ts:879` reads `defaultSynth`) the value is still `'beep'` — `use_synth` runs *deferred* at scheduler time, not *eagerly* at build time. With no trailing bare code, `use_synth` is emitted eager and the bug doesn't fire.

### Fix (vyapti SV55 — desktop fork-snapshot parity)
Desktop SP snapshots `current_synth` at the loop's fork point in **sequential source order** (`runtime.rb:1067`); trailing code is irrelevant and `use_synth` *after* a loop doesn't apply. `transpileProgram` now restores this: it tracks the top-level `use_synth` in source order (`currentTopSynth`), tags each registration-capturing block (`blockSynth`), and emits an eager `use_synth("X")` before each `live_loop`/auto-`loop` registration in `blockJS`.

- `use_synth` **still** flows deferred to `__run_once` → bare-play interleave preserved (SP36/#164 untouched).
- Non-literal args (`use_synth foo`) → no prefix, no guess.
- Loop-*before*-`use_synth` → not tagged (forward-only snapshot).
- Restricted to `live_loop`/`loop`; `in_thread` inheritance stays owned by SP72's parentBuilder path (SV28).
- **No `capture.ts` change** — the engine fix clears the #418 contamination on its own (a capture-only fix is infeasible per #266: the recording scaffold must be bare top-level, which is the trigger).

## Test plan

**Unit (TDD, RED→GREEN):** new `#419 / SV55` describe block in `TreeSitterTranspiler.test.ts` — T-A (the bug), T-B (multi-loop source-order), T-C (loop-before-use_synth not tagged), T-D (non-literal → no prefix/no crash), T-E (engine: loop registers `currentSynth='saw'`), T-F (regression SP36/#164 interleave), T-G (regression SP72 in_thread no eager leak). `1080/1080` vitest, `tsc --noEmit` clean.

**Level-3 (Lokayata, audio observation):**
- `tools/engine-saw-osc-probe.ts` → OSC now `/s_new "sonic-pi-saw"` (was `sonic-pi-beep`); `harmonic-analysis.py` richness **0.645** (pure sine ≈ 0).
- `capture.ts --file iso_saw_hicut.rb --wrap-recording 5` → sidecar shows `sonic-pi-saw`; WAV richness **0.581**. #418 contamination cleared with no capture.ts edit.

## Follow-ups (out of scope)
- `use_synth_defaults` / `use_transpose` registration visibility (same fork-snapshot mechanism — mechanical when a test shows need).
- `with_fx`-wrapped `live_loop` eager prefix (no regression — was already `:beep`; restricted to `live_loop`/`loop` this pass).
- Re-sweep parity examples previously mis-measured as `:beep` (separate instrument task; cause is now removed engine-side).

Closes #419. Resolves the engine root of #417 and the capture contamination of #418.