### PR TITLE
🐛 fix(runtime): Ruby String × Integer repeats the string in __spMul (#441)

### DIFF
--- a/src/engine/Sandbox.ts
+++ b/src/engine/Sandbox.ts
@@ -189,6 +189,13 @@ export function createIsolatedExecutor(
     // Needed for patterns like `hats = [1,0,1,0] * 4`.
     '  if (Array.isArray(a) && typeof b === "number") return new Array(b).fill(a).flat();',
     '  if (typeof a === "number" && Array.isArray(b)) return new Array(a).fill(b).flat();',
+    // Ruby String * Integer → repeat the string (e.g. `"0" * 5 == "00000"`).
+    // Without this, string*number fell through to `a * b` === NaN, which then
+    // broke iterating helpers like `shuffle("0" * n)` ("arr is not iterable",
+    // #441). Clamp to a non-negative integer so a stray negative/float can't
+    // crash a live loop (Ruby would raise; silent-safe is better mid-loop).
+    '  if (typeof a === "string" && typeof b === "number") return a.repeat(Math.max(0, Math.floor(b)));',
+    '  if (typeof a === "number" && typeof b === "string") return b.repeat(Math.max(0, Math.floor(a)));',
     '  return a * b;',
     '}',
     // Ruby x.kind_of?(Class) / x.is_a?(Class) — dispatch by class name.

--- a/src/engine/__tests__/Sandbox.test.ts
+++ b/src/engine/__tests__/Sandbox.test.ts
@@ -254,4 +254,17 @@ describe('Sandbox', () => {
     )
     expect(result).toBe(24) // 48 - 24, NOT NaN
   })
+
+  // #441 — Ruby String * Integer is repeat ("0" * 5 == "00000"). Before the
+  // fix __spMul fell through to `a * b` === NaN, which broke iterating helpers
+  // like `shuffle("0" * n)` ("arr is not iterable").
+  it('String * Integer repeats the string (both operand orders)', async () => {
+    let result: unknown = null
+    const execute = createSandboxedExecutor(
+      'storeResult([__spMul("0", 5), __spMul(3, "ab"), __spMul("x", 0)])',
+      ['storeResult']
+    )
+    await execute((v: unknown) => { result = v })
+    expect(result).toEqual(['00000', 'ababab', ''])
+  })
 })


### PR DESCRIPTION
## Problem

`shuffle("0" * (30 - t) + ("1" * t))` in sonic_dreams' `play_synths` threw
**`arr is not iterable`** at build time, killing the `:synths` thread so the
`mod_*` synths never played. Closes #441.

### Root cause (grounded)

Ruby's `String#*` is **repeat** (`"0" * 5 == "00000"`). The transpiler correctly
routes `*` through the runtime helper `__spMul`, but `__spMul` (`Sandbox.ts`)
only handled `Ring × number`, `number × Ring`, `Array × number`, `number ×
Array`, then fell through to `return a * b`. For a string that is `NaN`.
`shuffle(NaN)` then does `[...NaN]` → `TypeError: arr is not iterable`.

## Fix

Add String × Integer (both operand orders) to `__spMul`, returning
`str.repeat(Math.max(0, Math.floor(n)))` — clamped to a non-negative integer so
a stray negative/float can't crash a live loop (Ruby raises; silent-safe is
better mid-loop). Mirrors the existing Array × Integer repeat case.

## Test plan

- ✅ `npx vitest run` — **1089/1089** (added a Sandbox.test.ts case exercising
  the real polyfill: `__spMul("0",5)`/`__spMul(3,"ab")`/`__spMul("x",0)`)
- ✅ `npx tsc --noEmit` — clean
- ✅ **Level-3** isolated reproducer: `shuffle("0" * n)` now builds — 3 shuffled
  binary strings printed, 4 tb303 notes dispatched, 0 errors (was crash).
- ✅ **Level-3 combined** (with #435 + #432/#437 applied): sonic_dreams renders
  fully — `mod_saw`×56 (was 0), `fm`×63, `noise`×33, `tb303`×14, `zawa`×11,
  `bd_haus`×3 — every thread executes, **zero errors**.

## Context

One of the last blockers (with #435 and #432/#437) to full `sonic_dreams`
measurability. Independent, pre-existing; surfaced once #435 let the named
threads run.