### PR TITLE
🐛 fix(engine): mod_303_phade silent-run race — immediate-timetag FX ordering (#423); honest launch gate

### DIFF
--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -440,6 +440,13 @@ export async function runProgram(
             // the inline `__run_once` path was the one create site still using a
             // future timetag. The inner synth still plays at vt + schedAhead, so
             // it lands after the (already-instantiated) FX chain.
+            //
+            // Drain any messages already queued THIS iteration (e.g. a `play`
+            // earlier in the same iteration with no intervening sleep) at THEIR
+            // own time first — the FX flush below uses timetag 0, and folding a
+            // pending future-timed /s_new into that immediate bundle would fire
+            // it early. No-op when the queue is empty (the mod_303 case).
+            ctx.bridge.flushMessages()
             const fxWarn = ctx.printHandler
               ? (m: string) => ctx.printHandler!(`[Warning] with_fx :${step.name} — ${m}`)
               : undefined

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -421,17 +421,35 @@ export async function runProgram(
           const fxGroupId = ctx.bridge.createFxGroup()
           let fxNodeId: number | undefined
           try {
-            const audioTime = task.virtualTime + ctx.schedAheadTime
+            // SP83/#423: create the FX node with an IMMEDIATE timetag (0), not
+            // the future `vt + schedAhead`. A future timetag puts the /s_new in
+            // the prescheduler's time-ordered queue; sibling FX in a nested
+            // chain (reverb→slicer) share that exact timetag because no sleep
+            // separates the with_fx entry from its body, and the WASM
+            // prescheduler does not guarantee FIFO for equal-timetag bundles
+            // under the bundle pressure a concurrent live_loop adds. The two FX
+            // /s_new then land in either tree order within group 101 — and
+            // `applyFxImmediate` uses addToHead, so a reversed processing order
+            // inverts the chain (reverb runs before slicer, reading an unwritten
+            // bus) → the whole node lifetime is silent (~20% of mod_303_phade
+            // runs; OSC byte-identical between good and silent runs — the race
+            // is purely scsynth-side ordering). Timetag 0/1 bypasses the
+            // prescheduler (`bypassImmediate`) → FIFO dispatch → the outer FX is
+            // instantiated before the inner, deterministically. This is exactly
+            // how preCreatePersistentFx (SV37) keeps loop-WRAPPING FX race-free;
+            // the inline `__run_once` path was the one create site still using a
+            // future timetag. The inner synth still plays at vt + schedAhead, so
+            // it lands after the (already-instantiated) FX chain.
             const fxWarn = ctx.printHandler
               ? (m: string) => ctx.printHandler!(`[Warning] with_fx :${step.name} — ${m}`)
               : undefined
             const fxOpts = normalizeFxParams(step.name, step.opts, currentBpm, fxWarn)
-            fxNodeId = await ctx.bridge.applyFx(step.name, audioTime, fxOpts, newBus, prevOutBus)
+            fxNodeId = await ctx.bridge.applyFx(step.name, 0, fxOpts, newBus, prevOutBus)
             if (step.nodeRef && fxNodeId !== undefined) {
               ctx.nodeRefMap.set(step.nodeRef, fxNodeId)
             }
             task.outBus = newBus
-            ctx.bridge.flushMessages()
+            ctx.bridge.flushMessages(0)
             // Store for reuse — with pending kill timer as safety net.
             // aliveUntil starts at the current vt (no plays yet); `case 'play'`
             // bumps it as inner synths dispatch.

--- a/test_results/launch-gate.html
+++ b/test_results/launch-gate.html
@@ -29,22 +29,21 @@
     <a href="e2e.html">E2E suite</a>
     <a href="community.html">community + forum</a>
     <a href="launch-gate.html" data-active="1">🚦 Launch Gate</a>
-    <a href="mono-sample-sp107.html" style="margin-left:auto">SP107 mono-sample fix →</a>
   </nav>
   <div class="wrap">
     <h1>Launch Gate — PRNG-free non-heavy official roster</h1>
-    <div class="verdict pass">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
+    <div class="verdict fail">4/7 = 57.1% · threshold ≥70% · ❌ NOT MET</div>
     <p class="note">Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly <b>projection</b> that exercises the same engine logic (<code>tools/gate-reproducers/</code>). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation. Projection verdicts depend on #405 + #409 (merged), re-captured live on merged main.</p>
     <table>
       <thead><tr><th>Row</th><th>Raw sweep</th><th>Gate verdict</th><th>Graded via</th><th>Detail</th></tr></thead>
       <tbody>
-        <tr class="pass"><td>✅ chord_inversions</td><td>inconcl</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md</td></tr>
+        <tr class="pass"><td>✅ chord_inversions</td><td>match</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md</td></tr>
         <tr class="pass"><td>✅ reich_phase</td><td>match</td><td><b>match</b></td><td>raw-sweep</td><td class="detail"></td></tr>
         <tr class="warn"><td>⚠️ dark_neon</td><td>inconcl</td><td><b>inconcl</b></td><td>documented-limitation</td><td class="detail">One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage.</td></tr>
-        <tr class="pass"><td>✅ mod_303_phade</td><td>inconcl</td><td><b>match</b></td><td>raw-refreshed</td><td class="detail">re-measured → compare_2026-05-29T08-33-35-255Z_mod_303_phade.md</td></tr>
+        <tr class="fail"><td>❌ mod_303_phade</td><td>inconcl</td><td><b>diverge</b></td><td>documented-limitation</td><td class="detail">REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example.</td></tr>
         <tr class="warn"><td>⚠️ bach</td><td>inconcl</td><td><b>inconcl</b></td><td>documented-limitation</td><td class="detail">Sustained :beep polyphony — desktop onset detector finds ~3 onsets in 9s (#368); the web capture renders the full ~95s composition vs the windowed desktop capture (#406). No faithful gradeable projection: a monophonic literal-note list would test almost nothing (bach's substance is timing + concurrent in_thread alignment, exactly what's not onset-gradeable).</td></tr>
         <tr class="pass"><td>✅ driving_pulse</td><td>match</td><td><b>match</b></td><td>raw-sweep</td><td class="detail"></td></tr>
-        <tr class="pass"><td>✅ monday_blues</td><td>inconcl</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106</td></tr>
+        <tr class="pass"><td>✅ monday_blues</td><td>match</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106</td></tr>
       </tbody>
     </table>
     <h2 style="font-size:15px">Excluded from denominator <span class="detail">(SV49 — cross-engine PRNG is a v1 non-goal)</span></h2>

--- a/test_results/launch-gate.html
+++ b/test_results/launch-gate.html
@@ -32,7 +32,7 @@
   </nav>
   <div class="wrap">
     <h1>Launch Gate — PRNG-free non-heavy official roster</h1>
-    <div class="verdict fail">4/7 = 57.1% · threshold ≥70% · ❌ NOT MET</div>
+    <div class="verdict pass">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
     <p class="note">Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly <b>projection</b> that exercises the same engine logic (<code>tools/gate-reproducers/</code>). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation. Projection verdicts depend on #405 + #409 (merged), re-captured live on merged main.</p>
     <table>
       <thead><tr><th>Row</th><th>Raw sweep</th><th>Gate verdict</th><th>Graded via</th><th>Detail</th></tr></thead>
@@ -40,7 +40,7 @@
         <tr class="pass"><td>✅ chord_inversions</td><td>match</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md</td></tr>
         <tr class="pass"><td>✅ reich_phase</td><td>match</td><td><b>match</b></td><td>raw-sweep</td><td class="detail"></td></tr>
         <tr class="warn"><td>⚠️ dark_neon</td><td>inconcl</td><td><b>inconcl</b></td><td>documented-limitation</td><td class="detail">One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage.</td></tr>
-        <tr class="fail"><td>❌ mod_303_phade</td><td>inconcl</td><td><b>diverge</b></td><td>documented-limitation</td><td class="detail">REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example.</td></tr>
+        <tr class="pass"><td>✅ mod_303_phade</td><td>inconcl</td><td><b>match</b></td><td>raw-refreshed</td><td class="detail">re-measured → compare_2026-05-30T19-32-34-562Z_mod_303_phade.md</td></tr>
         <tr class="warn"><td>⚠️ bach</td><td>inconcl</td><td><b>inconcl</b></td><td>documented-limitation</td><td class="detail">Sustained :beep polyphony — desktop onset detector finds ~3 onsets in 9s (#368); the web capture renders the full ~95s composition vs the windowed desktop capture (#406). No faithful gradeable projection: a monophonic literal-note list would test almost nothing (bach's substance is timing + concurrent in_thread alignment, exactly what's not onset-gradeable).</td></tr>
         <tr class="pass"><td>✅ driving_pulse</td><td>match</td><td><b>match</b></td><td>raw-sweep</td><td class="detail"></td></tr>
         <tr class="pass"><td>✅ monday_blues</td><td>match</td><td><b>match</b></td><td>projection</td><td class="detail">tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106</td></tr>

--- a/test_results/launch-gate.json
+++ b/test_results/launch-gate.json
@@ -1,10 +1,10 @@
 {
   "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json",
   "denominator": 7,
-  "passCount": 4,
-  "pct": 57.1,
+  "passCount": 5,
+  "pct": 71.4,
   "thresholdPct": 70,
-  "passed": false,
+  "passed": true,
   "rows": [
     {
       "example": "chord_inversions",
@@ -33,10 +33,10 @@
     {
       "example": "mod_303_phade",
       "rawVerdict": "inconcl",
-      "gateVerdict": "diverge",
-      "pass": false,
-      "gradedVia": "documented-limitation",
-      "detail": "REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example."
+      "gateVerdict": "match",
+      "pass": true,
+      "gradedVia": "raw-refreshed",
+      "detail": "re-measured → compare_2026-05-30T19-32-34-562Z_mod_303_phade.md"
     },
     {
       "example": "bach",

--- a/test_results/launch-gate.json
+++ b/test_results/launch-gate.json
@@ -1,14 +1,14 @@
 {
   "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json",
   "denominator": 7,
-  "passCount": 5,
-  "pct": 71.4,
+  "passCount": 4,
+  "pct": 57.1,
   "thresholdPct": 70,
-  "passed": true,
+  "passed": false,
   "rows": [
     {
       "example": "chord_inversions",
-      "rawVerdict": "inconcl",
+      "rawVerdict": "match",
       "gateVerdict": "match",
       "pass": true,
       "gradedVia": "projection",
@@ -33,10 +33,10 @@
     {
       "example": "mod_303_phade",
       "rawVerdict": "inconcl",
-      "gateVerdict": "match",
-      "pass": true,
-      "gradedVia": "raw-refreshed",
-      "detail": "re-measured → compare_2026-05-29T08-33-35-255Z_mod_303_phade.md"
+      "gateVerdict": "diverge",
+      "pass": false,
+      "gradedVia": "documented-limitation",
+      "detail": "REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example."
     },
     {
       "example": "bach",
@@ -56,7 +56,7 @@
     },
     {
       "example": "monday_blues",
-      "rawVerdict": "inconcl",
+      "rawVerdict": "match",
       "gateVerdict": "match",
       "pass": true,
       "gradedVia": "projection",

--- a/test_results/launch-gate.md
+++ b/test_results/launch-gate.md
@@ -1,6 +1,6 @@
 # Launch Gate — PRNG-free non-heavy official roster
 
-**4/7 = 57.1%** · threshold ≥70% · **❌ NOT MET**
+**5/7 = 71.4%** · threshold ≥70% · **✅ PASS**
 
 > Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly projection that exercises the same engine logic (see `tools/gate-reproducers/`). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation.
 
@@ -11,7 +11,7 @@
 | ✅ chord_inversions | match | match | projection | tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md |
 | ✅ reich_phase | match | match | raw-sweep |  |
 | ⚠️ dark_neon | inconcl | inconcl | documented-limitation | One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage. |
-| ❌ mod_303_phade | inconcl | diverge | documented-limitation | REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example. |
+| ✅ mod_303_phade | inconcl | match | raw-refreshed | re-measured → compare_2026-05-30T19-32-34-562Z_mod_303_phade.md |
 | ⚠️ bach | inconcl | inconcl | documented-limitation | Sustained :beep polyphony — desktop onset detector finds ~3 onsets in 9s (#368); the web capture renders the full ~95s composition vs the windowed desktop capture (#406). No faithful gradeable projection: a monophonic literal-note list would test almost nothing (bach's substance is timing + concurrent in_thread alignment, exactly what's not onset-gradeable). |
 | ✅ driving_pulse | match | match | raw-sweep |  |
 | ✅ monday_blues | match | match | projection | tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106 |

--- a/test_results/launch-gate.md
+++ b/test_results/launch-gate.md
@@ -1,6 +1,6 @@
 # Launch Gate — PRNG-free non-heavy official roster
 
-**5/7 = 71.4%** · threshold ≥70% · **✅ PASS**
+**4/7 = 57.1%** · threshold ≥70% · **❌ NOT MET**
 
 > Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly projection that exercises the same engine logic (see `tools/gate-reproducers/`). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation.
 
@@ -8,13 +8,13 @@
 
 | Row | raw sweep | gate verdict | graded via | detail |
 |---|---|---|---|---|
-| ✅ chord_inversions | inconcl | match | projection | tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md |
+| ✅ chord_inversions | match | match | projection | tools/gate-reproducers/chord_inversions.rb → compare_2026-05-29T16-00-01-355Z_chord_inversions.md |
 | ✅ reich_phase | match | match | raw-sweep |  |
 | ⚠️ dark_neon | inconcl | inconcl | documented-limitation | One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage. |
-| ✅ mod_303_phade | inconcl | match | raw-refreshed | re-measured → compare_2026-05-29T08-33-35-255Z_mod_303_phade.md |
+| ❌ mod_303_phade | inconcl | diverge | documented-limitation | REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example. |
 | ⚠️ bach | inconcl | inconcl | documented-limitation | Sustained :beep polyphony — desktop onset detector finds ~3 onsets in 9s (#368); the web capture renders the full ~95s composition vs the windowed desktop capture (#406). No faithful gradeable projection: a monophonic literal-note list would test almost nothing (bach's substance is timing + concurrent in_thread alignment, exactly what's not onset-gradeable). |
 | ✅ driving_pulse | match | match | raw-sweep |  |
-| ✅ monday_blues | inconcl | match | projection | tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106 |
+| ✅ monday_blues | match | match | projection | tools/gate-reproducers/monday_blues.rb → compare_2026-05-29T15-58-36-335Z_monday_blues.md · requires #409 note(octave:) fix (MERGED 8f38e2c) — without it web played +24 semitones; the projection itself surfaced this engine bug, SP106 |
 
 ## Excluded from denominator (SV49 — cross-engine PRNG is a v1 non-goal)
 - **ambient_experiment** — Uses choose([:D4,:E4]) etc. — PRNG-driven. Cross-engine PRNG parity is a declared v1 NON-GOAL (SV49), so it is excluded from the PRNG-free gate denominator (it belongs with the other ~22 PRNG rows). The post-SP104 framing wrongly counted it in the denom.

--- a/tools/gate-reproducers/manifest.json
+++ b/tools/gate-reproducers/manifest.json
@@ -48,16 +48,22 @@
       "reason": "One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage.",
       "engineEvidence": "No pitch-sequence to verify; the relevant engine paths (FX chain routing, sample playback) are covered by the FX-sweep / sample tooling, not Tier-1 pitch.",
       "countsAsPass": false
-    },
-    {
-      "example": "mod_303_phade",
-      "verdict": "diverge",
-      "reason": "REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example.",
-      "engineEvidence": "Isolation (Lokayata): tb303 plain=audible 0.256 · tb303+nested-FX (no loop)=audible 0.269 · tb303+live_loop+sync (no FX)=audible 0.256 · all three combined (real)=SILENT 0.000. Bug = trailing bare nested with_fx after a concurrent live_loop+sync routes FX output to an unmonitored bus (B2). Filed #423.",
-      "countsAsPass": false
     }
   ],
-  "refreshed": [],
+  "refreshed": [
+    {
+      "example": "mod_303_phade",
+      "reason": "SV55 (#419/#420) corrected the synth (web now plays :tb303, not :beep) and EXPOSED a latent scsynth-side FX-ordering race that rendered web SILENT ~15-20% of runs (#423). Fixed in commit 30d2d4a: inline with_fx FX nodes are now created at an immediate timetag (0), bypassing the prescheduler's same-timetag queue (the SV37 preCreatePersistentFx mechanism), so the nested chain instantiates in deterministic order. Re-measured 2026-05-30 on the fixed engine — genuine raw Tier-1 PITCH-MATCH (note 45 = correct tb303). CAVEAT: a ~3% residual intermittent silence remains (#424) — the dominant race is fixed but a single gate capture flakes ~1-in-30; the audio is musically correct when it sounds. Counted as pass with that documented flake.",
+      "evidence": {
+        "report": "compare_2026-05-30T19-32-34-562Z_mod_303_phade.md",
+        "verdict": "match",
+        "method": "onset/onset conf 1",
+        "desktop": "45,45,45,45,45,45,45,45,45,45,45,45,45,45",
+        "web": "45,45,45,45,45,45,45,45,45,45,45,45,45",
+        "note": "PITCH-MATCH over 13 notes on the fixed engine (commit 30d2d4a); residual ~3% silent-run flake tracked in #424"
+      }
+    }
+  ],
   "exclusions": [
     {
       "example": "ambient_experiment",

--- a/tools/gate-reproducers/manifest.json
+++ b/tools/gate-reproducers/manifest.json
@@ -48,22 +48,16 @@
       "reason": "One sustained note (:cs1) + a sample texture, not a melody — Tier-1 pitch comparison is the wrong lens entirely. A reproducer would test a single note, which is not meaningful musical-correctness coverage.",
       "engineEvidence": "No pitch-sequence to verify; the relevant engine paths (FX chain routing, sample playback) are covered by the FX-sweep / sample tooling, not Tier-1 pitch.",
       "countsAsPass": false
-    }
-  ],
-  "refreshed": [
+    },
     {
       "example": "mod_303_phade",
-      "reason": "examples-sweep.json is a 2026-05-28 snapshot predating the #403 (SP104 with_fx sustain) merge, where this row read INCONCL. Re-measured on current main (all fixes present) — now a genuine raw MATCH (not a projection).",
-      "evidence": {
-        "report": "compare_2026-05-29T08-33-35-255Z_mod_303_phade.md",
-        "verdict": "match",
-        "method": "onset/onset conf 1",
-        "desktop": "45,45,45,45,45,45,45,45,45,45,45,45,45",
-        "web": "45,45,45,45,45,45,45,45,45,45,45",
-        "note": "PITCH-MATCH over 11 notes; confirms PR #403"
-      }
+      "verdict": "diverge",
+      "reason": "REGRESSION-EXPOSED by SV55 (#419/#420), re-measured 2026-05-30 on merged main: web is now SILENT (peak 0.0000, RMS 0.0000) while desktop plays (peak 0.4564). Pre-SV55 the top-level use_synth :tb303 was dropped, web played :beep, and that accidentally produced a coincidental Tier-1 PITCH-MATCH (both ~36.7Hz, tracker read 45) — the stale 2026-05-29 'raw-refreshed MATCH' was that masked :beep. Post-SV55 web correctly plays :tb303 and the latent FX-bus silent-failure surfaces (#423). Does NOT count as pass — web produces no audio for this official example.",
+      "engineEvidence": "Isolation (Lokayata): tb303 plain=audible 0.256 · tb303+nested-FX (no loop)=audible 0.269 · tb303+live_loop+sync (no FX)=audible 0.256 · all three combined (real)=SILENT 0.000. Bug = trailing bare nested with_fx after a concurrent live_loop+sync routes FX output to an unmonitored bus (B2). Filed #423.",
+      "countsAsPass": false
     }
   ],
+  "refreshed": [],
   "exclusions": [
     {
       "example": "ambient_experiment",


### PR DESCRIPTION
## Summary

Post-SV55 re-measure of the launch gate surfaced that `incubation/mod_303_phade` rendered **intermittently silent** on web (~15-20% of runs). This PR (1) makes the launch gate honest about it, (2) fixes the dominant cause, and (3) restores the gate to a genuine pass.

SV55 (#419/#420) **exposed** this latent bug — it did not create it. Pre-SV55 the row played `:beep` (top-level `use_synth :tb303` dropped), which was audible and coincidentally Tier-1 PITCH-MATCHED — masking the silent failure. Post-SV55 web correctly plays `:tb303`, and the race surfaced.

## Root cause (confirmed, scsynth-side ordering race)

The inline `with_fx` create branch dispatched each FX `/s_new` at the **future** timetag `vt + schedAhead`. Sibling FX in a nested chain (reverb→slicer→tb303) share that exact timetag because no `sleep` separates the `with_fx` entry from its body. The WASM prescheduler does not guarantee FIFO for equal-timetag bundles under the bundle pressure a concurrent `live_loop` adds, and `applyFxImmediate` adds FX with `addToHead` in the flat group 101 — so a reversed processing order **inverts the chain** (the outer FX runs before the inner and reads an as-yet-unwritten bus for the node's whole lifetime) → permanent silence that run.

Confirmed via isolation (each variant repeated 12-20×, since the bug is intermittent):

| Variant | silent runs |
|---|---|
| `tb303` plain (no FX, no loop) | 0/20 |
| nested reverb+slicer FX, no loop | 0/32 |
| nested FX **+ concurrent `live_loop`** (real) | ~3-4/20 |

The OSC is **byte-identical** between a silent and an audible run (same `/s_new`, node IDs, busses, group, monitor map) — only the timetag differs. The divergence is purely scsynth-side instantiation order.

## Fix

Create inline `with_fx` FX nodes at an **immediate timetag (0)** + `flushMessages(0)`, mirroring `preCreatePersistentFx` (SV37). Timetag 0/1 bypasses the prescheduler (`bypassImmediate`) → FIFO dispatch → the outer FX is instantiated before the inner, deterministically. The inner synth still plays at `vt + schedAhead`, landing after the FX chain exists. This was the one FX create site still using a future timetag; loop-wrapping FX already went through `preCreatePersistentFx`.

Two earlier framings were tried and **refuted** (the lever is immediate-vs-future, not a timetag nudge):
- `/sync` send-barrier → reorders the *sends*, not scsynth's same-timetag instantiation → **worse** (11/20).
- lead FX by one schedAhead (`audioTime = vt`) → still a *future* timetag; reverb/slicer still shared it → 3/20.

A self-review pass caught a regression risk (a `play` earlier in the same iteration would be folded into the immediate flush and fire early) and added a guard: drain the pending queue at its own time before queuing the FX.

## Results (Level-3, WAV over many runs)

- mod_303_phade silent rate **~15-20% → ~2% (2/75)**; now a genuine Tier-1 PITCH-MATCH (note 45, 13 notes identical to desktop).
- **No regression:** dark_neon (`with_fx` inside loop, same branch) 0/10, echo_drama (FX wrapping loop) 0/5, `play`-then-`with_fx` timing correct (verified via OSC probe).
- **1082/1082 vitest, tsc clean.**

## Launch gate

Honest 7-row gate: **4/7 = 57.1% NOT MET → restored to 5/7 = 71.4% PASS** on real fixed `:tb303` audio (not the old masked `:beep`). The prior 5/7 had been computed off a stale pre-SV55 capture; the manifest is corrected to record the genuine fixed-engine MATCH with the residual flake documented.

## Desktop grounding

Desktop Sonic Pi guarantees FX node-tree order **structurally** — each `with_fx` creates a dedicated container group (`new_group(:tail, current_group)` + `new_group(:head, container)`, `sound.rb:1768-1769`) so ordering is fixed at group-creation time, independent of `/s_new` timing. Our immediate-timetag fix achieves the same ordering guarantee for the dominant case via the proven SV37 path.

## Remaining

A smaller **~3% residual** intermittent silence persists (random positions, not cold-start) — tracked in **#424**. The robust form is the structural container-group nesting above; this PR is the 80%-solution.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — 1082/1082
- `npx tsx tools/capture.ts --file <mod_303_phade.rb> --duration 5000` ×~20 — count `Peak: 0` (expect ≤1)
- `npx tsx tools/compare-desktop-vs-web.ts --file <mod_303_phade.rb>` — Tier-1 PITCH-MATCH
- `npx tsx tools/gate-report.ts` — 5/7 = 71.4% PASS

Closes #423. Follow-up: #424.

Catalogues (separate anvideck repo): hetvābhāsa SP109 FIXED + vyāpti SV56.