### PR TITLE
🐛 fix(transpiler): namespace user-defined functions so a local can't shadow a same-named define (#432)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -337,6 +337,28 @@ const BUILDER_METHODS = new Set([
  * Inside a loop, these must NOT get the `b.` prefix —
  * they're captured from the enclosing scope via the Proxy.
  */
+/**
+ * Ruby keeps method names and local variables in SEPARATE namespaces, so a
+ * `define :synths` and a local `synths = [...]` coexist — `synths(n)` calls the
+ * method, bare `synths` reads the local. JS collapses both into one lexical
+ * binding: the bare assignment `synths = [...]` reassigns the `function synths`
+ * declaration's slot (the assignment is lexically resolved, never reaching the
+ * Sandbox proxy), so the later `synths(n)` call hits the array → "synths is not
+ * a function" (#432, sonic_dreams).
+ *
+ * Fix: emit every user-defined function (define / ndefine / def) under a reserved
+ * prefix that a user's local variable can never lexically shadow. Method CALLS
+ * (`synths(n)`, bare-statement `bd`) resolve to the prefixed name; local-variable
+ * reads (`synths.first`, `synths = [...]`) keep the plain name and flow through
+ * the proxy scope — exactly mirroring Ruby's two-namespace rule. The persistence
+ * registrar `define(name, fn)` keeps the PLAIN string key so #215 cross-eval
+ * seeding (proxy resolves a removed define's plain name) still works.
+ */
+const DEF_PREFIX = '__spdef_'
+function defJsName(name: string): string {
+  return DEF_PREFIX + name
+}
+
 const TOP_LEVEL_SCOPE = new Set([
   'live_loop', 'stop_loop', 'define',
   'use_bpm', 'use_synth', 'use_random_seed', 'use_arg_bpm_scaling',
@@ -534,9 +556,10 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       const isStatement = parentType === 'body_statement' || parentType === 'program' ||
                           parentType === 'then' || parentType === 'block_body'
 
-      // Bare identifier that matches a user-defined function → call it with __b
+      // Bare identifier that matches a user-defined function → call it with __b.
+      // Namespaced so a same-named local variable can't shadow the call (#432).
       if (isStatement && ctx.definedFunctions.has(name)) {
-        return `${name}(__b)`
+        return `${defJsName(name)}(__b)`
       }
 
       // Bare identifier that matches a known no-arg DSL function.
@@ -825,7 +848,9 @@ function transpileNode(node: any, ctx: TranspileContext): string {
         ? params.namedChildren.map((c: any) => transpileNode(c, ctx)).join(', ')
         : ''
       const bodyStr = body ? transpileNode(body, ctx) : ''
-      return `function ${nameNode.text}(${paramStr}) {\n${bodyStr}\n${ctx.indent}}`
+      // Namespaced (#432) — calls resolve via defJsName; keeps def out of the
+      // local-variable namespace, mirroring Ruby's method-vs-local separation.
+      return `function ${defJsName(nameNode.text)}(${paramStr}) {\n${bodyStr}\n${ctx.indent}}`
     }
 
     // ---- Lambda ----
@@ -1314,10 +1339,11 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
       return `__b.play(${args}, { synth: "${methodName}" })`
     }
 
-    // User-defined function call
+    // User-defined function call — namespaced so a same-named local variable
+    // can't shadow the call (#432). The local read keeps the plain name.
     if (ctx.definedFunctions.has(methodName)) {
       const args = argsNode ? transpileArgList(argsNode, ctx) : ''
-      return `${methodName}(__b${args ? ', ' + args : ''})`
+      return `${defJsName(methodName)}(__b${args ? ', ' + args : ''})`
     }
 
     // Methods ending with ? — rename to _q, with b. prefix (on ProgramBuilder)
@@ -1817,9 +1843,13 @@ function transpileDefine(
   // For `define`, also call the runtime registrar so the engine persists the
   // function across re-evals (#215). `ndefine` skips this — its semantic is
   // per-eval only.
-  const decl = `function ${name}(__b${paramStr ? ', ' + paramStr : ''}) {\n${bodyStr}\n${ctx.indent}}`
+  // Namespaced JS binding (#432) so a same-named local variable can't clobber
+  // the function. The persistence registrar keeps the PLAIN string key — proxy
+  // seeding of a removed define (#215) resolves by plain name.
+  const jsName = defJsName(name)
+  const decl = `function ${jsName}(__b${paramStr ? ', ' + paramStr : ''}) {\n${bodyStr}\n${ctx.indent}}`
   if (methodName === 'define') {
-    return `${decl};\n${ctx.indent}define(${JSON.stringify(name)}, ${name})`
+    return `${decl};\n${ctx.indent}define(${JSON.stringify(name)}, ${jsName})`
   }
   return decl
 }

--- a/src/engine/__tests__/Cogate2BrokenRuby.test.ts
+++ b/src/engine/__tests__/Cogate2BrokenRuby.test.ts
@@ -46,7 +46,8 @@ describe('cogate-2 SILENT-FAIL fixes (#382 #383 #384)', () => {
       expect(r.hasError).toBe(false)
       // Before fix: `function f() { f }` — bare reference, no recursion possible.
       // After fix: `function f() { f(__b) }` — recursion → stack overflow → user-visible error.
-      expect(r.code).toMatch(/function\s+f\s*\(\s*\)\s*\{\s*f\(__b\)\s*\}/)
+      // User-defined functions are namespaced (#432) so a local can't shadow them.
+      expect(r.code).toMatch(/function\s+__spdef_f\s*\(\s*\)\s*\{\s*__spdef_f\(__b\)\s*\}/)
     })
 
     it('def + call afterwards: f resolves to f(__b)', () => {
@@ -54,7 +55,8 @@ describe('cogate-2 SILENT-FAIL fixes (#382 #383 #384)', () => {
       expect(r.hasError).toBe(false)
       // The post-def `f` MUST be a call. Before fix it was a bare reference
       // (no-op evaluating to the function object), so user code did nothing.
-      expect(r.code).toMatch(/^\s*f\(__b\)/m)
+      // Namespaced (#432).
+      expect(r.code).toMatch(/^\s*__spdef_f\(__b\)/m)
     })
 
     it('B6 reproducer compiles to recursing JS that throws RangeError', () => {

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -679,9 +679,11 @@ live_loop :groove do
   sleep 0.5
 end`)
       expect(result.ok).toBe(true)
-      expect(result.code).toContain('function bass_hit(__b)')
+      // User-defined functions live in a reserved namespace (#432) so a local
+      // variable can never shadow the call.
+      expect(result.code).toContain('function __spdef_bass_hit(__b)')
       // Call to defined function should inject __b
-      expect(result.code).toContain('bass_hit(__b)')
+      expect(result.code).toContain('__spdef_bass_hit(__b)')
     })
 
     it('ndefine produces same JS function decl as define (#211)', () => {
@@ -694,8 +696,8 @@ live_loop :run do
   sleep 1
 end`)
       expect(result.ok).toBe(true)
-      expect(result.code).toContain('function hit(__b)')
-      expect(result.code).toContain('hit(__b)')
+      expect(result.code).toContain('function __spdef_hit(__b)')
+      expect(result.code).toContain('__spdef_hit(__b)')
     })
   })
 
