### PR TITLE
🐛 fix(transpiler): strip bang on receiver methods + array .rotate runtime (#430)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -938,6 +938,17 @@ export class ProgramBuilder {
     return new Ring(items)
   }
 
+  /**
+   * Rotate an array or Ring by n positions (default 1). Positive = left,
+   * matching Ruby `Array#rotate` / `Ring.rotate`. Returns a Ring (#430). Used
+   * by the transpiler for `.rotate` / `.rotate!` (bang stripped, copy
+   * semantics) — see `transpileReceiverMethodCall`.
+   */
+  rotate<T>(arr: T[] | Ring<T>, n: number = 1): Ring<T> {
+    const ring = arr instanceof Ring ? arr : new Ring([...arr])
+    return ring.rotate(n)
+  }
+
   pick<T>(arr: T[] | Ring<T>, n: number = 1): Ring<T> {
     const items = arr instanceof Ring ? arr.toArray() : [...arr]
     const result: T[] = []

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1381,7 +1381,14 @@ function transpileReceiverMethodCall(
   receiver: any, methodNode: any, argsNode: any, blockNode: any,
   fullNode: any, ctx: TranspileContext
 ): string {
-  const method = methodNode.text
+  // Strip the Ruby bang (!) from receiver method names — `a.rotate!` → `rotate`,
+  // `a.shuffle!` → `shuffle`, `a.sort!` → `sort` (#430). JS has no `!`-suffixed
+  // method names, so passing the bang through emits invalid JS (`a.rotate!()` →
+  // "Unexpected token '!'", which refused sonic_dreams.rb). Mirrors the bare-call
+  // strip at the top of transpileMethodCall. In-place mutation semantics are not
+  // preserved (copy semantics) — that only matters for exact non-PRNG parity.
+  const rawMethod = methodNode.text
+  const method = rawMethod.endsWith('!') ? rawMethod.slice(0, -1) : rawMethod
   const recStr = transpileNode(receiver, ctx)
 
   // N.times do |i| ... end
@@ -1467,6 +1474,14 @@ function transpileReceiverMethodCall(
   // .shuffle → b.shuffle(receiver) — works on both arrays and Rings
   if (method === 'shuffle') {
     return `__b.shuffle(${recStr})`
+  }
+
+  // .rotate(n) → __b.rotate(receiver, n) — works on arrays and Rings (#430).
+  // `rotate!` reaches here too (bang stripped above). Returns a Ring, so a
+  // chained `.first`/`[0]` resolves via the Ring proxy.
+  if (method === 'rotate') {
+    const args = argsNode ? transpileArgList(argsNode, ctx) : ''
+    return args ? `__b.rotate(${recStr}, ${args})` : `__b.rotate(${recStr})`
   }
 
   // .mirror(n) / .reflect(n) → thread the optional repeat arg (desktop

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -1389,6 +1389,48 @@ end`)
       expect(steps[0].note).toBe(60) // first tick → index 0
     })
 
+    // #430: `a.rotate!` used to emit invalid JS `a.rotate!()` ("Unexpected
+    // token '!'") which refused sonic_dreams.rb. Bang is now stripped on
+    // receiver methods, and `.rotate` maps to __b.rotate (returns a Ring; the
+    // chained `.first`/`[0]` resolves via the Ring proxy).
+    it('.rotate! strips the bang and rotates left by 1 (#430)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  notes = [60, 62, 64]
+  play notes.rotate!.first
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].tag).toBe('play')
+      expect(steps[0].note).toBe(62) // rotate left 1 → [62,64,60], .first = 62
+    })
+
+    it('.rotate!(n) threads the rotation arg (#430)', () => {
+      const { steps, error } = executeTranspiled(`live_loop :t do
+  notes = [60, 62, 64, 65]
+  play notes.rotate!(2).first
+  sleep 1
+end`)
+      expect(error).toBeUndefined()
+      expect(steps[0].note).toBe(64) // rotate left 2 → [64,65,60,62], .first = 64
+    })
+
+    it('.shuffle! / .sort! receiver bang is stripped (#430)', () => {
+      const sorted = executeTranspiled(`live_loop :t do
+  notes = [64, 60, 62]
+  play notes.sort!.first
+  sleep 1
+end`)
+      expect(sorted.error).toBeUndefined()
+      expect(sorted.steps[0].note).toBe(60) // sort ascending → first = 60
+      // shuffle! must not throw (deterministic value depends on rng seed)
+      const shuffled = executeTranspiled(`live_loop :t do
+  play [60, 62, 64].shuffle!.first
+  sleep 1
+end`)
+      expect(shuffled.error).toBeUndefined()
+      expect(shuffled.steps[0].tag).toBe('play')
+    })
+
     it('variable reassignment works (bare assignment, not const)', () => {
       const { steps, error } = executeTranspiled(`live_loop :t do
   x = 60


### PR DESCRIPTION
> **Stacked PR.** Base = `chore/full-sweep-aggregate-dashboard` (where #431 just merged). Review shows only `bf4e6a4`.

## Problem
`algomancer/sonic_dreams.rb` (`synths.rotate!.first`) transpiled to invalid JS `synths.rotate!()[0]` → **"Unexpected token '!'"** → transpile-refuse → the fixture never ran. The comparator mis-reported it as a #358 blob-retrieval TOOL-FAIL; reading the App Console showed it was actually an engine refuse. Two gaps:
1. The bang-strip only covered **bare** calls (`set_volume! → set_volume`), not **receiver** methods (`a.rotate!`).
2. `.rotate` had no runtime (unlike `.shuffle` → `__b.shuffle`), so even bang-stripped, `[].rotate()` on a plain array would fail.

## Fix
- `transpileReceiverMethodCall` strips a trailing `!` → `rotate!`/`shuffle!`/`sort!`/… route to their non-bang handlers (mirrors the bare-call strip). Copy semantics — in-place mutation isn't preserved, which only matters for exact non-PRNG parity (sonic_dreams is PRNG-VARIANT, SV49).
- New `.rotate(n)` → `__b.rotate(receiver, n)` (mirrors `.shuffle`), backed by new `ProgramBuilder.rotate` returning a `Ring` (via `Ring.rotate`); chained `.first`/`[0]` resolves through the Ring proxy.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — **1085/1085** (+3 semantic-execution tests against a real ProgramBuilder: `.rotate!.first`→62, `.rotate!(2).first`→64, `.sort!.first`→60; `.shuffle!` runs without throwing)
- [x] **Level-3:** sonic_dreams no longer refuses on `rotate!` — the "Unexpected token '!'" error is gone.

## Scope / follow-up
This unblocks `rotate!` only. sonic_dreams now reaches a **separate** downstream error — `fn is not a function`, a `synths` local-var-shadows-`define :synths` name collision (filed **#432**). So sonic_dreams stays INVALID until #432 too; this PR removes the first of two blockers. Catalogue: hetvābhāsa **SP112**.

Part of #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)