### PR TITLE
fix(transpiler): re-land #460 nested-loop sequencing (data + timing) onto main

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -2190,6 +2190,33 @@ function isVtimeAdvancing(child: any): boolean {
   return /\b(?:sleep|sync|sync_bpm)\b/.test(child?.text ?? '')
 }
 
+/** #460: the LHS name of a bare `lhs = rhs` assignment (identifier only), else null.
+ *  Operator-assignments (`x += 1`) and destructuring are NOT lifted — they depend
+ *  on a prior value, so they must stay where they are. */
+function bareAssignTarget(child: any): string | null {
+  if (child?.type !== 'assignment') return null
+  const lhs = child.namedChildren?.[0]
+  return lhs?.type === 'identifier' ? lhs.text : null
+}
+
+/** #460: collect every identifier READ anywhere in a subtree (over-inclusive —
+ *  used only to intersect with setup assignment LHS names, so extra names are
+ *  harmless). */
+function collectReadIdentifiers(node: any, out: Set<string>): void {
+  if (!node) return
+  if (node.type === 'identifier' && typeof node.text === 'string') out.add(node.text)
+  for (const c of node.namedChildren ?? []) collectReadIdentifiers(c, out)
+}
+
+/** #460: is this child a `live_loop … do … end` call (a nested registered loop
+ *  that gets its OWN scope, so a sibling assignment it reads must be lifted)? */
+function isLiveLoopNode(child: any): boolean {
+  const m = (child?.type === 'call' || child?.type === 'method_call')
+    ? (child.childForFieldName?.('method')?.text ?? child.namedChildren?.[0]?.text)
+    : null
+  return m === 'live_loop' && (child.namedChildren ?? []).some((c: any) => c.type === 'do_block' || c.type === 'block')
+}
+
 function transpileInThread(
   argsNode: any, blockNode: any, ctx: TranspileContext
 ): string {
@@ -2266,9 +2293,93 @@ function transpileInThread(
   }
 
   if (loopChildren.length === 0) {
-    // No nested loop → original codepath.
-    const bodyCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
-    const bodyStr = transpileBlockBody(blockNode, bodyCtx)
+    // No bare `loop` to hoist. Two facets of the SAME fork/scope split (#460)
+    // hit a NESTED `live_loop` that stays inline in the in_thread body:
+    //
+    //   • DATA (SP121): the live_loop keeps its OWN scope, so a preceding bare
+    //     assignment it reads (`n = 7; live_loop :x { play 60 + n }`) is invisible
+    //     to it (scope-isolation, Sandbox.ts:109-128). Lift those assignments to
+    //     the top-level shared scope; the live_loop stays inline.
+    //   • TIMING (#460): the inline live_loop is emitted as a BARE GLOBAL
+    //     `live_loop()` call (transpileLiveLoop never prefixes — SV16), so it
+    //     registers at launch (vt 0) during the in_thread builderFn, IGNORING a
+    //     preceding `sleep`/`sync` in the body (matrix
+    //     live_loop__preceding_sleep__nested: web saw@0.03s vs desktop@4s). Gate
+    //     its first iteration on a synthetic cue (`__itg_N`) the in_thread fires
+    //     AFTER the vtime-advancing setup, so it forks at the enclosing cursor's
+    //     vtime. Mirrors the #457 bare-loop `__itg` gate, but the live_loop stays
+    //     INLINE — it is NOT hoisted (hoisting a nested live_loop out of the
+    //     in_thread breaks SP72's use_synth-into-nested-live_loop propagation, the
+    //     T-G test). The engine's wrappedLiveLoop already honours `__startGate`
+    //     (#448) regardless of nesting depth → ZERO engine change. The cue is a
+    //     deferred runtime step fired at vt T while the waiter was armed at launch
+    //     → no register/fire race (SK21).
+    //
+    // Both are root-only (a nested in_thread keeps the un-lifted, un-gated path —
+    // the cue machinery is top-level, SP118).
+    const canLift0 = !ctx.insideLoop
+    const liveLoops = canLift0 ? bodyChildren.filter(isLiveLoopNode) : []
+    let lifted: any[] = []
+    if (liveLoops.length > 0) {
+      const readNames = new Set<string>()
+      for (const ll of liveLoops) collectReadIdentifiers(ll, readNames)
+      lifted = bodyChildren.filter((c: any) => {
+        const t = bareAssignTarget(c)
+        return t !== null && readNames.has(t)
+      })
+    }
+    const hasLift = lifted.length > 0
+    const remaining = hasLift ? bodyChildren.filter((c: any) => !lifted.includes(c)) : bodyChildren
+
+    // Timing gate needed? — a nested live_loop preceded (in source order) by a
+    // vtime-advancing statement. Pre-scanned so the plain case keeps the original
+    // transpileBlockBody codepath byte-for-byte (no regression to existing tests).
+    const canGate0 = !ctx.insideLoop
+    let needsGate = false
+    if (canGate0) {
+      let seen = false
+      for (const c of remaining) {
+        if (seen && isLiveLoopNode(c)) { needsGate = true; break }
+        if (isVtimeAdvancing(c)) seen = true
+      }
+    }
+
+    if (!hasLift && !needsGate) {
+      // No nested loop to lift, nothing to gate → original codepath, unchanged.
+      const bodyCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
+      const bodyStr = transpileBlockBody(blockNode, bodyCtx)
+      return `${prefix}in_thread(${itOpts}(__b) => {\n${bodyStr}\n${ctx.indent}})`
+    }
+
+    // Lift + gate path: build the in_thread body child-by-child so we can (a) omit
+    // the lifted assignments and (b) inject a `__b.cue("__itg_N")` right before any
+    // gated live_loop and tag that live_loop's registration `{ __startGate }`.
+    const bodyLines: string[] = []
+    let seenVtime = false
+    for (const c of remaining) {
+      if (canGate0 && seenVtime && isLiveLoopNode(c)) {
+        const gate = `__itg_${(ctx.inthreadGateCounter ??= { n: 0 }).n++}`
+        bodyLines.push(`  __b.cue(${JSON.stringify(gate)})`)
+        const gateCtx: TranspileContext = { ...ctxNoGate, insideLoop: true, startGate: gate }
+        const s = transpileNode(c, gateCtx)
+        if (s.trim()) bodyLines.push('  ' + s)
+      } else {
+        const bodyCtx: TranspileContext = { ...ctxNoGate, insideLoop: true }
+        const s = transpileNode(c, bodyCtx)
+        if (s.trim()) bodyLines.push('  ' + s)
+        if (isVtimeAdvancing(c)) seenVtime = true
+      }
+    }
+    const bodyStr = bodyLines.join('\n')
+
+    if (hasLift) {
+      const liftCtx: TranspileContext = { ...ctxNoGate, insideLoop: false }
+      const liftStr = lifted
+        .map((c: any) => transpileNode(c, liftCtx))
+        .filter((s: string) => s.trim())
+        .join('\n')
+      return `${liftStr}\n${prefix}in_thread(${itOpts}(__b) => {\n${bodyStr}\n${ctx.indent}})`
+    }
     return `${prefix}in_thread(${itOpts}(__b) => {\n${bodyStr}\n${ctx.indent}})`
   }
 
@@ -2298,7 +2409,44 @@ function transpileInThread(
   //     ONCE → keep them in a setup in_thread (folding a `play` into the loop
   //     would re-fire it every iteration).
   const settingChildren = setupChildren.filter(isFlowSensitiveSetting)
-  const actionChildren = setupChildren.filter((c) => !isFlowSensitiveSetting(c))
+  const nonSettingChildren = setupChildren.filter((c) => !isFlowSensitiveSetting(c))
+
+  // #460 (data facet): a bare `loop` is hoisted OUT to a sibling top-level
+  // live_loop, so a pre-loop assignment the loop body reads (`n = 7; loop { play
+  // 60 + n }`) is left behind INSIDE the in_thread arrow. Under the Sandbox's
+  // per-scope proxy (Sandbox.ts:109-128), a bare assignment in a thread/loop
+  // scope writes to that scope's ISOLATED locals — invisible to the sibling
+  // loop's scope → the loop reads `undefined` every iteration → `60 + undefined`
+  // = NaN → SV51 refuses dispatch → the whole loop is silent (matrix
+  // bare_loop__var_read__nested: web 0, desktop 19). Fix: lift such assignments
+  // to the TOP-LEVEL shared scope (emitted before the in_thread, where the proxy
+  // routes a bare assign to the shared target — the same exception __run_once
+  // relies on, SV21), so the hoisted loop reads the value. Free-variable-gated:
+  // only assignments whose LHS the loop actually reads are lifted (minimal). Only
+  // at the program root (canLift); a nested in_thread keeps the old behaviour.
+  const canLift = !ctx.insideLoop
+  const loopReadNames = new Set<string>()
+  if (canLift) for (const ln of loopChildren) collectReadIdentifiers(ln, loopReadNames)
+  const liftedAssignChildren = canLift
+    ? nonSettingChildren.filter((c) => {
+        const t = bareAssignTarget(c)
+        return t !== null && loopReadNames.has(t)
+      })
+    : []
+  const actionChildren = nonSettingChildren.filter((c) => !liftedAssignChildren.includes(c))
+
+  // #460 (data facet): emit the lifted setup assignments at TOP-LEVEL shared
+  // scope, BEFORE the in_thread + hoisted loops. As bare top-level statements
+  // they run during sandbox.execute with no active loop scope → the proxy routes
+  // them to the shared target (Sandbox.ts:130) → the hoisted sibling loop reads
+  // the value. insideLoop:false so they emit unprefixed (not __b.-scoped).
+  if (liftedAssignChildren.length > 0) {
+    const liftCtx: TranspileContext = { ...ctxNoGate, insideLoop: false }
+    for (const c of liftedAssignChildren) {
+      const s = transpileNode(c, liftCtx)
+      if (s.trim()) parts.push(s)
+    }
+  }
 
   // Settings folded into each hoisted loop body. asyncBody so any `await` is legal.
   const settingCtx: TranspileContext = { ...ctxNoGate, insideLoop: true, asyncBody: true }

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -2244,4 +2244,108 @@ end`)
       expect(r.code).toContain('await __b.sync("tick")')
     })
   })
+
+  // #460 (found by the #459 matrix, data facet): a loop nested in an in_thread
+  // reading a pre-loop assignment got `undefined` forever (the Sandbox proxy
+  // isolates a thread-scope bare assignment from the loop's own scope) → NaN note
+  // → SV51 refuses → silent. Fix: lift such assignments to the top-level shared
+  // scope so both scopes resolve them through the proxy's shared target.
+  describe('#460: in_thread setup var read by a nested loop is lifted to shared scope', () => {
+    const beforeIdx = (code: string, a: string, b: string) => {
+      const ia = code.indexOf(a), ib = code.indexOf(b)
+      return ia !== -1 && ib !== -1 && ia < ib
+    }
+
+    it('hoisted bare loop: the read assignment is lifted ABOVE the sibling live_loop', () => {
+      const r = treeSitterTranspile(`in_thread do\n  n = 7\n  loop do\n    play 60 + n\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toMatch(/(^|\n)n = 7/)
+      expect(beforeIdx(r.code, 'n = 7', 'live_loop("__inthread_loop_0"')).toBe(true)
+      expect(r.code).toContain('__spAdd(60, n)')
+    })
+
+    it('inline nested live_loop: the read assignment is lifted to top level', () => {
+      const r = treeSitterTranspile(`in_thread do\n  n = 7\n  live_loop :test do\n    play 60 + n\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toMatch(/(^|\n)n = 7/)
+      expect(beforeIdx(r.code, 'n = 7', 'live_loop("test"')).toBe(true)
+    })
+
+    it('an assignment the loop does NOT read is left inside the in_thread (minimal lift)', () => {
+      const r = treeSitterTranspile(`in_thread do\n  i = 0\n  loop do\n    play 60\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toMatch(/in_thread\([\s\S]*i = 0/)
+    })
+
+    it('a play action in the setup stays in the in_thread; only the read var lifts', () => {
+      const r = treeSitterTranspile(`in_thread do\n  n = 7\n  play 50\n  loop do\n    play 60 + n\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(beforeIdx(r.code, 'n = 7', 'in_thread(')).toBe(true)
+      expect(r.code).toMatch(/in_thread\([\s\S]*play\(50/)
+    })
+  })
+
+  // #460 (timing facet, found by the #459 matrix cell
+  // live_loop__preceding_sleep__nested): an inline nested live_loop emitted as a
+  // bare global live_loop() registers at launch (vt 0), ignoring a preceding
+  // `sleep`/`sync` in the in_thread body (web saw@0.03s vs desktop@4s). Fix: gate
+  // it on a synthetic `__itg_N` cue the in_thread fires AFTER the vtime-advancing
+  // setup. NOT hoisting — the live_loop stays inline (SP72 propagation), the
+  // engine's wrappedLiveLoop honours `__startGate` (#448).
+  describe('#460: nested live_loop after a vtime-advancing setup is start-gated in place', () => {
+    const beforeIdx = (code: string, a: string, b: string) => {
+      const ia = code.indexOf(a), ib = code.indexOf(b)
+      return ia !== -1 && ib !== -1 && ia < ib
+    }
+
+    it('sleep before nested live_loop → cue injected + __startGate on the inline live_loop', () => {
+      const r = treeSitterTranspile(`in_thread do\n  sleep 4\n  live_loop :x do\n    play 60\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      // The live_loop stays INLINE inside the in_thread (not hoisted to a sibling).
+      expect(r.code).toMatch(/in_thread\([\s\S]*live_loop\("x",\s*\{__startGate:\s*"__itg_0"/)
+      // The cue is fired AFTER the sleep and BEFORE the live_loop registers.
+      expect(beforeIdx(r.code, '__b.sleep(4)', '__b.cue("__itg_0")')).toBe(true)
+      expect(beforeIdx(r.code, '__b.cue("__itg_0")', 'live_loop("x"')).toBe(true)
+    })
+
+    it('sync before nested live_loop → also gated (sync is vtime-advancing)', () => {
+      const r = treeSitterTranspile(`in_thread do\n  sync :go\n  live_loop :x do\n    play 60\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).toMatch(/live_loop\("x",\s*\{__startGate:\s*"__itg_0"/)
+    })
+
+    it('nested live_loop WITHOUT a preceding vtime statement is NOT gated', () => {
+      const r = treeSitterTranspile(`in_thread do\n  live_loop :x do\n    play 60\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      expect(r.code).not.toContain('__startGate')
+      expect(r.code).not.toContain('__itg_0')
+    })
+
+    it('use_synth (non-vtime) before sleep + nested live_loop: gated, use_synth kept inline before the loop (SP72)', () => {
+      const r = treeSitterTranspile(`in_thread do\n  use_synth :prophet\n  sleep 4\n  live_loop :probe do\n    play 60\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      // use_synth stays inline in the in_thread (parentBuilder propagation) AND
+      // precedes the still-inline live_loop registration; the loop is gated.
+      expect(r.code).toMatch(/in_thread\([\s\S]*use_synth\("prophet"\)[\s\S]*live_loop\("probe",\s*\{__startGate/)
+      expect(beforeIdx(r.code, 'use_synth("prophet")', 'live_loop("probe"')).toBe(true)
+    })
+
+    it('combined data+timing: var-read lifts to top level AND the live_loop is gated', () => {
+      const r = treeSitterTranspile(`in_thread do\n  n = 7\n  sleep 4\n  live_loop :x do\n    play 60 + n\n    sleep 0.5\n  end\nend`)
+      expect(r.ok).toBe(true)
+      // data facet: n lifted above the in_thread
+      expect(beforeIdx(r.code, 'n = 7', 'in_thread(')).toBe(true)
+      // timing facet: gated in place
+      expect(r.code).toMatch(/live_loop\("x",\s*\{__startGate:\s*"__itg_0"/)
+      expect(r.code).toContain('__spAdd(60, n)')
+    })
+
+    it('a nested in_thread (not at program root) does NOT gate its inner live_loop', () => {
+      const r = treeSitterTranspile(`in_thread do\n  in_thread do\n    sleep 4\n    live_loop :x do\n      play 60\n      sleep 0.5\n    end\n  end\nend`)
+      expect(r.ok).toBe(true)
+      // The cue/gate machinery is top-level only (SP118); the inner in_thread
+      // keeps the un-gated path.
+      expect(r.code).not.toContain('__startGate')
+    })
+  })
 })


### PR DESCRIPTION
## Why a second PR for #460

PR #464 was stacked on #463's branch (base retargeted to `fix/461-withfx-sync-async`). During the rapid 3-PR merge burst (#462→#463→#464 within ~30s), GitHub's base auto-retarget didn't fire in time, so **#464 merged into the `fix/461` branch instead of main** — the #460 fix never reached main. #460 correctly stayed OPEN.

This PR cherry-picks the squashed #460 change (`9cd68a9`) onto current main (`b10a4dc`, which has #461 + #462). Clean apply — the #460 diff touches `transpileInThread` (the #461 fix touched `transpileWithBlock`).

## What it fixes — both facets of #460

**DATA (SP121):** a loop nested in an `in_thread` reading a setup var rendered nothing — scope isolation (Sandbox per-scope proxy), not a vt0 race. Lifts loop-read setup assignments to the shared scope.

**TIMING:** an inline nested `live_loop` after a `sleep`/`sync` forked at vt0 (web@0.03s vs desktop@4s) — it's emitted as a bare global `live_loop()` that registers at launch. Gated in place on a synthetic `__itg` cue fired after the setup + `{ __startGate }` on the still-inline live_loop; the engine's `wrappedLiveLoop` already awaits `__startGate` (#448) → **zero engine change**. NOT hoisting (hoisting breaks SP72's use_synth propagation — the T-G test).

## Verification
- **Level-3** (event-parity, SP122 vt-0 anchor): loop's first beep **web@0.03s → web@4.0s == desktop@4.003s** (STRUCTURE-MATCH). Both #460 data cells green.
- +10 regression tests; full suite **1145/1145**; tsc clean; T-G + LiveLoopDelay green.

Closes #460.