@@ -766,7 +768,36 @@ live_loop :t do
   sleep 4
 end`)
       expect(result.ok).toBe(true)
-      expect(result.code).toContain('function ocean(__b, num, amp_mul = 1)')
+      expect(result.code).toContain('function __spdef_ocean(__b, num, amp_mul = 1)')
+    })
+
+    it('a local variable does not clobber a same-named define call (#432)', () => {
+      // Ruby keeps method names and local variables in separate namespaces:
+      // `synths = [...]` is a local, `synths(n)` (with args) calls the define.
+      // JS collapses both into one lexical binding, so the array used to clobber
+      // the `function synths` declaration → "synths is not a function".
+      // Defines must live in a reserved namespace a local can never shadow.
+      const result = treeSitterTranspile(`define :synths do |x|
+  play x
+end
+
+define :go do
+  synths = [60, 62, 64]
+  n = synths.first
+  synths(n)
+end`)
+      expect(result.ok).toBe(true)
+      // Declaration is namespaced…
+      expect(result.code).toContain('function __spdef_synths(__b, x)')
+      // …and so is the call site (with args) — it must NOT resolve to the local.
+      expect(result.code).toContain('__spdef_synths(__b, n)')
+      expect(result.code).not.toMatch(/(?<!__spdef_)\bsynths\(__b, n\)/)
+      // The local variable read/assign stay on the plain name (proxy scope).
+      // `.first` lowers to `[0]`, so the read surfaces as `synths[0]`.
+      expect(result.code).toContain('synths = [60, 62, 64]')
+      expect(result.code).toContain('n = synths[0]')
+      // Persistence registrar keeps the PLAIN string key (#215 cross-eval seed).
+      expect(result.code).toContain('define("synths", __spdef_synths)')
     })
 
     it('begin/rescue', () => {


### PR DESCRIPTION
Closes #432. Stacked on the dashboard branch (`dea030e`).

## Problem
Ruby keeps method names and local variables in **separate namespaces** — `synths = [...]` is a local, `synths(n)` calls the `define :synths`. Our transpiler collapsed both into one lexical JS binding; a function declaration inside the Sandbox `with(__scope__){…}` **bypasses the proxy** (verified by probe), so the bare assignment `synths = [...]` reassigned the `function synths` slot → `synths(n)` hit the array → `fn is not a function` (sonic_dreams `play_synths`).

## Fix
Emit every user-defined function (`define`/`ndefine`/`def`) under a reserved `__spdef_` prefix at declaration + all call sites; local reads/assignments keep the plain name. Persistence registrar keeps the plain string key (#215 unaffected).

## Test plan
- Level-1: 1089/1089 vitest, tsc clean. +1 regression test (#432) + 3 shape-test updates.
- **Level-3**: minimal reproducer (`define :synths` + local `synths=[...]` + `synths(x)` in a live_loop) plays note 60 via the define, 0 errors; pre-fix it threw.

⚠️ sonic_dreams remains gated by a **separate, pre-existing** blocker (#435, 3 anonymous threads `fn is not a function`), confirmed independent by a controlled stash experiment. Catalogues: SP113, SV58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)