### PR TITLE
fix(tools): exclude FX nodes from event-parity rebase anchor (#466 part 1 — SP122 residual)

### DIFF
--- a/tools/__tests__/event-parity-parsers.test.ts
+++ b/tools/__tests__/event-parity-parsers.test.ts
@@ -3,8 +3,8 @@
  * Pure functions only — no Sonic Pi / browser needed.
  */
 import { describe, it, expect } from 'vitest'
-import { parseDumpOsc, type OscEvent } from '../lib/desktop-events.ts'
-import { parseTraceLine } from '../lib/web-events.ts'
+import { parseDumpOsc, isFxEvent, type OscEvent } from '../lib/desktop-events.ts'
+import { parseTraceLine, rebase } from '../lib/web-events.ts'
 import { buildReport } from '../event-parity.ts'
 
 describe('parseDumpOsc (desktop scsynth dumpOSC stream)', () => {
@@ -84,6 +84,43 @@ describe('parseTraceLine (web formatOscTrace stream)', () => {
     expect(parseTraceLine('[t:2.0000] /n_set 1056 {amp: 0}')!.addr).toBe('/n_set')
     expect(parseTraceLine('how does it feel?')).toBeNull()
     expect(parseTraceLine('[t:0.0] /run-code 5')).toBeNull()
+  })
+})
+
+// --- rebase: FX nodes must not anchor the timeline (issue #466 / SP122) -------
+describe('web rebase excludes FX nodes from the anchor', () => {
+  const ev = (synthdef: string, tRel: number): OscEvent => ({ addr: '/s_new', synthdef, params: {}, tRel, raw: '' })
+
+  it('anchors on the earliest NON-FX event, not an earlier FX node', () => {
+    // The #466 scenario: web emits the with_fx FX node at tRel=0 (registration),
+    // the vt-0 marker bell at 2.935, and the first saw at 6.935. Anchoring on the
+    // FX node (old behaviour) leaves the bell at 2.935 / saw at 6.935 → a false
+    // ~2.9s onset gap vs desktop (which anchors on the bell). Excluding FX from
+    // the anchor puts the bell at 0 and the saw at 4.0, matching desktop.
+    const out = rebase([
+      ev('sonic-pi-fx_reverb', 0),
+      ev('sonic-pi-pretty_bell', 2.935),
+      ev('sonic-pi-saw', 6.935),
+    ])
+    const bell = out.find((e) => e.synthdef === 'sonic-pi-pretty_bell')!
+    const saw = out.find((e) => e.synthdef === 'sonic-pi-saw')!
+    const fx = out.find((e) => e.synthdef === 'sonic-pi-fx_reverb')!
+    expect(bell.tRel).toBe(0) // marker is the shared zero
+    expect(saw.tRel).toBeCloseTo(4.0, 3) // == desktop, no false gap
+    expect(fx.tRel).toBeCloseTo(-2.935, 3) // FX shifted with everything (excluded from compare anyway)
+  })
+
+  it('falls back to all scheduled events when there are no non-FX events', () => {
+    const out = rebase([ev('sonic-pi-fx_reverb', 5), ev('sonic-pi-fx_echo', 7)])
+    expect(out.find((e) => e.synthdef === 'sonic-pi-fx_reverb')!.tRel).toBe(0)
+    expect(out.find((e) => e.synthdef === 'sonic-pi-fx_echo')!.tRel).toBeCloseTo(2, 3)
+  })
+
+  it('matches isFxEvent on both naming conventions', () => {
+    expect(isFxEvent({ synthdef: 'sonic-pi-fx_reverb' })).toBe(true)
+    expect(isFxEvent({ synthdef: 'sonic_pi_fx_echo' })).toBe(true)
+    expect(isFxEvent({ synthdef: 'sonic-pi-beep' })).toBe(false)
+    expect(isFxEvent({ synthdef: undefined })).toBe(false)
   })
 })
 

--- a/tools/lib/desktop-events.ts
+++ b/tools/lib/desktop-events.ts
@@ -116,6 +116,20 @@ export interface OscEvent {
   raw: string
 }
 
+/**
+ * Is this event an FX node (with_fx synthdef)? Mirrors event-parity's `classify`
+ * fx test. Used to EXCLUDE FX nodes from the rebase anchor: with_fx creates its
+ * FX node at registration time, which on web is tRel=0 even when the with_fx sits
+ * after a sleep. Anchoring the rebase on it shifts the whole web timeline and
+ * manufactures a false onset gap vs desktop (where the FX node is immediate,
+ * tRel=null, already excluded). Anchoring on non-FX events (voices + the vt-0
+ * marker) keeps both sides on the same zero. (SP122 residual, issue #466.)
+ */
+export function isFxEvent(e: { synthdef?: string }): boolean {
+  const s = e.synthdef
+  return !!s && (s.includes('-fx_') || s.includes('_fx_'))
+}
+
 /** NTP 64-bit fixed-point → seconds (high 32 = secs since 1900, low 32 = fraction). */
 function ntpToSeconds(ntpStr: string): number {
   const v = BigInt(ntpStr)
@@ -201,7 +215,13 @@ export function parseDumpOsc(text: string): OscEvent[] {
   // timeline (the absolute NTP epoch is meaningless for diff). Anchor on the
   // minimum, not the first-in-order — events are not strictly time-sorted, and a
   // first-in-order anchor produces spurious negative onsets.
-  const scheduled = events.filter((e) => e.tRel !== null).map((e) => e.tRel as number)
+  // EXCLUDE FX nodes from the anchor (issue #466): see isFxEvent. Desktop FX
+  // nodes are usually already immediate (tRel=null) and excluded, but anchoring
+  // on non-FX symmetrically with the web side guarantees both share the same
+  // zero. Fall back to all scheduled events if there are no non-FX ones.
+  const nonFx = events.filter((e) => e.tRel !== null && !isFxEvent(e)).map((e) => e.tRel as number)
+  const allScheduled = events.filter((e) => e.tRel !== null).map((e) => e.tRel as number)
+  const scheduled = nonFx.length > 0 ? nonFx : allScheduled
   if (scheduled.length > 0) {
     const t0 = Math.min(...scheduled)
     for (const e of events) {

--- a/tools/lib/web-events.ts
+++ b/tools/lib/web-events.ts
@@ -16,7 +16,7 @@
  */
 
 import { chromium, type Browser } from '@playwright/test'
-import type { OscEvent } from './desktop-events.ts'
+import { isFxEvent, type OscEvent } from './desktop-events.ts'
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -74,11 +74,18 @@ function parseParams(body: string): Record<string, number | string> {
   return params
 }
 
-function rebase(events: OscEvent[]): OscEvent[] {
+export function rebase(events: OscEvent[]): OscEvent[] {
   // Anchor on the EARLIEST event (minimum tRel), not the first-in-order — the
   // trace stream is emission-ordered, not strictly time-sorted, so a
   // first-in-order anchor produces spurious negative onsets.
-  const ts = events.filter((e) => e.tRel !== null).map((e) => e.tRel as number)
+  // EXCLUDE FX nodes from the anchor (issue #466, SP122 residual): with_fx
+  // creates its FX node at tRel=0 on web even when the with_fx sits after a
+  // sleep, so anchoring on it shifts the whole timeline and manufactures a false
+  // onset gap vs desktop (where the FX node is immediate, tRel=null). Anchor on
+  // non-FX events (voices + the vt-0 marker). Fall back to all if FX-only.
+  const nonFx = events.filter((e) => e.tRel !== null && !isFxEvent(e)).map((e) => e.tRel as number)
+  const all = events.filter((e) => e.tRel !== null).map((e) => e.tRel as number)
+  const ts = nonFx.length > 0 ? nonFx : all
   if (ts.length === 0) return events
   const t0 = Math.min(...ts)
   for (const e of events) {


### PR DESCRIPTION
## What & why

The post-#460 full diff-matrix run was **52/52 authoritative-match** (driver verdicts), but the **viewer** (`build-diff-matrix.ts deriveStatus`) false-flagged `with_fx__preceding_sleep__top_level` as TIMING.

**Root (raw capture):** both `rebase()` functions anchor the timeline on `min(tRel)` over all events. `with_fx` creates its FX node at registration — on web that's `tRel=0` even when the `with_fx` sits after a `sleep` — so web rebased onto the FX node while desktop excluded it (FX is immediate, `tRel=null`). The whole web timeline shifted by the bell→fx gap (~2-3s, capture-variance-sensitive), manufacturing a false onset gap that tripped the 3s `deriveStatus` threshold. The vt-0 `:pretty_bell` marker (SP122) doesn't help when the FX node is *earlier than the marker* on web.

## Fix

Anchor the rebase on the earliest **non-FX** event on both sides (`isFxEvent` helper, mirrors event-parity's `classify`). FX nodes are excluded from the compare anyway; excluding them from the anchor too keeps both engines on the same zero (voices + the marker). Falls back to all scheduled events if a reproducer has only FX events. **Engine unchanged — oracle/measurement fix only.**

## Verification

- `with_fx__preceding_sleep__top_level` event-parity: **saw web@4s == desktop@4s** (was web@6.9s) → `deriveStatus` now classifies it `match`.
- +3 regression tests (rebase FX-anchor exclusion + `isFxEvent`); full suite **1150/1150**; tsc clean.

## Scope

Part 1 of #466 (the `deriveStatus` harden). **Part 2** (refresh the committed `test_results/diff-matrix*.{json,html}` — currently the stale pre-fix snapshot) follows once the #460 fix (#465) is also on main, so a full re-run shows 52/52 clean in the viewer too.

Part of #466.