### PR TITLE
🔧 fix(comparator): name the missing-WAV layer — ENGINE-REFUSED / ENGINE-SILENT / TOOL-FAIL (SV48, #427)

### DIFF
--- a/tools/build-aggregate-index.ts
+++ b/tools/build-aggregate-index.ts
@@ -45,7 +45,7 @@ const esc = (s: unknown) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g,
 // ── Manifest shapes (only the fields we read) ──────────────────────────────
 interface PitchManifest {
   generatedAt?: string
-  counts: { match: number; diverge: number; prngVariant: number; invalid: number; inconcl: number; error: number; prng: number; prngFreeReal: number; heavy: number; totalRows: number }
+  counts: { match: number; diverge: number; prngVariant: number; invalid: number; inconcl: number; error: number; engineSilent?: number; toolFail?: number; prng: number; prngFreeReal: number; heavy: number; totalRows: number }
 }
 interface ConsistencyManifest {
   generatedAt?: string
@@ -88,6 +88,9 @@ function pitchCard(title: string, count: number, viewer: string, m: PitchManifes
     chip('DIVERGE', c.diverge, 'fail'),
     chip('INCONCL', c.inconcl, 'incon'),
     chip('ERROR', c.error, 'faildark'),
+    // SV48 (#427): missing-WAV layers named distinctly from INVALID.
+    chip('ENGINE-SILENT', c.engineSilent ?? 0, 'faildark'),
+    chip('TOOL-FAIL', c.toolFail ?? 0, 'incon'),
     chip('INVALID', c.invalid, 'incon'),
   ].filter(Boolean).join('')
   const stamp = m.generatedAt ? new Date(m.generatedAt).toISOString().replace('T', ' ').slice(0, 16) + ' UTC' : ''

--- a/tools/build-examples-sweep.ts
+++ b/tools/build-examples-sweep.ts
@@ -75,7 +75,7 @@ interface SweepRow {
   category: string
   example: string
   path: string
-  verdict: 'match' | 'diverge' | 'prng-variant' | 'invalid' | 'inconcl' | 'error'
+  verdict: 'match' | 'diverge' | 'prng-variant' | 'invalid' | 'inconcl' | 'error' | 'engine-silent' | 'tool-fail'
   verdictRaw: string
   tempoDesktop: number | null
   tempoWeb: number | null
@@ -166,7 +166,13 @@ function parseReport(reportPath: string): Partial<SweepRow> {
       row.verdict = 'diverge'
       const m = row.verdictRaw.match(/at (note|pc) (\d+)/)
       if (m) row.divergeAt = `${m[1]} ${m[2]}`
-    } else if (/INVALID/.test(row.verdictRaw)) row.verdict = 'invalid'
+    }
+    // SV48 (#427): name the missing-WAV layer — ENGINE-SILENT (engine ran, no
+    // audio) and TOOL-FAIL (harness lost a real blob) are distinct from a
+    // precondition INVALID. Matched before INVALID.
+    else if (/^❌ ENGINE-SILENT\b/.test(row.verdictRaw)) row.verdict = 'engine-silent'
+    else if (/^❌ TOOL-FAIL\b/.test(row.verdictRaw)) row.verdict = 'tool-fail'
+    else if (/INVALID/.test(row.verdictRaw)) row.verdict = 'invalid'
     else if (/inconclusive/i.test(row.verdictRaw)) row.verdict = 'inconcl'
     else row.verdict = 'inconcl'
   }
@@ -385,6 +391,8 @@ const counts = {
   invalid: rows.filter(r => r.verdict === 'invalid').length,
   inconcl: rows.filter(r => r.verdict === 'inconcl').length,
   error: rows.filter(r => r.verdict === 'error').length,
+  engineSilent: rows.filter(r => r.verdict === 'engine-silent').length,
+  toolFail: rows.filter(r => r.verdict === 'tool-fail').length,
   prng: rows.filter(r => r.prng).length,
   prngFreeReal: rows.filter(r => r.prngFreeReal).length,
   heavy: rows.filter(r => r.heavy).length,

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -247,7 +247,14 @@ function writeComparisonReport(r: ComparisonResult): void {
   let invalid = false
   let webEngineError = false
   let aggregatesUnreliable = false
+  // SV48 (#427): a missing web WAV must NAME its layer — ENGINE-REFUSED (the
+  // engine threw / refused to transpile) ≠ ENGINE-SILENT (the engine ran but
+  // produced no recording) ≠ TOOL-FAIL (the capture pipeline lost a real blob).
+  // Branding everything "TOOL-FAIL #358" sent triage to the harness when the
+  // bug was in the engine/transpiler (cost the #426/#427/#430 re-diagnoses).
+  let webNoWavClass: 'engine-refused' | 'engine-silent' | 'tool-fail' | null = null
   const fail = (m: string) => { t0.push(`- ✗ ${m}  **(HARD — verdict INVALID)**`); invalid = true }
+  const failNamed = (m: string) => { t0.push(`- ✗ ${m}  **(HARD — no Tier-1 verdict)**`); invalid = true }
   const errFail = (m: string) => { t0.push(`- ✗ ${m}  **(HARD — verdict ERROR; pitch verdict not formed)**`); webEngineError = true }
   const soft = (m: string) => { t0.push(`- ⚠ ${m}  **(SOFT — Tier 3 + 1.3 unreliable; Tier 1 pitch still valid)**`); aggregatesUnreliable = true }
   const passG = (m: string) => t0.push(`- ✓ ${m}`)
@@ -264,13 +271,27 @@ function writeComparisonReport(r: ComparisonResult): void {
   }
   if (!dStats) fail('Desktop produced no WAV — see desktop tool stdout below')
   if (!wStats) {
-    // #358: distinguish capture-tool failure (TOOL-FAIL) from engine silence.
-    // The sentinel reason comes from capture.ts emitting `**File:** none — <reason>`
-    // when the blob never resolved. Without this distinction the verdict line
-    // reads as if the engine produced no audio — when in fact the engine may
-    // have rendered audio that the capture tool failed to pick up.
-    if (r.web.toolFailReason) {
-      fail(`Web produced no WAV — TOOL-FAIL (capture-pipeline #358): ${r.web.toolFailReason}. The engine may have produced audio; check the App Console Output in the web report for /s_new activity before concluding ENGINE-SILENT`)
+    // SV48 (#427): classify the missing web WAV by LAYER instead of always
+    // "TOOL-FAIL #358". The capture diag carries the decisive signal —
+    // `wavBlobClicks` counts how many times a `.wav` download anchor was
+    // clicked. >0 ⇒ a recording WAS produced and a download fired but the blob
+    // could not be resolved (genuine capture-pipeline failure). 0 ⇒
+    // recording_save never had a recording: the engine refused (errored) or ran
+    // silently. Branding all three "TOOL-FAIL" sent triage to the harness when
+    // the bug was in the engine/transpiler (the #426/#427/#430 re-diagnoses).
+    const reason = r.web.toolFailReason ?? ''
+    const wavClicks = parseInt(reason.match(/wavBlobClicks=(\d+)/)?.[1] ?? '0', 10)
+    if (webEngineError) {
+      // Engine threw/refused (Tier-0 ERROR already set). The missing WAV is a
+      // consequence — attribute it to the error, not the capture tool.
+      webNoWavClass = 'engine-refused'
+      failNamed('Web produced no WAV — ENGINE-REFUSED: the engine errored/refused to run (see "Web engine errors" above). NOT a capture-tool miss.')
+    } else if (reason && wavClicks > 0) {
+      webNoWavClass = 'tool-fail'
+      failNamed(`Web produced no WAV — TOOL-FAIL (capture pipeline): a .wav download fired (wavBlobClicks=${wavClicks}) but the blob could not be resolved — the engine likely produced audio. Debug the harness. ${reason}`)
+    } else if (reason) {
+      webNoWavClass = 'engine-silent'
+      failNamed(`Web produced no WAV — ENGINE-SILENT: no .wav download fired (wavBlobClicks=0) — recording_save found no recording, so the engine emitted no audio. NOT a capture-tool failure; check the App Console for /s_new activity. ${reason}`)
     } else {
       fail('Web produced no WAV — see web tool stdout below')
     }
@@ -452,6 +473,15 @@ function writeComparisonReport(r: ComparisonResult): void {
     // chase the wrong question.
     const summary = r.web.errors[0].replace(/\s+/g, ' ').slice(0, 200)
     lines.push(`### ❌ ERROR — Web engine threw during capture; pitch verdict not formed. \`${summary}\``)
+  } else if (webNoWavClass === 'engine-silent') {
+    // SV48 (#427): the engine ran but produced no recording — debug the engine,
+    // not the capture harness. Distinct from a precondition INVALID and from a
+    // genuine TOOL-FAIL.
+    lines.push(`### ❌ ENGINE-SILENT — the web engine ran but produced no recording (no /s_new reached the recorder; SV48). Debug the engine, not the capture harness. No Tier-1 verdict.`)
+  } else if (webNoWavClass === 'tool-fail') {
+    // SV48 (#427): a real blob was lost by the capture pipeline — debug the
+    // harness, not the engine.
+    lines.push(`### ❌ TOOL-FAIL — capture pipeline lost a real WAV blob (a .wav download fired but could not be resolved; SV48). The engine likely produced audio. Debug the harness, not the engine. No Tier-1 verdict.`)
   } else if (invalid) {
     lines.push(`### ❌ INVALID — Tier 0 HARD gate failed. The pitch sequence itself is unreliable; no verdict until fixed.`)
   } else if (pitchVerdict.startsWith('✓')) {


### PR DESCRIPTION
> **Stacked PR.** Base = `chore/full-sweep-aggregate-dashboard`. Review shows only `643de9e`. Tools-only — engine untouched.

## Problem
The comparator branded **every** missing web WAV as "TOOL-FAIL (capture-pipeline #358)", sending triage to the capture harness even when the bug was in the engine/transpiler. This mislabel cost three re-diagnoses this session — `sonic_dreams` (a `rotate!` transpile-refuse, #430) and `orchard_improv` (engine produced no audio) were both reported as blob-retrieval failures when the blob path was working correctly: **there was simply no WAV to retrieve.**

## Fix (SV48 — a missing-WAV verdict must name its layer)
Classify the missing web WAV using `webEngineError` + the capture diag's **`wavBlobClicks`** counter (how many times a `.wav` download anchor was clicked):

| Signal | Layer | Triage |
|---|---|---|
| `## Errors` non-empty | **ENGINE-REFUSED** (headline stays ERROR) | engine/transpiler |
| `wavBlobClicks == 0` | **ENGINE-SILENT** (engine ran, no recording) | engine |
| `wavBlobClicks > 0` | **TOOL-FAIL** (real blob lost) | harness |

New distinct headline verdicts `### ❌ ENGINE-SILENT` / `### ❌ TOOL-FAIL`; the sweep parser buckets them (`engine-silent` / `tool-fail`, matched before INVALID) and the aggregate dashboard shows them as their own chips.

## Verified (Level 3, re-ran both fixtures)
- `sonic_dreams` → **ERROR** headline + Tier-0 "ENGINE-REFUSED … NOT a capture-tool miss" (was "TOOL-FAIL #358").
- `orchard_improv` → **ENGINE-SILENT** headline + "no .wav download fired (wavBlobClicks=0) … Debug the engine, not the harness" (was "TOOL-FAIL #358 / INVALID").
- `npx tsc --noEmit` clean. Gate unaffected (both fixtures are PRNG, outside the gate denominator).

## Why this is the high-leverage one
It fixes the **instrument**, not one fixture — every future sweep now routes a missing-WAV row to the correct layer, killing the misdiagnosis blind spot that misled #426, #427, and #430→#432 (the project's own "verify the instrument before declaring an engine bug" principle). Catalogue: vyāpti **SV48** upgraded to 3-way + a falsified prior claim corrected; hetvābhāsa **SP112**.

Closes #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)