### PR TITLE
🐛 fix(transpiler): hoisted in_thread loop — await sync + fold use_* settings (#451)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -2151,6 +2151,19 @@ function transpileWithBlock(
   return `${prefix}${methodName}(${argParts.join(', ')})`
 }
 
+/** #451: a pre-loop statement that is a flow-sensitive thread-local SETTING
+ *  (`use_synth`/`use_bpm`/`use_transpose`/`use_synth_defaults`/`use_random_seed`/…)
+ *  — idempotent and safe to fold into a hoisted loop body (re-applied each
+ *  iteration). Everything else (play/sample/sleep/cue/assignments) is a one-time
+ *  action that must NOT be folded. Matches the `use_*` flow-sensitive family the
+ *  SV55 / SP36 / SP72 fixes already special-case. */
+function isFlowSensitiveSetting(child: any): boolean {
+  const m = (child?.type === 'call' || child?.type === 'method_call')
+    ? (child.childForFieldName?.('method')?.text ?? child.namedChildren?.[0]?.text)
+    : null
+  return typeof m === 'string' && m.startsWith('use_')
+}
+
 function transpileInThread(
   argsNode: any, blockNode: any, ctx: TranspileContext
 ): string {
@@ -2247,18 +2260,44 @@ function transpileInThread(
   const baseName = nameExpr !== null ? nameExpr : null
   const parts: string[] = []
 
-  if (setupChildren.length > 0) {
+  // #451: partition the pre-loop setup. The loop is hoisted OUT to a sibling
+  // top-level live_loop, so it no longer sits inside the in_thread builder —
+  // SP72's parentBuilder path (which carries use_* into a NESTED live_loop)
+  // can't reach it. Two kinds of setup need different handling:
+  //   • flow-sensitive SETTINGS (`use_synth`/`use_bpm`/`use_transpose`/…) must
+  //     reach the hoisted loop → fold them into its body (idempotent, re-applied
+  //     each iteration — matches desktop "set once, then loop forever"). Without
+  //     this the hoisted loop registers the default synth (syncer mod_saw→beep).
+  //   • one-time ACTIONS (`play`/`sample`/`sleep`/`cue`/var assigns) must run
+  //     ONCE → keep them in a setup in_thread (folding a `play` into the loop
+  //     would re-fire it every iteration).
+  const settingChildren = setupChildren.filter(isFlowSensitiveSetting)
+  const actionChildren = setupChildren.filter((c) => !isFlowSensitiveSetting(c))
+
+  // Settings folded into each hoisted loop body. asyncBody so any `await` is legal.
+  const settingCtx: TranspileContext = { ...ctxNoGate, insideLoop: true, asyncBody: true }
+  const settingStr = settingChildren
+    .map((c) => '  ' + transpileNode(c, settingCtx))
+    .filter((s) => s.trim())
+    .join('\n')
+
+  if (actionChildren.length > 0) {
     const setupCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
-    const setupStr = setupChildren
-      .map(c => '  ' + transpileNode(c, setupCtx))
-      .filter(s => s.trim())
+    const setupStr = actionChildren
+      .map((c) => '  ' + transpileNode(c, setupCtx))
+      .filter((s) => s.trim())
       .join('\n')
     parts.push(`${prefix}in_thread(${itOpts}(__b) => {\n${setupStr}\n${ctx.indent}})`)
   }
 
   for (const loopNode of loopChildren) {
     const body = loopNode.namedChildren.find((c: any) => c.type === 'do_block' || c.type === 'block')
-    const bodyCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
+    // #451: emit the hoisted loop body `async` with asyncBody — exactly like a
+    // normal top-level live_loop (SP95(d) #393). Without asyncBody, `sync`/
+    // `sync_bpm` emit a bare `__b.sync()` whose cue Promise is dropped on the
+    // floor → the loop never blocks on the cue and a sync-gated loop free-runs
+    // (the syncer 1024-voice runaway). asyncBody makes them `await __b.sync()`.
+    const bodyCtx: TranspileContext = { ...ctxNoGate, insideLoop: true, asyncBody: true }
     const bodyStr = transpileBlockBody(body, bodyCtx)
     const idx = counter.n++
     const autoName = baseName !== null
@@ -2268,7 +2307,8 @@ function transpileInThread(
     // as a top-level scheduler-owned loop. Inside another deferred context,
     // route through __b.live_loop.
     const liveLoopPrefix = ctx.insideLoop ? '__b.' : ''
-    parts.push(`${liveLoopPrefix}live_loop(${autoName}, (__b) => {\n${bodyStr}\n${ctx.indent}})`)
+    const fullBody = settingStr ? `${settingStr}\n${bodyStr}` : bodyStr
+    parts.push(`${liveLoopPrefix}live_loop(${autoName}, async (__b) => {\n${fullBody}\n${ctx.indent}})`)
   }
 
   return parts.join('\n')

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -759,9 +759,49 @@ end`)
       expect(result.code).toContain('live_loop("__inthread_loop_0"')
     })
 
-    it('keeps setup statements before loop in in_thread; hoists the loop', () => {
+    // Issue #451: a flow-sensitive setting (`use_synth`) before the hoisted loop
+    // must FOLD INTO the loop body — the loop is hoisted OUT to a sibling
+    // top-level live_loop, so leaving use_synth in a separate in_thread strands
+    // it (the loop registers the default synth → syncer's mod_saw played :beep).
+    it('folds use_synth before loop into the hoisted in_thread live_loop body (#451)', () => {
       const result = treeSitterTranspile(`in_thread do
   use_synth :saw
+  loop do
+    play 60
+    sleep 1
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toContain('while (true)')
+      expect(result.code).toContain('live_loop("__inthread_loop_0"')
+      // setting is folded into the loop, NOT stranded in a dead sibling in_thread
+      expect(result.code).toContain('use_synth("saw")')
+      expect(result.code).not.toContain('in_thread(')
+    })
+
+    // Issue #451: `sync` inside a hoisted in_thread loop must be `await`ed —
+    // the body is emitted `async` so `await __b.sync()` blocks on the cue. Without
+    // it the cue Promise is dropped and a sync-gated loop free-runs (syncer 1024
+    // runaway).
+    it('emits await __b.sync inside a hoisted in_thread loop (#451 sync gating)', () => {
+      const result = treeSitterTranspile(`in_thread do
+  loop do
+    sync :tick
+    sample :drum_heavy_kick
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toContain('while (true)')
+      expect(result.code).toContain('live_loop("__inthread_loop_0", async (__b)')
+      expect(result.code).toContain('await __b.sync("tick")')
+    })
+
+    // Issue #451: a one-time ACTION (play) before the loop must stay in a setup
+    // in_thread (run once) — folding it into the loop would re-fire it every
+    // iteration. Only flow-sensitive use_* settings fold.
+    it('keeps a one-time action before loop in a setup in_thread, not folded (#451)', () => {
+      const result = treeSitterTranspile(`in_thread do
+  play 48
   loop do
     play 60
     sleep 1


### PR DESCRIPTION
## Problem
`in_thread do … loop do … end end` with a cross-thread `sync` (e.g. `syncer.rb`) produced runaway voices (~1024) and ignored `use_synth`. The #205 in_thread bare-`loop` **hoist** in `transpileInThread` had two defects in one transform:

1. It emitted the hoisted `live_loop` **non-async**, so `__b.sync()`'s build-time cue Promise was dropped → no blocking → runaway to the ~1024 voice cap.
2. It **stranded `use_synth`** in a dead sibling `in_thread` → the loop registered the default `beep` instead of the intended synth.

## Fix
- Emit the hoisted loop as `async (__b) =>` with `asyncBody: true` → `await __b.sync()`, matching a normal `live_loop` (SP95(d) / #393).
- Partition setup via new `isFlowSensitiveSetting`: `use_*` settings **fold into the loop body**; one-time actions stay in a setup thread.

## Test plan
- **Level 1:** `npx vitest run` → 1124/1124; `npx tsc --noEmit` clean. +3 regression tests in `TreeSitterTranspiler.test.ts`.
- **Level 2 (event-parity — the layer that caught it):** `syncer` STRUCTURE-DIVERGE → **STRUCTURE-MATCH**: `mod_saw` web 0→12 (==desktop 13), `basic_mono_player` web 1024→12 (==desktop 13).

## Catalogues
hetvabhasa **SP119**, vyapti **SV16 corollary 2** (hoist fidelity), dharana **B1** 4th ordering-member (anvideck `c32c62c`).

### Known latent gap (NOT in scope — candidate follow-up)
A one-time `sleep`/var before a hoisted bare loop, and `in_thread delay:` / `__startGate` (#447/#448), do not yet reach the hoisted `__inthread_loop_N` (starts at vt0). Equally broken pre-fix; `syncer` exercises none of these.

Closes #451