### PR TITLE
fix(transpiler): sync inside with_fx no longer emits await in a non-async callback (#461)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -2122,9 +2122,19 @@ function transpileWithBlock(
   // Inside a loop, the block body is inside ProgramBuilder context (insideLoop: true).
   // At top level, with_fx just wraps live_loops — the body stays at top-level context.
   // The engine's topLevelWithFx passes null to the callback, so `b` is not available.
+  // #461: the with_fx callback arrow is emitted NON-async (line ~2157), so its
+  // body must NOT inherit `asyncBody` from an enclosing async wrapper (e.g.
+  // __run_once, whose bareCtx sets asyncBody:true). If it did, a `sync` in the
+  // body would emit `await __b.sync(...)` inside a non-async arrow → "await is
+  // only valid in async functions" → whole program is invalid JS → renders
+  // nothing. Inside with_fx, `sync`/`sync_bpm` must take the runtime-step path
+  // (pushed Step, awaited by AudioInterpreter `case 'sync'` when the sub-program
+  // is walked) — exactly what the line-1436 comment intends. Hoisted bare-loops
+  // inside with_fx are unaffected: transpileWithFxLoopBody builds its OWN async
+  // live_loop ctx (the hoisted loop IS async).
   const bodyCtx: TranspileContext = ctx.insideLoop
-    ? { ...ctx, insideLoop: true }
-    : { ...ctx }  // keep insideLoop false — live_loops inside will set their own
+    ? { ...ctx, insideLoop: true, asyncBody: false }
+    : { ...ctx, asyncBody: false }  // keep insideLoop false — live_loops inside will set their own
   // #426/SP111: a bare `loop do … end` directly inside with_fx must be hoisted
   // to an auto-named live_loop, exactly as top-level (lines ~1116) and in_thread
   // (transpileInThread) loops are (SV16). Building it inline emits a synchronous

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -2207,4 +2207,41 @@ end`)
       expect(r.code).toContain('live_loop("__loop_0"')
     })
   })
+
+  // #461 (found by the #459 differential-coverage matrix): a `sync` inside a
+  // with_fx body was emitted as `await __b.sync(...)` inside the NON-async with_fx
+  // callback → "await is only valid in async functions" → invalid JS → the WHOLE
+  // program rendered nothing. The with_fx body must take the runtime-step sync
+  // path (no await; AudioInterpreter `case 'sync'` awaits it when walking the
+  // sub-program), so the callback can stay non-async.
+  describe('#461: sync inside with_fx must not emit await in the non-async callback', () => {
+    it('transpiles with_fx { sync } to valid JS (runtime-step sync, no await)', () => {
+      const r = treeSitterTranspile(`with_fx :reverb do\n  sync :tick\n  play 60\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toContain('__b.sync("tick")')
+      expect(r.code).not.toContain('await __b.sync')
+    })
+
+    it('transpiles with_fx { N.times { sync } } to valid JS', () => {
+      const r = treeSitterTranspile(
+        `with_fx :reverb do\n  8.times do\n    sync :tick\n    synth :saw, note: 60\n  end\nend`,
+      )
+      expect(r.ok).toBe(true)
+      expect(r.code).not.toContain('await __b.sync')
+    })
+
+    it('the full #461 reproducer (driver + with_fx sync loop) transpiles cleanly', () => {
+      const r = treeSitterTranspile(
+        `live_loop :driver do\n  cue :tick\n  sleep 0.5\nend\n\nwith_fx :reverb do\n  8.times do\n    sync :tick\n    synth :saw, note: 60\n  end\nend`,
+      )
+      expect(r.ok).toBe(true)
+    })
+
+    it('a top-level live_loop with sync still emits the build-time await (unchanged)', () => {
+      // regression guard: the fix must NOT touch the async-live_loop sync path.
+      const r = treeSitterTranspile(`live_loop :x do\n  sync :tick\n  play 60\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toContain('await __b.sync("tick")')
+    })
+  })
 })


### PR DESCRIPTION
Closes #461. Found by the #459 differential-coverage matrix (cell `with_fx__sync__top_level`).

## Problem
`with_fx :reverb do sync :tick; ... end` at top level made the **whole program render nothing** (not even preceding statements). The transpiler emits the with_fx callback as a non-async arrow `(__b) => {…}`, but its body ctx inherited `asyncBody: true` from the enclosing `__run_once`, so a `sync` in the body emitted `await __b.sync(...)` inside a non-async function → `"await is only valid in async functions"` → invalid JS → `new Function` throws → silent total failure.

(My original issue hypothesis — a runtime build deadlock — was **wrong**; dumping the transpiler output showed a transpile failure. Corrected on the issue.)

## Fix
`transpileWithBlock` forces `asyncBody: false` in the with_fx body ctx. The callback stays non-async; `sync`/`sync_bpm` take the runtime-step path (pushed Step, awaited by `AudioInterpreter` `case 'sync'` when the sub-program is walked) — exactly what the existing line-1436 comment intended. Same class as SP119 facet-(a), here on the with_fx callback. Hoisted bare-loops inside with_fx are unaffected.

## Test plan
- `npx vitest run` → 1131/1131; `npx tsc --noEmit` → clean.
- +4 regression tests (with_fx{sync}, with_fx{N.times{sync}}, full reproducer, **+ a guard that the async-live_loop sync path still emits `await`**).
- Level-3 event-parity vs desktop: web went from **WEB-EMPTY (crash)** → **STRUCTURE-MATCH** (8 saws + bell + reverb == desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)