### PR TITLE
🐛 fix(transpiler): drop inline comments in comma-joined constructs + alias .to_int — unblock orchard ENGINE-SILENT (#436)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -498,13 +498,19 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       return `[${node.namedChildren.map((c: any) => `"${c.text}"`).join(', ')}]`
 
     case 'array': {
+      // Drop inline `#` comments — a literal is comma-joined onto ONE JS line,
+      // so a `//` comment child would swallow the rest of the array (orchard_improv
+      // `pent = [#:B1, … :Fs2, …]` → broken literal → ENGINE-SILENT). A comment
+      // carries no element value; keeping it would also leave an elision hole.
       const elements = node.namedChildren
+        .filter((c: any) => c.type !== 'comment')
         .map((c: any) => transpileNode(c, ctx))
       return `[${elements.join(', ')}]`
     }
 
     case 'hash': {
       const pairs = node.namedChildren
+        .filter((c: any) => c.type !== 'comment')
         .map((c: any) => transpileNode(c, ctx))
       return `{ ${pairs.join(', ')} }`
     }
@@ -519,7 +525,7 @@ function transpileNode(node: any, ctx: TranspileContext): string {
     }
 
     case 'subarray':
-      return `[${node.namedChildren.map((c: any) => transpileNode(c, ctx)).join(', ')}]`
+      return `[${node.namedChildren.filter((c: any) => c.type !== 'comment').map((c: any) => transpileNode(c, ctx)).join(', ')}]`
 
     // ---- Identifiers ----
     case 'identifier': {
@@ -1541,8 +1547,10 @@ function transpileReceiverMethodCall(
     return recStr
   }
 
-  // .to_i → Math.floor
-  if (method === 'to_i') {
+  // .to_i / .to_int → Math.floor. Ruby's Integer#to_int is the implicit-coercion
+  // alias of to_i; orchard_improv uses `lene.to_int.times`. Without this, a number
+  // has no `.to_int` method → "x.to_int is not a function".
+  if (method === 'to_i' || method === 'to_int') {
     return `Math.floor(${recStr})`
   }
 
@@ -2491,6 +2499,10 @@ function transpileArgList(node: any, ctx: TranspileContext, injectSrcLine = fals
   const kwargs: string[] = []
 
   for (const arg of args) {
+    // Inline `#` comments are comma-joined with real args onto one JS line; a
+    // `//` would swallow the rest of the call. Drop them (#436, same class as
+    // the array/hash literal fix).
+    if (arg.type === 'comment') continue
     if (arg.type === 'pair') {
       const key = arg.namedChildren[0]
       const val = arg.namedChildren[1]

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -750,6 +750,36 @@ end`)
       expect(result.ok).toBe(true)
       expect(result.code).toContain('//')
     })
+
+    it('inline # comment inside a multi-line array literal does not break the flattened literal (orchard_improv)', () => {
+      // The array is comma-joined onto one JS line, so a `//` comment child would
+      // swallow the rest of the array. Drop comment children instead.
+      const result = treeSitterTranspile(`pent = [#:B1, :Cs2,
+        :Fs2, :Gs2,
+        :B2]
+play pent[0]`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('pent = ["Fs2", "Gs2", "B2"]')
+      expect(result.code).not.toContain('[//')
+    })
+
+    it('inline # comment inside an argument list does not break the call (same class as #436)', () => {
+      const result = treeSitterTranspile(`play 60, # the root
+        amp: 0.5`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toContain(', //')
+      expect(result.code).toContain('amp: 0.5')
+    })
+
+    it('.to_int lowers to Math.floor like .to_i (orchard_improv `lene.to_int.times`)', () => {
+      const result = treeSitterTranspile(`n = 5
+n.to_int.times do
+  play 60
+  sleep 0.1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('Math.floor(n)')
+    })
   })
 
   describe('Advanced constructs', () => {


### PR DESCRIPTION
Closes #436. Stacked on the dashboard branch (`dea030e`).

## Problem
`orchard_improv.rb` was ENGINE-SILENT. `pent = [#:B1, :Cs2,\n :Fs2,…]` — a `#` comment **inside** the array. The array case comma-joins all children (incl. the comment, emitted `//…`) onto one JS line → the `//` swallows the rest of the flattened array → invalid JS → silent. Secondary: `.to_int` was unhandled.

## Fix (the class, not the instance)
Drop `comment` children from every construct that comma-joins onto one line: `array`, `hash`, `subarray` literals AND `transpileArgList`. Alias `.to_int` → `Math.floor`.

## Test plan
- Level-1: 1091/1091 vitest, tsc clean. +3 regression tests.
- **Level-3**: orchard renders 9.73s audio (107 `sonic-pi-tri` /s_new + reverb FX, peak 0.67, RMS 0.18, 0 errors) — was silent. PRNG-heavy → A/B is SV49 PRNG-VARIANT by design.

Catalogue: SP114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)