### PR TITLE
🐛 fix(transpiler): hoist bare `loop do` inside with_fx to a live_loop — kill #426 crushed renderer OOM

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -180,6 +180,7 @@ export function treeSitterTranspile(ruby: string): TreeSitterTranspileResult {
     definedFunctions: new Set(),
     indent: '',
     inthreadLoopCounter: { n: 0 },
+    fxLoopCounter: { n: 0 },
   }
 
   const js = transpileNode(tree.rootNode, ctx)
@@ -232,6 +233,8 @@ interface TranspileContext {
   srcLine?: number
   /** Hoisted-loop counter for `loop do` inside `in_thread` (issue #205). */
   inthreadLoopCounter?: { n: number }
+  /** Hoisted-loop counter for `loop do` inside `with_fx` (issue #426/SP111). */
+  fxLoopCounter?: { n: number }
   /**
    * SP95(d) #393: true while transpiling the *direct* body of a live_loop,
    * whose wrapper arrow is emitted `async`. Lets `sync` emit `await __b.sync()`
@@ -978,7 +981,13 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     if (method !== 'with_fx') return false
     // Check if with_fx contains a live_loop — if so, it's a block, not bare
     const text = c.text ?? ''
-    return !/live_loop/.test(text)
+    if (/live_loop/.test(text)) return false
+    // #426/SP111: a with_fx wrapping a bare `loop do` is ALSO a registering
+    // block (the loop is hoisted to an auto-named live_loop inside the fx),
+    // NOT bare code. Routing it through __run_once would emit a synchronous
+    // build-time `while(true)` → infinite Step[] push → renderer OOM.
+    const wfBlk = c.namedChildren.find((x: any) => x.type === 'do_block' || x.type === 'block')
+    return !(wfBlk && blockBodyHasBareLoop(wfBlk))
   })
   // Top-level `loop do … end` triggers the split so it can be hoisted to a
   // named live_loop. Without this flag, a program that contains only
@@ -1024,8 +1033,15 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
       currentTopSynth = extractLiteralSynthArg(child)
     }
 
-    // Bare with_fx (no live_loop inside) should be treated as bare code, not a block
-    const isBareFxNode = method === 'with_fx' && !/live_loop/.test(child.text ?? '')
+    // Bare with_fx (no live_loop inside) should be treated as bare code, not a
+    // block — UNLESS it wraps a bare `loop do`, which is hoisted to a live_loop
+    // inside the fx (#426/SP111). Mirrors the hasBareFx check above.
+    const wfBlk = method === 'with_fx'
+      ? child.namedChildren.find((x: any) => x.type === 'do_block' || x.type === 'block')
+      : null
+    const isBareFxNode = method === 'with_fx'
+      && !/live_loop/.test(child.text ?? '')
+      && !(wfBlk && blockBodyHasBareLoop(wfBlk))
 
     // Bare top-level `loop do … end` — route to blocks and emit below as a
     // dedicated auto-named live_loop (SV16 — do not let the loop become
@@ -1858,6 +1874,74 @@ function transpileDefonce(
   return `${name} = defonce(${JSON.stringify(name)}, ${optsStr}, (__b) => {\n${stmts.join('\n')}\n${ctx.indent}})`
 }
 
+/**
+ * Drill into a do_block/block's `body_statement` wrapper to get the real
+ * statement children (skipping any block_parameters). Mirrors the body
+ * extraction in transpileInThread (#205).
+ */
+function blockBodyChildren(blockNode: any): any[] {
+  const raw = (blockNode?.namedChildren ?? []).filter((c: any) => c.type !== 'block_parameters')
+  if (raw.length === 1 && raw[0]?.type === 'body_statement') {
+    return raw[0].namedChildren ?? []
+  }
+  return raw
+}
+
+/** True if a do/brace block directly contains a `loop do … end` statement (#426/SP111). */
+function blockBodyHasBareLoop(blockNode: any): boolean {
+  return blockBodyChildren(blockNode).some((c: any) => {
+    const m = (c.type === 'call' || c.type === 'method_call')
+      ? (c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text)
+      : null
+    return m === 'loop' && c.namedChildren.some((x: any) => x.type === 'do_block' || x.type === 'block')
+  })
+}
+
+/**
+ * Transpile a with_fx body that contains a bare `loop do`, hoisting each loop
+ * to an auto-named live_loop INSIDE the fx callback (#426/SP111, SV16). Setup
+ * statements before the loop are emitted as-is; statements after a loop are
+ * unreachable (a `loop` runs forever) and dropped with a warning — same policy
+ * as transpileInThread.
+ */
+function transpileWithFxLoopBody(
+  blockNode: any, bodyCtx: TranspileContext, ctx: TranspileContext
+): string {
+  const counter = ctx.fxLoopCounter ?? { n: 0 }
+  // `live_loop` is always a FREE function (a global from the sandbox scope),
+  // never a ProgramBuilder method — transpileLiveLoop emits it unprefixed at
+  // every depth, and BUILDER_METHODS excludes it. So emit it unprefixed here
+  // too; `__b.live_loop` would throw "is not a function".
+  const parts: string[] = []
+  let sawLoop = false
+  let droppedAfterLoop = false
+  for (const child of blockBodyChildren(blockNode)) {
+    const m = (child.type === 'call' || child.type === 'method_call')
+      ? (child.childForFieldName('method')?.text ?? child.namedChildren[0]?.text)
+      : null
+    const isLoop = m === 'loop' &&
+      child.namedChildren.some((c: any) => c.type === 'do_block' || c.type === 'block')
+    if (isLoop) {
+      const body = child.namedChildren.find((c: any) => c.type === 'do_block' || c.type === 'block')
+      // live_loop bodies are emitted async (SP95(d) — `await __b.sync()`).
+      const innerCtx: TranspileContext = { ...bodyCtx, insideLoop: true, asyncBody: true }
+      const innerStr = transpileBlockBody(body, innerCtx)
+      const idx = counter.n++
+      parts.push(`${ctx.indent}  live_loop("__fxloop_${idx}", async (__b) => {\n${innerStr}\n${ctx.indent}  })`)
+      sawLoop = true
+    } else if (sawLoop) {
+      droppedAfterLoop = true
+    } else {
+      parts.push(`${ctx.indent}  ${transpileNode(child, bodyCtx)}`)
+    }
+  }
+  if (droppedAfterLoop) {
+    const line = blockNode.startPosition?.row != null ? blockNode.startPosition.row + 1 : '?'
+    ctx.errors.push(`Warning at line ${line}: statements after \`loop do\` inside with_fx are unreachable and were dropped.`)
+  }
+  return parts.filter(s => s.trim()).join('\n')
+}
+
 function transpileWithBlock(
   methodName: string, argsNode: any, blockNode: any, ctx: TranspileContext
 ): string {
@@ -1895,7 +1979,18 @@ function transpileWithBlock(
   const bodyCtx: TranspileContext = ctx.insideLoop
     ? { ...ctx, insideLoop: true }
     : { ...ctx }  // keep insideLoop false — live_loops inside will set their own
-  const bodyStr = transpileBlockBody(blockNode, bodyCtx)
+  // #426/SP111: a bare `loop do … end` directly inside with_fx must be hoisted
+  // to an auto-named live_loop, exactly as top-level (lines ~1116) and in_thread
+  // (transpileInThread) loops are (SV16). Building it inline emits a synchronous
+  // `while(true) { __b.play; __b.sleep }` whose build-time sleep-step resets the
+  // budget guard every iteration → infinite Step[] push during the build pass →
+  // renderer OOM (issue #426 / crushed.rb). The live_loop stays INSIDE the
+  // with_fx callback so the FX bus still wraps it (SV13). Only with_fx is
+  // affected because it is the only with-block that reaches `blocks` (registering
+  // path); other with-blocks keep current behaviour.
+  const bodyStr = (methodName === 'with_fx' && blockBodyHasBareLoop(blockNode))
+    ? transpileWithFxLoopBody(blockNode, bodyCtx, ctx)
+    : transpileBlockBody(blockNode, bodyCtx)
 
   const optsStr = opts.length > 0 ? `{ ${opts.join(', ')} }` : ''
   const posStr = positional.join(', ')

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -618,6 +618,57 @@ end`)
       expect(result.code).toContain('live_loop("__inthread_loop_0"')
     })
 
+    // Issue #426/SP111: `loop do` inside with_fx used to emit a synchronous
+    // build-time `while(true) { __b.play; __b.sleep }` (the sleep-step resets
+    // the budget guard every iteration → infinite Step[] push → renderer OOM).
+    // crushed.rb (`with_fx :bitcrusher do loop do … end end`) crashed the tab.
+    // Fix hoists the loop to an auto-named live_loop INSIDE the fx (top-level
+    // `with_fx{live_loop}` is the proven FX-routing path), exactly like a
+    // top-level / in_thread loop (SV16).
+    it('hoists loop do inside with_fx to a live_loop, not build-time while(true) (#426)', () => {
+      const result = treeSitterTranspile(`with_fx :bitcrusher do
+  loop do
+    play 50
+    sleep 0.5
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toContain('while (true)')
+      expect(result.code).toContain('with_fx("bitcrusher"')
+      expect(result.code).toContain('live_loop("__fxloop_0"')
+      // `live_loop` is a free function (never `__b.live_loop`) — that would throw
+      // "is not a function".
+      expect(result.code).not.toContain('__b.live_loop')
+      expect(() => new Function(result.code)).not.toThrow()
+    })
+
+    it('keeps setup statements before loop in with_fx; hoists the loop (#426)', () => {
+      const result = treeSitterTranspile(`with_fx :reverb do
+  play 72
+  loop do
+    play 50
+    sleep 0.5
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toContain('while (true)')
+      expect(result.code).toContain('with_fx("reverb"')
+      expect(result.code).toContain('live_loop("__fxloop_0"')
+    })
+
+    it('with_fx wrapping live_loop is unchanged by the #426 loop-hoist', () => {
+      const result = treeSitterTranspile(`with_fx :bitcrusher do
+  live_loop :crush do
+    play 50
+    sleep 0.5
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('with_fx("bitcrusher"')
+      expect(result.code).toContain('live_loop("crush"')
+      expect(result.code).not.toContain('__fxloop')
+    })
+
     it('define with block params', () => {
       const result = treeSitterTranspile(`define :bass_hit do
   sample :bd_haus, amp: 2

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -102,11 +102,18 @@ async function captureRun(
     // `topLevelWithFx` / `fxAwareWrappedLiveLoop` path does. Result: dry
     // signal in the capture even though desktop hears the FX.
     //
-    // Heuristic: regex-detect `live_loop` or `in_thread` as standalone
-    // identifiers at column-zero-ish positions. Strings/comments containing
-    // these words are rare in test snippets; false positives just degrade
-    // to "skipped wrap" which is safe for short snippets too.
-    const alreadyAsync = /^[ \t]*(?:live_loop|in_thread)\b/m.test(code)
+    // Heuristic: regex-detect `live_loop`, `in_thread`, or a bare `loop do`
+    // as standalone identifiers at column-zero-ish positions. After the
+    // #426/SP111 transpiler fix, a top-level `loop do` (bare OR wrapped in
+    // `with_fx`) is async-by-construction — it registers an auto-named
+    // live_loop and returns immediately, exactly like an explicit live_loop.
+    // Pushing it into `in_thread` would (a) be unnecessary and (b) break the
+    // with_fx FX-routing parity (the nested `__b.with_fx` builder path doesn't
+    // wire the FX bus the way top-level `topLevelWithFx` does — `crushed.rb`).
+    // So treat a top-level `loop do` like live_loop/in_thread and skip the wrap.
+    // Strings/comments containing these words are rare in test snippets; a false
+    // positive just degrades to "skipped wrap", safe for short snippets too.
+    const alreadyAsync = /^[ \t]*(?:live_loop|in_thread|loop)\b/m.test(code)
     // with_bpm 60 around the sleep so a user's `use_bpm 120` (or any other
     // tempo set inside <code>) doesn't shrink/expand the recording window.
     // At 60 BPM, sleep N == N real seconds.


### PR DESCRIPTION
> **Stacked PR.** Base = `chore/full-sweep-aggregate-dashboard` (itself unmerged, on top of #424 `bedac3c`). Review shows only `edfc06d`. Merge after the base lands.

## Problem
`incubation/crushed.rb` (`with_fx :bitcrusher do loop do … end end`) **crashed the browser tab** at ~73s (`Target page/context/browser has been closed`), so the web capture produced no WAV. The real app freezes too — Run hangs at the build pass (crushed.rb is an official Sonic Pi example). The original #426 framing ("capture-drain stall") was wrong: this is a real **engine** bug.

## Root cause (grounded)
A discriminating experiment — the identical code as a `live_loop` captured clean in 14s, the bare `loop do` crashed at 73s — plus the transpiler output pinned it:

```js
__b.with_fx("bitcrusher", (__b) => {
  while (true) { __b.__checkBudget__(); __b.play(50,…); __b.sleep(0.5) }
})
```

A `loop do` whose immediate enclosing block is `with_fx` escaped SV16's bare-loop→live_loop hoisting (which fires only at depth-0 #190 and inside `in_thread` #205) and fell to the `while(true)` fallback. `with_fx` runs its body callback **synchronously at build time** (`ProgramBuilder.with_fx:407 fn(inner)`), and `__b.sleep` inside a builder is a synchronous `Step` push that **resets the budget guard every iteration** → the `while(true)` never yields → infinite `Step[]` array → renderer OOM. (A `live_loop` body is an async coroutine the engine awaits per-iteration, so its `while(true)` yields — that's why the live_loop variant is fine and why `loop` inside `live_loop` legitimately stays `while(true)`.)

## Fix
- **Transpiler** (`TreeSitterTranspiler.ts`): classify a top-level `with_fx` wrapping a bare `loop do` as a registering block (not bare code), and hoist the inner loop to `live_loop("__fxloop_N", …)` **inside** the fx callback — the proven `with_fx{live_loop}` FX-routing path (SV13). Mirrors the #190 (depth-0) and #205 (in_thread) hoists. `live_loop` is emitted unprefixed (it's a free sandbox global; `__b.live_loop` throws "is not a function").
- **`tools/capture.ts`**: a top-level `loop do` is now async-by-construction, so the `alreadyAsync` heuristic skips the `in_thread` wrap and routes crushed through the top-level FX path (the nested `__b.with_fx` path doesn't wire the FX bus).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **1085/1085** (+3 transpiler tests for the with_fx loop-hoist; RealWorldExamples 62/62)
- [x] **Level-3 audio (A/B vs desktop):** crushed web went **crash → 7.68s audio (peak 0.20)**; verdict **Tier-1 PRNG-VARIANT** — pitch-class histogram cos 0.976, tempo + density match (crushed uses `.choose`, so cross-engine PRNG divergence is expected per SV49). mod_fm/mod_dsaw + bitcrusher route correctly.
- [x] Regression check: plain top-level `loop do` still captures clean through the new routing.

## Scope
Crushed only. **bach** (also in #426) has no bare loop — it's a long ~95s composition vs the comparator timeout, split to #429. Catalogues updated: hetvābhāsa **SP111** (OPEN→FIXED), vyāpti **SV16** span extended to `with_fx`.

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)