### PR TITLE
🔧 fix(comparator): reconcile pitch-tracker method asymmetry → gradable PRNG-VARIANT (#443, #376 follow-up)

### DIFF
--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -180,6 +180,12 @@ interface ComparisonResult {
   spectrogram: SpectrogramMetrics | null
   spectrogramError: string | null
   reportPath: string
+  // #376 reconciliation — when the two sides auto-select DIFFERENT pitch-track
+  // methods, both are re-tracked with a forced common method (contour) capped
+  // to the shorter capture's duration, so a method-asymmetric pair can still
+  // yield a Tier-1 verdict (MATCH / PRNG-VARIANT) instead of an automatic
+  // INCONCL. Populated only in the asymmetric case; null otherwise.
+  reconciledPitch?: { desktop: PitchTrack | null; web: PitchTrack | null } | null
 }
 
 function writeComparisonReport(r: ComparisonResult): void {
@@ -446,7 +452,38 @@ function writeComparisonReport(r: ComparisonResult): void {
     else if (mismatch < 0) pitchVerdict = `✓ PITCH-MATCH — ${unit} identical over ${n}`
     else if (onsetUnreliable) pitchVerdict = `⚠ INCONCLUSIVE — onset detector unreliable: gross density mismatch (desktop ${dp.count} vs web ${wp.count} onsets, ratio ${countRatio.toFixed(2)} < 0.3) on slewed/sustained material; onset method cannot judge this — no Tier-1 verdict (#368)`
     else if (polyphonicUnreliable) pitchVerdict = `⚠ INCONCLUSIVE — polyphonic material (play_chord) judged via contour pitch-tracker; ordering reported on both sides contains pitch-classes outside any single chord (overtone/chord-member picking) — contour method cannot judge polyphonic-chord arpeggios reliably — no Tier-1 verdict (#374; for engine verification use an instrument-friendly monophonic reproducer)`
-    else if (methodAsymmetric) pitchVerdict = `⚠ INCONCLUSIVE — pitch-tracker method asymmetry: desktop \`${dp.method}\` (conf ${dp.confidence}) vs web \`${wp.method}\` (conf ${wp.confidence}); different envelope characteristics route each side to a different tracker (often gain-staging or FX accumulation makes a different signal dominate each side) — sequences from different methods are not comparable, no Tier-1 verdict (#376; for engine verification use an instrument-friendly reproducer with symmetric envelopes)`
+    else if (methodAsymmetric) {
+      // #376 — instead of an automatic INCONCL, try to RECONCILE: both sides
+      // were re-tracked with a forced common method (contour) capped to the
+      // shorter capture's duration (r.reconciledPitch). Compared over the same
+      // method + same time span, a method-asymmetric pair can still yield a
+      // verdict — but ONLY a PRNG-VARIANT, and ONLY when the source is PRNG-
+      // driven AND the pitch-class histogram genuinely matches. Everything
+      // else stays INCONCL, so a pair where DIFFERENT signals dominate each
+      // side (the dark_neon case — no PRNG token, blade vs kick) is never
+      // misread as MATCH or as an engine bug. The reconciled "tempo" is
+      // contour-segmentation spacing (not musical), so it is NOT a gate here;
+      // the pc-histogram cosine carries the verdict (#358/#364/#367).
+      const rd = r.reconciledPitch?.desktop, rw = r.reconciledPitch?.web
+      const rdSeq = rd ? (rd.pc.filter(x => x !== null) as number[]) : []
+      const rwSeq = rw ? (rw.pc.filter(x => x !== null) as number[]) : []
+      const rn = Math.min(rdSeq.length, rwSeq.length)
+      const rCos = rn > 0 ? cosine(pcHist(rdSeq.slice(0, rn)), pcHist(rwSeq.slice(0, rn))) : 0
+      const rCount = rd && rw && Math.max(rd.count, rw.count) > 0
+        ? Math.min(rd.count, rw.count) / Math.max(rd.count, rw.count) : 0
+      const rLowConf = !rd || !rw || rd.confidence < 0.6 || rw.confidence < 0.6
+      const alignedDur = Math.min(r.desktop.stats?.duration ?? 0, r.web.stats?.duration ?? 0)
+      if (rd && rw && !rLowConf && rn > 0 && PRNG_RE.test(r.code) && rCos >= 0.92 && rCount >= 0.5) {
+        prngVariant = true; prngCos = rCos
+        pitchVerdict = `≈ pitch-class histogram cos=${rCos.toFixed(3)} (≥0.92), density ratio ${rCount.toFixed(2)} (≥0.5), PRNG token; same composition, different random walk — method-reconciled (desktop \`${dp.method}\`→contour · web \`${wp.method}\`→contour over aligned ${alignedDur.toFixed(1)}s window; #376/#358/#364/#367)`
+      } else {
+        const why = !PRNG_RE.test(r.code) ? '; no PRNG token — not promoted (different signals dominate each side)'
+          : rLowConf ? `; reconciled-contour low confidence (desktop ${rd?.confidence ?? '—'} · web ${rw?.confidence ?? '—'})`
+          : rn === 0 ? '; reconciled track empty'
+          : `; reconciled-contour histogram cos=${rCos.toFixed(3)} < 0.92 (different signals dominate each side)`
+        pitchVerdict = `⚠ INCONCLUSIVE — pitch-tracker method asymmetry: desktop \`${dp.method}\` (conf ${dp.confidence}) vs web \`${wp.method}\` (conf ${wp.confidence})${why} — no Tier-1 verdict (#376)`
+      }
+    }
     else if (multiLoopPhaseDrift) pitchVerdict = `⚠ INCONCLUSIVE — multi-loop interleaved phase drift: ${liveLoopCount} live_loops, first ${prefixLen} notes matched exactly desktop ↔ web before drift began. When two near-simultaneous onsets fall within onset-detector resolution (~5-10ms), which side "wins" is timing-jitter dependent, not engine semantics — engine provably correct on the long prefix-match (#377; for engine verification use an instrument-friendly single-loop variant)`
     else if (prngVariant) {
       pitchVerdict = `≈ pitch-class histogram cos=${prngCos.toFixed(3)} (≥0.92), tempo match, density ratio ${countRatio.toFixed(2)} (≥0.5), PRNG token in source; same composition, different random walk (cross-engine seed parity is not a v1 goal — #358/#364/#367)`
@@ -738,11 +775,16 @@ async function main(): Promise<void> {
 
   // Tier 1 — pitch-track (the musical-correctness verdict). Run for each WAV
   // independently so a missing one still yields the other's sequence.
-  const runPitch = async (wav: string | null): Promise<PitchTrack | null> => {
+  const runPitch = async (
+    wav: string | null,
+    opts?: { forceMethod?: 'onset' | 'contour'; maxDur?: number }
+  ): Promise<PitchTrack | null> => {
     if (!wav) return null
     try {
       const pArgs = ['tools/pitchtrack.py', '--json']
       if (args.bpm !== null) pArgs.push('--bpm', String(args.bpm))
+      if (opts?.forceMethod) pArgs.push('--force-method', opts.forceMethod)
+      if (opts?.maxDur !== undefined) pArgs.push('--max-dur', opts.maxDur.toFixed(3))
       pArgs.push(wav)
       const py = await runChild('python3', pArgs)
       if (py.exitCode !== 0) return null
@@ -757,6 +799,22 @@ async function main(): Promise<void> {
   }
   const [desktopPitch, webPitch] = await Promise.all([runPitch(desktopWav), runPitch(webWav)])
 
+  // #376 reconciliation — if the two sides auto-selected DIFFERENT methods,
+  // re-track both with a forced common method (contour) capped to the shorter
+  // capture's duration. Compared over the same time span + same method, a
+  // method-asymmetric pair can still yield a real Tier-1 verdict.
+  let reconciledPitch: { desktop: PitchTrack | null; web: PitchTrack | null } | null = null
+  if (desktopPitch && webPitch && desktopPitch.method !== webPitch.method) {
+    const dDur = desktopStats?.duration ?? 0
+    const wDur = webStats?.duration ?? 0
+    const capDur = dDur > 0 && wDur > 0 ? Math.min(dDur, wDur) : undefined
+    const [dRec, wRec] = await Promise.all([
+      runPitch(desktopWav, { forceMethod: 'contour', maxDur: capDur }),
+      runPitch(webWav, { forceMethod: 'contour', maxDur: capDur }),
+    ])
+    reconciledPitch = { desktop: dRec, web: wRec }
+  }
+
   const result: ComparisonResult = {
     timestamp: new Date().toISOString(),
     code: args.code,
@@ -767,6 +825,7 @@ async function main(): Promise<void> {
     spectrogram,
     spectrogramError,
     reportPath,
+    reconciledPitch,
   }
   writeComparisonReport(result)
 

--- a/tools/pitchtrack.py
+++ b/tools/pitchtrack.py
@@ -14,12 +14,17 @@ import sys, json, numpy as np, wave
 NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
 
-def load(path):
+def load(path, max_dur=None):
     w = wave.open(path, 'rb')
     sr, n, ch = w.getframerate(), w.getnframes(), w.getnchannels()
     a = np.frombuffer(w.readframes(n), dtype=np.int16).astype(np.float64)
     if ch == 2:
         a = a.reshape(-1, 2).mean(axis=1)
+    # #376 reconciliation — cap to a common duration so two captures of an
+    # evolving generative piece are compared over the SAME time span (a
+    # misaligned window otherwise confounds note-count / histogram parity).
+    if max_dur is not None:
+        a = a[:int(max_dur * sr)]
     a /= (np.abs(a).max() or 1.0)          # normalise away the 0.5× gain delta
     return a, sr
 
@@ -57,10 +62,10 @@ def estimate_note_dt(a, sr):
     return float(np.clip(np.median(iois), 0.05, 2.0))
 
 
-def track(path, note_dt=None):
+def track(path, note_dt=None, max_dur=None):
     """Onset-based pitch-track. note_dt auto-estimated from the signal when
     not given (#348 — removes the hardcoded-0.25s assumption)."""
-    a, sr = load(path)
+    a, sr = load(path, max_dur)
     if note_dt is None:
         note_dt = estimate_note_dt(a, sr)
     notes = []
@@ -101,11 +106,11 @@ def _ac_pitch(seg, sr):
     return sr / peak
 
 
-def contour(path):
+def contour(path, max_dur=None):
     """#348: pitch-contour fallback for sustained / slow-attack material that
     has no sharp onsets. Per-frame autocorrelation → median-filter → segment
     runs of stable MIDI into notes."""
-    a, sr = load(path)
+    a, sr = load(path, max_dur)
     fl, hop = int(sr * 0.046), int(sr * 0.01)
     midis = []
     for i in range(0, len(a) - fl, hop):
@@ -134,13 +139,21 @@ def contour(path):
     return notes, sr, len(a) / sr, conf
 
 
-def analyse(path, note_dt=None):
-    on, ndt, sr, dur = track(path, note_dt)
+def analyse(path, note_dt=None, force_method=None, max_dur=None):
+    on, ndt, sr, dur = track(path, note_dt, max_dur)
     method, conf = 'onset', 1.0
+    # #376 reconciliation: when the comparator forces a common method on both
+    # sides (because each auto-selected a different one), bypass auto-selection.
+    if force_method == 'onset':
+        pass  # keep the onset track as-is
+    elif force_method == 'contour':
+        cn, _, _, ccon = contour(path, max_dur)
+        on, conf = cn, ccon
+        method = 'contour' if ccon >= 0.6 else 'contour-low'
     # Expected note count is unknown; fall back to contour when onset yields
     # implausibly few notes for the signal length (sustained/legato material).
-    if len(on) < max(2, dur / (ndt * 8)):
-        cn, _, _, ccon = contour(path)
+    elif len(on) < max(2, dur / (ndt * 8)):
+        cn, _, _, ccon = contour(path, max_dur)
         if len(cn) > len(on):
             on, conf = cn, ccon
             method = 'contour' if ccon >= 0.6 else 'contour-low'
@@ -170,14 +183,19 @@ if __name__ == '__main__':
 
     def opt(flag):
         return float(args[args.index(flag) + 1]) if flag in args else None
+    def opt_str(flag):
+        return args[args.index(flag) + 1] if flag in args else None
     note_dt = opt('--note-dt')
     bpm = opt('--bpm')
     if note_dt is None and bpm:                 # one beat = the default grid
         note_dt = 60.0 / bpm
+    force_method = opt_str('--force-method')    # #376 — 'onset' | 'contour'
+    max_dur = opt('--max-dur')                  # #376 — cap to common span (s)
+    VALUE_FLAGS = ('--note-dt', '--bpm', '--force-method', '--max-dur')
     pos = [x for i, x in enumerate(args)
            if not x.startswith('--')
-           and (i == 0 or args[i - 1] not in ('--note-dt', '--bpm'))]
-    r = analyse(pos[0], note_dt)
+           and (i == 0 or args[i - 1] not in VALUE_FLAGS)]
+    r = analyse(pos[0], note_dt, force_method, max_dur)
     if as_json:
         print(json.dumps(r))
     else:


### PR DESCRIPTION
## Problem

#376's `methodAsymmetric` gate emits INCONCLUSIVE whenever desktop and web
auto-select different pitch-track methods (one `onset`, one `contour`). For
heavily-PRNG generative pieces this is **permanent** — `sonic_dreams` renders
the same composition on both sides (proven by direct capture: `mod_saw`×56, all
threads, 0 err), but desktop's 13–16s window has **0 onsets** (FX/sustained-
dominant → contour) while web stays onset, so the verdict was stuck at INCONCL.
Closes #443.

## Observation (grounded)

Under a COMMON method (contour), time-aligned to the shorter capture, the
desktop/web pitch-class histograms are near-identical — **cosine 0.995–0.997**.
The asymmetry was an instrument artifact, not an engine difference.

## Fix

When `methodAsymmetric` fires, re-track BOTH sides with a forced common method
(contour) capped to the shorter capture's duration, then:
- **promote to PRNG-VARIANT** iff source has a PRNG token AND reconciled
  pc-histogram cosine ≥ 0.92 AND density ratio ≥ 0.5 AND both contour
  confidences ≥ 0.6;
- **otherwise stay INCONCLUSIVE** — a non-PRNG pair where different signals
  dominate each side (`dark_neon` blade-vs-kick) is never promoted or misread as
  an engine bug, so #376's protection and the launch gate are preserved.

The reconciled inter-onset "tempo" is contour-segmentation spacing (not
musical), so it does not gate the verdict; the pc-histogram cosine carries it
(#358/#364/#367).

- `pitchtrack.py`: new `--force-method {onset,contour}` + `--max-dur <sec>`
  (default invocation unchanged — backward compatible).
- `compare-desktop-vs-web.ts`: populates `reconciledPitch` (only on asymmetry) +
  a dedicated methodAsymmetric branch.

## Test plan

- ✅ `npx tsc --noEmit` — clean
- ✅ **Level-3** sonic_dreams: INCONCL → **PRNG-VARIANT** (cos 0.995, reconciled
  desktop `contour` · web `onset`→contour, aligned 16.4s window)
- ✅ **Level-3** dark_neon (no PRNG token): stays **INCONCLUSIVE**
  ("not promoted") — gate-safe
- ⏳ full official-pool sweep refresh in progress (5 PRNG asymmetric candidates
  may flip: sonic_dreams, haunted, ambient_experiment, fm_noise, rerezzed; the
  5 non-PRNG asymmetric — incl. gate fixtures — stay INCONCL)

## Scope

Comparator/instrument only — no engine change.