### PR TITLE
🐛 fix(transpiler): pre-loop delay/sleep/start-gate reaches hoisted in_thread loop (#457)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -180,6 +180,7 @@ export function treeSitterTranspile(ruby: string): TreeSitterTranspileResult {
     definedFunctions: new Set(),
     indent: '',
     inthreadLoopCounter: { n: 0 },
+    inthreadGateCounter: { n: 0 },
     fxLoopCounter: { n: 0 },
   }
 
@@ -233,6 +234,12 @@ interface TranspileContext {
   srcLine?: number
   /** Hoisted-loop counter for `loop do` inside `in_thread` (issue #205). */
   inthreadLoopCounter?: { n: number }
+  /**
+   * Counter for the synthetic start-gate cue (`__itg_N`) that sequences a
+   * hoisted in_thread bare-`loop` AFTER its setup/delay (#451 follow-up). Shared
+   * across all in_threads so cue names never collide.
+   */
+  inthreadGateCounter?: { n: number }
   /**
    * #448/SP118: source-position START-GATE cue name for THIS top-level
    * construct only. When set, the construct's registration emits
@@ -2164,6 +2171,15 @@ function isFlowSensitiveSetting(child: any): boolean {
   return typeof m === 'string' && m.startsWith('use_')
 }
 
+/** #451 follow-up: a pre-loop setup statement that ADVANCES virtual time
+ *  (`sleep`/`sync`/`sync_bpm`). When such a statement precedes a hoisted bare
+ *  `loop`, the loop must start at the advanced vtime, not vt 0 — so the hoist
+ *  routes it through a start-gate cue. Text-level check mirrors the top-level
+ *  `seenVtimeAdvancingBareCode` arm (line ~1140). */
+function isVtimeAdvancing(child: any): boolean {
+  return /\b(?:sleep|sync|sync_bpm)\b/.test(child?.text ?? '')
+}
+
 function transpileInThread(
   argsNode: any, blockNode: any, ctx: TranspileContext
 ): string {
@@ -2281,14 +2297,49 @@ function transpileInThread(
     .filter((s) => s.trim())
     .join('\n')
 
-  if (actionChildren.length > 0) {
+  // #451 follow-up: a hoisted bare `loop` becomes a separate scheduler-owned
+  // live_loop that starts at vt 0 unless told otherwise. Three things must push
+  // its first iteration later — all observed DROPPED before this fix:
+  //   (A) `in_thread delay: N`                    — static
+  //   (B) a one-time `sleep`/`sync` in the setup  — RUNTIME duration
+  //   (C) the top-level source-position start-gate (#448) — static cue
+  // (A)+(C) are static and go straight onto the loop's registration opts (the
+  // engine's wrappedLiveLoop honours `delay:` per #447 and `__startGate` per
+  // #448). (B) can't be expressed statically — the loop must wait out the
+  // setup's runtime sleep — so we sequence it through a synthetic start-gate
+  // cue (`__itg_N`) that the setup in_thread fires AFTER its sleep, and the loop
+  // gates on. Root only: a nested in_thread keeps the un-gated path (the cue
+  // machinery is top-level, SP118).
+  const canGate = !ctx.insideLoop
+  const hasVtimeSetup = actionChildren.some(isVtimeAdvancing)
+  const loopGate = (canGate && hasVtimeSetup)
+    ? `__itg_${(ctx.inthreadGateCounter ??= { n: 0 }).n++}`
+    : null
+
+  // Setup in_thread — carries name/delay/top-level-gate (itOpts), runs the
+  // one-time actions in order, and (when sequencing via a cue) fires it once the
+  // setup completes. Emitted whenever there are actions OR a gate cue is needed.
+  if (actionChildren.length > 0 || loopGate !== null) {
     const setupCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
-    const setupStr = actionChildren
+    const setupLines = actionChildren
       .map((c) => '  ' + transpileNode(c, setupCtx))
       .filter((s) => s.trim())
-      .join('\n')
-    parts.push(`${prefix}in_thread(${itOpts}(__b) => {\n${setupStr}\n${ctx.indent}})`)
+    if (loopGate !== null) setupLines.push(`  __b.cue(${JSON.stringify(loopGate)})`)
+    parts.push(`${prefix}in_thread(${itOpts}(__b) => {\n${setupLines.join('\n')}\n${ctx.indent}})`)
   }
+
+  // Registration opts shared by every hoisted loop in this in_thread (they all
+  // start after the same setup). Cue-gated (B) → gate on `__itg`, with delay +
+  // top-level gate already applied upstream in the setup thread. Otherwise (A)+(C)
+  // → static `delay:`/`__startGate` directly on the loop.
+  const loopOptsParts: string[] = []
+  if (loopGate !== null) {
+    loopOptsParts.push(`__startGate: ${JSON.stringify(loopGate)}`)
+  } else if (canGate) {
+    if (delayExpr !== null) loopOptsParts.push(`delay: ${delayExpr}`)
+    if (startGateName !== null) loopOptsParts.push(`__startGate: ${JSON.stringify(startGateName)}`)
+  }
+  const loopOpts = loopOptsParts.length > 0 ? `{ ${loopOptsParts.join(', ')} }, ` : ''
 
   for (const loopNode of loopChildren) {
     const body = loopNode.namedChildren.find((c: any) => c.type === 'do_block' || c.type === 'block')
@@ -2308,7 +2359,7 @@ function transpileInThread(
     // route through __b.live_loop.
     const liveLoopPrefix = ctx.insideLoop ? '__b.' : ''
     const fullBody = settingStr ? `${settingStr}\n${bodyStr}` : bodyStr
-    parts.push(`${liveLoopPrefix}live_loop(${autoName}, async (__b) => {\n${fullBody}\n${ctx.indent}})`)
+    parts.push(`${liveLoopPrefix}live_loop(${autoName}, ${loopOpts}async (__b) => {\n${fullBody}\n${ctx.indent}})`)
   }
 
   return parts.join('\n')

--- a/src/engine/__tests__/LiveLoopDelay.test.ts
+++ b/src/engine/__tests__/LiveLoopDelay.test.ts
@@ -63,3 +63,67 @@ describe('#447 ProgramBuilder.in_thread applies the delay before the body', () =
     expect(body[0].tag).toBe('play')
   })
 })
+
+describe('#451 follow-up — pre-loop timing reaches the hoisted in_thread bare loop', () => {
+  // A bare `loop` inside an in_thread is hoisted to a sibling scheduler-owned
+  // live_loop. Before this fix it always started at vt 0, ignoring (A) `delay:`,
+  // (B) a one-time `sleep` in the setup, and (C) the top-level #448 start-gate —
+  // all three were observed dropped. The loop must fork at the advanced vtime.
+
+  it('A: in_thread delay: 4 { loop } → delay on the hoisted loop opts', () => {
+    const out = autoTranspile('in_thread delay: 4 do\n  loop do\n    sync :tick\n    play 60\n  end\nend')
+    // delay is static → straight onto the hoisted live_loop registration opts
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*\{[^}]*delay:\s*4[^}]*\}/)
+    // pre-fix the delay vanished entirely
+    expect(out).toMatch(/delay:\s*4/)
+  })
+
+  it('B: in_thread { sleep 4; loop } → setup fires a start-gate cue the loop waits on', () => {
+    const out = autoTranspile('in_thread do\n  sleep 4\n  loop do\n    sync :tick\n    play 60\n  end\nend')
+    // setup thread runs the one-time sleep, THEN fires the synthetic gate cue
+    expect(out).toMatch(/__b\.sleep\(4\)[\s\S]*__b\.cue\("__itg_0"\)/)
+    // hoisted loop gates its first iteration on that cue
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*\{[^}]*__startGate:\s*"__itg_0"[^}]*\}/)
+  })
+
+  it('C: top-level sleep before in_thread{loop} → loop gates on the #448 source-position cue', () => {
+    const out = autoTranspile('sleep 4\nin_thread do\n  loop do\n    sync :tick\n    play 60\n  end\nend')
+    // __run_once fires __sg_0 at the in_thread's source position (vt 4)
+    expect(out).toMatch(/__run_once[\s\S]*__b\.cue\("__sg_0"\)/)
+    // the hoisted loop now waits for it (was un-gated → started at vt 0)
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*\{[^}]*__startGate:\s*"__sg_0"[^}]*\}/)
+  })
+
+  it('D: delay + sleep-setup combined → delay upstream on setup thread, loop gates the cue', () => {
+    const out = autoTranspile('in_thread delay: 2 do\n  sleep 4\n  loop do\n    play 60\n  end\nend')
+    // delay applied on the SETUP thread (upstream of the cue), not duplicated on the loop
+    expect(out).toMatch(/in_thread\(\{[^}]*delay:\s*2[^}]*\}[\s\S]*__b\.sleep\(4\)[\s\S]*__b\.cue\("__itg_0"\)/)
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*\{\s*__startGate:\s*"__itg_0"\s*\}/)
+    // the loop opts carry ONLY the gate — delay is not double-applied
+    expect(out).not.toMatch(/live_loop\("__inthread_loop_0",\s*\{[^}]*delay/)
+  })
+
+  it('regression: settings-only setup still folds (no gate, vt 0) — #451 syncer shape', () => {
+    const out = autoTranspile('in_thread do\n  use_synth :saw\n  loop do\n    sync :tick\n    play 60\n  end\nend')
+    // use_synth folds into the loop body; no start-gate, no delay → loop starts at vt 0
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*async/)
+    expect(out).not.toMatch(/__startGate/)
+    expect(out).not.toMatch(/__itg_/)
+    expect(out).toMatch(/__b\.use_synth\("saw"\)/)
+  })
+
+  it('regression: one-time non-vtime action (play) stays concurrent — loop un-gated', () => {
+    const out = autoTranspile('in_thread do\n  play 50\n  loop do\n    sync :tick\n    play 60\n  end\nend')
+    // a play does not advance vtime → no gate; setup thread plays once, loop forks at vt 0
+    expect(out).toMatch(/__b\.play\(50/)
+    expect(out).toMatch(/live_loop\("__inthread_loop_0",\s*async/)
+    expect(out).not.toMatch(/__itg_/)
+  })
+
+  it('regression: nested in_thread (inside live_loop) keeps the un-gated path', () => {
+    const out = autoTranspile('live_loop :outer do\n  in_thread do\n    sleep 1\n    loop do\n      play 60\n    end\n  end\n  sleep 4\nend')
+    // nested → __b.live_loop with no gate opts (cue machinery is top-level, SP118)
+    expect(out).toMatch(/__b\.live_loop\("__inthread_loop_0",\s*async/)
+    expect(out).not.toMatch(/__itg_/)
+  })
+})


### PR DESCRIPTION
## Problem
A bare `loop` inside an `in_thread` is hoisted to a sibling scheduler-owned `live_loop` (#205/SV16). Any timing offset that should precede the loop was **dropped** — the loop forked at virtual time 0. Grounded by transpiler-output dump; observed for all three offset sources:

```ruby
in_thread delay: 4 do            # (A) delay dropped entirely
  loop { sync :tick; play 60 }
end
in_thread do                     # (B) sleep ran in a dead setup thread; loop at vt0
  sleep 4
  loop { sync :tick; play 60 }
end
sleep 4                          # (C) top-level #448 start-gate fired __sg_0 but loop ignored it
in_thread do
  loop { sync :tick; play 60 }
end
```

This is the documented latent follow-up to #451 / SP119.

## Fix
Route the offset through the existing #447 `delay:` / #448 `__startGate` machinery:
- (A) `delay:` + (C) top-level start-gate are **static** → emitted directly on the hoisted loop's registration opts.
- (B) a one-time `sleep`/`sync` in setup is a **runtime duration** → the setup `in_thread` fires a synthetic start-gate cue `__itg_N` after its sleep; the hoisted loop gates its first iteration on it.
- Root only — a nested in_thread keeps the un-gated path (cue machinery is top-level, SP118).

New `isVtimeAdvancing` helper + `inthreadGateCounter`. No engine change — composes opts the engine already honors.

## Test plan
- **Level 1:** +7 transpiler-output tests (A/B/C/combined + regression guards: settings-fold #451, non-vtime action, nested) — `LiveLoopDelay.test.ts`. Suite **1131/1131**, `tsc --noEmit` clean.
- **Level 2 (web capture, real engine — no desktop):** within-run marker `play 72` → hoisted `play 60` delta = **4.000s exactly** for both `sleep 4` and `delay: 4` (was ≈0).

## Out of scope (documented)
A var-assignment before the hoisted loop whose value the loop body reads — the var lives in the setup thread's scope, not visible to the hoisted sibling loop (separate from timing). Nested in_thread.

Catalogue: hetvabhasa SP119 updated (anvideck `2ddc05d`). Closes #457.