### PR TITLE
🚦 feat(gate): differential-matrix parity as a second launch-gate criterion (#469)

### DIFF
--- a/tools/build-aggregate-index.ts
+++ b/tools/build-aggregate-index.ts
@@ -58,6 +58,11 @@ interface ConsistencyManifest {
 }
 interface GateManifest {
   denominator: number; passCount: number; pct: number; thresholdPct: number; passed: boolean
+  // passed is the OVERALL verdict (roster AND differential matrix, #469). roster.passed
+  // is the roster-only verdict; differentialMatrix is the second criterion (optional —
+  // absent in pre-#469 manifests).
+  roster?: { passed: boolean }
+  differentialMatrix?: { present: boolean; green: boolean | null; counts?: { match: number; active: number }; note: string }
   rows: { example: string; gateVerdict: string; pass: boolean; gradedVia: string; detail: string }[]
   exclusions?: { example: string; reason: string }[]
 }
@@ -174,16 +179,26 @@ function gateHero(g: GateManifest | null): string {
   }
   const verdict = g.passed ? 'PASS' : 'NOT MET'
   const cls = g.passed ? 'pass' : 'fail'
+  // Roster badge reflects the roster criterion specifically (not the overall verdict),
+  // so its pct and PASS/NOT-MET stay self-consistent even when the matrix blocks (#469).
+  const rosterPassed = g.roster?.passed ?? g.passed
+  const rosterCls = rosterPassed ? 'pass' : 'fail'
   const rows = g.rows.map(r =>
     `<div class="grow ${r.pass ? 'p' : 'f'}"><span>${r.pass ? '✓' : '✗'}</span><code>${esc(r.example)}</code><em>${esc(r.gateVerdict)} · ${esc(r.gradedVia)}</em></div>`
   ).join('')
   const excl = g.exclusions?.length
     ? `<div class="gate-excl">excluded: ${g.exclusions.map(e => esc(e.example)).join(', ')} (PRNG non-goal SV49)</div>` : ''
+  // Second criterion (#469): differential matrix. Optional — absent in pre-#469 manifests.
+  const dm = g.differentialMatrix
+  const matrixBadge = dm
+    ? `<div class="gate-badge ${dm.green === null ? 'warn' : dm.green ? 'pass' : 'fail'}">matrix ${dm.green === null ? '⚠ absent' : dm.green ? `✓ ${dm.counts ? `${dm.counts.match}/${dm.counts.active}` : 'green'}` : '✗ not green'}</div>`
+    : ''
   return `<a class="gate-hero ${cls}" href="launch-gate.html">
     <div class="gate-left">
-      <div class="gate-verdict">🚦 Tier-1 launch gate</div>
+      <div class="gate-verdict">🚦 Tier-1 launch gate — ${verdict}</div>
       <div class="gate-big"><b>${g.passCount}/${g.denominator}</b> <span>= ${g.pct}%</span></div>
-      <div class="gate-badge ${cls}">${verdict} <small>(≥ ${g.thresholdPct}%)</small></div>
+      <div class="gate-badge ${rosterCls}">roster ${rosterPassed ? 'PASS' : 'NOT MET'} <small>(≥ ${g.thresholdPct}%)</small></div>
+      ${matrixBadge}
       ${excl}
     </div>
     <div class="gate-rows">${rows}</div>
@@ -241,6 +256,7 @@ const html = `<!doctype html>
     font-weight:700;font-size:14px}
   .gate-badge.pass{background:#243218;color:var(--pass)}
   .gate-badge.fail{background:#321820;color:var(--fail)}
+  .gate-badge.warn{background:#322a18;color:#fbbf24}
   .gate-badge small{font-weight:400;color:var(--text-mute);font-size:11px}
   .gate-excl{font-size:11px;color:var(--text-mute);font-family:var(--mono);margin-top:2px}
   .gate-rows{flex:1;display:grid;grid-template-columns:1fr 1fr;gap:4px 18px;align-content:center}

--- a/tools/gate-report.ts
+++ b/tools/gate-report.ts
@@ -15,16 +15,25 @@
  * limitations (NOT counted as pass). PRNG rows are excluded from the denominator
  * (SV49 non-goal).
  *
+ * SECOND CRITERION — differential matrix (#469): the gate also reads
+ * test_results/diff-matrix.json (tools/diff-matrix.ts → construct×context×position
+ * event-parity vs desktop, dharana §36). It is GREEN iff every active cell is a
+ * structure-match (match === active, and diverge/timing/empty/error/pending all 0).
+ * When present and not-green it BLOCKS the overall gate (listing the diverged
+ * cells); when absent it WARNS only (the matrix needs desktop SP + scsynth and is
+ * not a CI artifact). Overall = rosterPassed && (matrix absent || matrix green).
+ *
  * Usage: npx tsx tools/gate-report.ts
- *   Writes test_results/launch-gate.{json,md}.
+ *   Writes test_results/launch-gate.{json,md,html}.
  */
-import { readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { navBlock } from './lib/dashboard-nav.ts'
 
 const ROOT = join(import.meta.dirname, '..')
 const SWEEP = join(ROOT, 'test_results/examples-sweep.json')
 const MANIFEST = join(ROOT, 'tools/gate-reproducers/manifest.json')
+const DIFF_MATRIX = join(ROOT, 'test_results/diff-matrix.json')
 
 interface SweepRow {
   example: string; verdict: string; prng: boolean; heavy: boolean
@@ -73,12 +82,47 @@ const gateRows: GateRow[] = denom.map(r => {
 const passCount = gateRows.filter(g => g.pass).length
 const total = gateRows.length
 const pct = total ? (passCount / total) * 100 : 0
-const passed = pct >= manifest.gateThresholdPct
+const rosterPassed = pct >= manifest.gateThresholdPct
+
+// ---- Second criterion: differential matrix (#469 / dharana §36) ----
+interface MatrixCounts {
+  match: number; diverge: number; timing: number; webEmpty: number
+  desktopEmpty: number; error: number; skipped: number; pending: number
+  active: number; total: number
+}
+interface MatrixCriterion {
+  present: boolean; green: boolean | null; generatedAt?: string; window?: number
+  counts?: MatrixCounts; diverged?: string[]; note: string
+}
+function readMatrix(): MatrixCriterion {
+  if (!existsSync(DIFF_MATRIX)) {
+    return { present: false, green: null, note: 'diff-matrix.json absent — run `npx tsx tools/diff-matrix.ts --fresh && npx tsx tools/build-diff-matrix.ts` (needs desktop SP + scsynth). Not blocking.' }
+  }
+  const m = JSON.parse(readFileSync(DIFF_MATRIX, 'utf8'))
+  const c: MatrixCounts = m.counts
+  const offenders = c.diverge + c.timing + c.webEmpty + c.desktopEmpty + c.error + c.pending
+  const green = c.match === c.active && offenders === 0
+  const diverged: string[] = (m.diverged ?? []).map((d: any) => typeof d === 'string' ? d : (d.cell ?? d.id ?? JSON.stringify(d)))
+  return {
+    present: true, green, generatedAt: m.generatedAt, window: m.window, counts: c, diverged,
+    note: green
+      ? `${c.match}/${c.active} cells structure-match · 0 diverge/timing/empty/error.`
+      : `NOT green — match ${c.match}/${c.active}, diverge ${c.diverge}, timing ${c.timing}, web-empty ${c.webEmpty}, desktop-empty ${c.desktopEmpty}, error ${c.error}, pending ${c.pending}.`,
+  }
+}
+const matrix = readMatrix()
+
+// Overall: roster threshold AND (matrix green when present). Absent matrix warns, does not block.
+const passed = rosterPassed && (matrix.green !== false)
 
 // ---- write JSON ----
 const out = {
-  generatedFrom: 'examples-sweep.json + tools/gate-reproducers/manifest.json',
-  denominator: total, passCount, pct: +pct.toFixed(1), thresholdPct: manifest.gateThresholdPct, passed,
+  generatedFrom: 'examples-sweep.json + tools/gate-reproducers/manifest.json + test_results/diff-matrix.json',
+  passed,
+  roster: { denominator: total, passCount, pct: +pct.toFixed(1), thresholdPct: manifest.gateThresholdPct, passed: rosterPassed },
+  differentialMatrix: matrix,
+  // Back-compat: keep the roster fields at top level (pre-#469 consumers read these).
+  denominator: total, passCount, pct: +pct.toFixed(1), thresholdPct: manifest.gateThresholdPct,
   rows: gateRows,
   exclusions: manifest.exclusions,
 }
@@ -86,10 +130,21 @@ writeFileSync(join(ROOT, 'test_results/launch-gate.json'), JSON.stringify(out, n
 
 // ---- write Markdown ----
 const verdictIcon = (g: GateRow) => g.pass ? '✅' : (g.gateVerdict === 'inconcl' ? '⚠️' : '❌')
+const matrixIcon = matrix.green === null ? '⚠️' : matrix.green ? '✅' : '❌'
 const md = [
-  `# Launch Gate — PRNG-free non-heavy official roster`,
+  `# Launch Gate`,
   ``,
-  `**${passCount}/${total} = ${pct.toFixed(1)}%** · threshold ≥${manifest.gateThresholdPct}% · **${passed ? '✅ PASS' : '❌ NOT MET'}**`,
+  `## Overall: **${passed ? '✅ PASS' : '❌ NOT MET'}** — roster ${rosterPassed ? 'pass' : 'fail'} · differential matrix ${matrix.green === null ? 'absent (warn)' : matrix.green ? 'green' : 'NOT green'}`,
+  ``,
+  `### Criterion 1 — PRNG-free non-heavy official roster`,
+  ``,
+  `**${passCount}/${total} = ${pct.toFixed(1)}%** · threshold ≥${manifest.gateThresholdPct}% · **${rosterPassed ? '✅ PASS' : '❌ NOT MET'}**`,
+  ``,
+  `### Criterion 2 — Differential matrix ${matrixIcon} (#469 · dharana §36)`,
+  ``,
+  matrix.present
+    ? `${matrix.note}${matrix.generatedAt ? ` _(captured ${matrix.generatedAt}, ${matrix.window}ms window)_` : ''}${matrix.diverged && matrix.diverged.length ? `\n\nOffending cells: ${matrix.diverged.map(c => `\`${c}\``).join(', ')}` : ''}`
+    : matrix.note,
   ``,
   `> Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly projection that exercises the same engine logic (see \`tools/gate-reproducers/\`). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation.`,
   ``,
@@ -133,12 +188,27 @@ const html = `<!doctype html>
   code { background: #1b1f29; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
   .detail { color: #9aa4b2; font-size: 12px; }
   .excl li { color: #9aa4b2; margin: 4px 0; }
+  .crit { border: 1px solid #262b36; border-radius: 8px; padding: 12px 16px; margin: 14px 0; }
+  .crit h2 { font-size: 14px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: .03em; color: #9aa4b2; }
+  .crit .v { font-size: 18px; font-weight: 700; }
+  .crit.pass { border-left: 3px solid #4ade80; } .crit.pass .v { color: #4ade80; }
+  .crit.fail { border-left: 3px solid #f87171; } .crit.fail .v { color: #f87171; }
+  .crit.warn { border-left: 3px solid #fbbf24; } .crit.warn .v { color: #fbbf24; }
 </style></head>
 <body>
   ${navBlock('🚦 Tier-1 launch gate · SV46')}
   <div class="wrap">
-    <h1>Launch Gate — PRNG-free non-heavy official roster</h1>
-    <div class="verdict ${passed ? 'pass' : 'fail'}">${passCount}/${total} = ${pct.toFixed(1)}% · threshold ≥${manifest.gateThresholdPct}% · ${passed ? '✅ PASS' : '❌ NOT MET'}</div>
+    <h1>Launch Gate</h1>
+    <div class="verdict ${passed ? 'pass' : 'fail'}">Overall: ${passed ? '✅ PASS' : '❌ NOT MET'}</div>
+    <div class="crit ${rosterPassed ? 'pass' : 'fail'}">
+      <h2>Criterion 1 — PRNG-free non-heavy official roster</h2>
+      <div class="v">${passCount}/${total} = ${pct.toFixed(1)}% · threshold ≥${manifest.gateThresholdPct}% · ${rosterPassed ? '✅ PASS' : '❌ NOT MET'}</div>
+    </div>
+    <div class="crit ${matrix.green === null ? 'warn' : matrix.green ? 'pass' : 'fail'}">
+      <h2>Criterion 2 — Differential matrix <span class="detail">(#469 · construct×context×position vs desktop · dharana §36)</span></h2>
+      <div class="v">${matrix.green === null ? '⚠️ ABSENT (warn, not blocking)' : matrix.green ? '✅ GREEN' : '❌ NOT GREEN'}</div>
+      <p class="detail">${esc(matrix.note)}${matrix.generatedAt ? ` · captured ${matrix.generatedAt}, ${matrix.window}ms window` : ''}${matrix.diverged && matrix.diverged.length ? ` · offenders: ${matrix.diverged.map(c => esc(c)).join(', ')}` : ''} — <a href="diff-matrix.html" style="color:#9aa4b2">open matrix →</a></p>
+    </div>
     <p class="note">Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly <b>projection</b> that exercises the same engine logic (<code>tools/gate-reproducers/</code>). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation. Projection verdicts depend on #405 + #409 (merged), re-captured live on merged main.</p>
     <table>
       <thead><tr><th>Row</th><th>Raw sweep</th><th>Gate verdict</th><th>Graded via</th><th>Detail</th></tr></thead>
@@ -155,6 +225,8 @@ ${manifest.exclusions.map(e => `      <li><b>${esc(e.example)}</b> — ${esc(e.r
 </body></html>`
 writeFileSync(join(ROOT, 'test_results/launch-gate.html'), html)
 
-console.log(`Launch gate: ${passCount}/${total} = ${pct.toFixed(1)}% — ${passed ? 'PASS' : 'NOT MET'}`)
-console.log(`Wrote test_results/launch-gate.{json,md}`)
+console.log(`Launch gate OVERALL: ${passed ? 'PASS' : 'NOT MET'}`)
+console.log(`  Criterion 1 — roster: ${passCount}/${total} = ${pct.toFixed(1)}% — ${rosterPassed ? 'PASS' : 'NOT MET'}`)
+console.log(`  Criterion 2 — diff matrix: ${matrix.green === null ? 'ABSENT (warn)' : matrix.green ? 'GREEN' : 'NOT GREEN'} — ${matrix.note}`)
+console.log(`Wrote test_results/launch-gate.{json,md,html}`)
 for (const g of gateRows) console.log(`  ${g.pass ? 'PASS' : 'fail'}  ${g.example.padEnd(20)} ${g.gateVerdict.padEnd(10)} (${g.gradedVia})`)


### PR DESCRIPTION
## Summary

Wires the **differential matrix** (`tools/diff-matrix.ts` → `test_results/diff-matrix.json`, construct×context×position event-parity vs desktop, dharana §36) into the launch gate as a recurring second criterion. Previously `gate-report.ts` graded only the PRNG-free non-heavy official roster (the 5/7 table), so a future construct-level parity regression would not surface in the gate.

## Behaviour

`gate-report.ts` now reads `diff-matrix.json` and reports **Criterion 2 — differential matrix**, GREEN iff `counts.match === counts.active` and `diverge + timing + webEmpty + desktopEmpty + error + pending === 0`:

| matrix state | criterion 2 | effect on overall |
|---|---|---|
| present + green | ✅ GREEN | contributes PASS |
| present + not-green | ❌ NOT GREEN | **blocks** (lists offending counts) |
| absent | ⚠️ ABSENT | warn only, **non-blocking** (needs desktop SP + scsynth; not a CI artifact) |

`Overall = rosterPassed && (matrix absent || matrix green)`. Roster behaviour is unchanged when the matrix is green. JSON keeps the roster fields at top level for back-compat; md + html dashboard views gain the criterion box (links to the matrix tab).

## Verification (ran the tool against all three input states)

```
green   (52/52 fresh)      → Criterion 2 GREEN,     overall PASS
not-green (stale 48/2/1/1) → Criterion 2 NOT GREEN, overall NOT MET (roster still 5/7 PASS)
absent  (no json)          → Criterion 2 ABSENT/warn, overall PASS
```

`npx tsc --noEmit` clean; standalone tool, no importers.

## ⚠️ Merge order

Merge **#468** (refreshes `diff-matrix.json` to 52/52 green) **before** this PR, then re-run `npx tsx tools/gate-report.ts` to refresh the committed `launch-gate.*` snapshot to the green two-criterion state. This PR is tool-only (no `launch-gate.*` snapshot committed) precisely to avoid shipping a transient NOT-MET snapshot while main's matrix data is still the stale pre-#460 capture.

Closes #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)