### PR TITLE
🐛 fix(engine): accept in_thread options hash so named threads don't die (#435)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -410,7 +410,21 @@ export class ProgramBuilder {
     return this
   }
 
-  in_thread(buildFn: (b: ProgramBuilder) => void): this {
+  in_thread(buildFn: (b: ProgramBuilder) => void): this
+  in_thread(opts: Record<string, unknown>, buildFn: (b: ProgramBuilder) => void): this
+  in_thread(
+    optsOrFn: Record<string, unknown> | ((b: ProgramBuilder) => void),
+    maybeFn?: (b: ProgramBuilder) => void
+  ): this {
+    // `in_thread name: :x do … end` passes an options hash first (desktop SP
+    // supports name:/delay:/sync:/seed:). The transpiler faithfully emits
+    // `in_thread({name:"x"}, fn)`; without this overload the hash landed in the
+    // block slot and `buildFn(inner)` threw "buildFn is not a function" (#435).
+    // Mirror with_fx's optsOrFn/maybeFn resolution.
+    const buildFn = typeof optsOrFn === 'function' ? optsOrFn : maybeFn
+    if (typeof buildFn !== 'function') {
+      throw new Error('in_thread requires a block')
+    }
     // in_thread forks a thread → fresh tick scope + re-seeded rng, but
     // inherits a snapshot of thread-locals (synth/bpm/transpose/density/
     // defaults/iteration introspection). #343 Defect: _currentBpm now threads.

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1013,8 +1013,18 @@ export class SonicPiEngine {
         topLevelBuilder.use_random_seed(seed)
       }
 
-      // Top-level in_thread: wrap callback in a one-shot live_loop
-      const topLevelInThread = (fn: (b: ProgramBuilder) => void) => {
+      // Top-level in_thread: wrap callback in a one-shot live_loop.
+      // `in_thread name: :x do … end` passes an options hash first; the
+      // transpiler emits `in_thread({name:"x"}, fn)`. Accept the optional
+      // leading hash so the block isn't mistaken for `fn` — without this the
+      // hash landed in `fn` and `fn(b)` threw "fn is not a function", silently
+      // killing every named top-level thread (#435). Mirrors topLevelAt's shape.
+      const topLevelInThread = (
+        optsOrFn: Record<string, unknown> | ((b: ProgramBuilder) => void),
+        maybeFn?: (b: ProgramBuilder) => void
+      ) => {
+        const fn = typeof optsOrFn === 'function' ? optsOrFn : maybeFn
+        if (typeof fn !== 'function') return
         const name = `__thread_${Date.now()}_${randomSuffix()}`
         fxAwareWrappedLiveLoop(name, (b: ProgramBuilder) => {
           fn(b)

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -276,6 +276,22 @@ describe('ProgramBuilder', () => {
       expect((program[1] as any).body).toHaveLength(2)  // play, sleep
     })
 
+    it('#435: accepts a leading options hash (in_thread name: :x do … end)', () => {
+      const b = new ProgramBuilder()
+      // Transpiler emits `in_thread({name:"x"}, fn)` for `in_thread name: :x`.
+      // Without the opts-hash overload, the hash landed in the block slot and
+      // `buildFn(inner)` threw "buildFn is not a function" — killing the thread.
+      expect(() =>
+        b.in_thread({ name: 'x' }, (inner) => {
+          inner.play(60)
+        })
+      ).not.toThrow()
+      const program = b.build()
+      const threadStep = program[0] as any
+      expect(threadStep.tag).toBe('thread')
+      expect(threadStep.body[0].note).toBe(60)
+    })
+
     it('inherits currentSynth from parent', () => {
       const b = new ProgramBuilder()
       b.use_synth('prophet')


### PR DESCRIPTION
## Problem

`algomancer/sonic_dreams.rb`'s three `in_thread name: :x do … end` threads
(`:bassdrums`, `:drums`, `:synths`) threw **`fn is not a function`** in lockstep
roughly every ~1s and produced no audio, while anonymous `in_thread do … end`
blocks played fine. Closes #435.

### Root cause (grounded by observation, SP115)

The transpiler faithfully emits `in_thread({name:"x"}, fn)` for a named thread.
But **both** `in_thread` entry points only accepted a single block argument:

- engine `topLevelInThread = (fn) => …` (top-level threads) — `SonicPiEngine.ts`
- `ProgramBuilder.in_thread(buildFn)` (nested threads) — `ProgramBuilder.ts`

So the options hash landed in the block slot and `fn(b)` / `buildFn(inner)` threw.
The scheduler's 1-beat error-recovery sleep produced the ~1s lockstep recurrence.

An instrumented `onLoopError` stack trace pinpointed `topLevelInThread`'s `fn(b)`
in a single capture (no bisection).

## Fix

Both entry points now accept an optional leading options hash and resolve the
real block via `typeof optsOrFn === 'function' ? optsOrFn : maybeFn`, mirroring
the existing `with_fx`/`tuplets` shape. The `name:` option is accepted (thread
keeps its existing anonymous `__thread_*` identity — no collision with inner
same-named `live_loop`s).

## Test plan

- ✅ `npx vitest run` — **1089/1089** (added a regression test for the nested
  `in_thread({name}, fn)` path in `ProgramBuilder.test.ts`)
- ✅ `npx tsc --noEmit` — clean
- ✅ **Level-3 observation** (`tools/capture.ts` on sonic_dreams): the three
  `fn is not a function` errors are **gone**; the named threads now execute —
  `sonic-pi-fm`×63 + `sonic-pi-noise`×33 (`:drums`), `bd_haus`/`elec_blip`/
  `ambi_lunar` (`:bassdrums`), `sonic-pi-zawa`×11 (anon thread).

## Follow-ups (separate, pre-existing bugs this fix unmasks)

With named threads now running, `:synths` → `play_synths` reaches two further
pre-existing blockers, both filed separately:
- **#432** (define/local namespace collapse — already fixed in PR #437)
- **String × Integer** Ruby repeat not handled by `__spMul` → `NaN` → new issue