### PR TITLE
🚦 chore(dashboard): refresh launch-gate + index snapshots to green two-criterion state

### DIFF
--- a/test_results/index.html
+++ b/test_results/index.html
@@ -46,6 +46,7 @@
     font-weight:700;font-size:14px}
   .gate-badge.pass{background:#243218;color:var(--pass)}
   .gate-badge.fail{background:#321820;color:var(--fail)}
+  .gate-badge.warn{background:#322a18;color:#fbbf24}
   .gate-badge small{font-weight:400;color:var(--text-mute);font-size:11px}
   .gate-excl{font-size:11px;color:var(--text-mute);font-family:var(--mono);margin-top:2px}
   .gate-rows{flex:1;display:grid;grid-template-columns:1fr 1fr;gap:4px 18px;align-content:center}
@@ -99,13 +100,14 @@
 <script src="nav.js"></script>
 <div class="wrap">
   <h1>SonicPi.js — Parity Dashboard</h1>
-  <p class="sub">Desktop Sonic Pi ↔ browser engine, every example pool. Built <b>2026-06-03 22:53 UTC</b> from the freshly-captured manifests. <b>Tier-1 pitch is the verdict</b> (SV46); consistency scores are timbre/level support only.</p>
+  <p class="sub">Desktop Sonic Pi ↔ browser engine, every example pool. Built <b>2026-06-04 15:18 UTC</b> from the freshly-captured manifests. <b>Tier-1 pitch is the verdict</b> (SV46); consistency scores are timbre/level support only.</p>
 
   <a class="gate-hero pass" href="launch-gate.html">
     <div class="gate-left">
-      <div class="gate-verdict">🚦 Tier-1 launch gate</div>
+      <div class="gate-verdict">🚦 Tier-1 launch gate — PASS</div>
       <div class="gate-big"><b>5/7</b> <span>= 71.4%</span></div>
-      <div class="gate-badge pass">PASS <small>(≥ 70%)</small></div>
+      <div class="gate-badge pass">roster PASS <small>(≥ 70%)</small></div>
+      <div class="gate-badge pass">matrix ✓ 52/52</div>
       <div class="gate-excl">excluded: ambient_experiment (PRNG non-goal SV49)</div>
     </div>
     <div class="gate-rows"><div class="grow p"><span>✓</span><code>chord_inversions</code><em>match · projection</em></div><div class="grow p"><span>✓</span><code>reich_phase</code><em>match · projection</em></div><div class="grow f"><span>✗</span><code>dark_neon</code><em>inconcl · documented-limitation</em></div><div class="grow p"><span>✓</span><code>mod_303_phade</code><em>match · raw-refreshed</em></div><div class="grow f"><span>✗</span><code>bach</code><em>inconcl · documented-limitation</em></div><div class="grow p"><span>✓</span><code>driving_pulse</code><em>match · projection</em></div><div class="grow p"><span>✓</span><code>monday_blues</code><em>match · projection</em></div></div>

--- a/test_results/launch-gate.html
+++ b/test_results/launch-gate.html
@@ -22,13 +22,28 @@
   code { background: #1b1f29; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
   .detail { color: #9aa4b2; font-size: 12px; }
   .excl li { color: #9aa4b2; margin: 4px 0; }
+  .crit { border: 1px solid #262b36; border-radius: 8px; padding: 12px 16px; margin: 14px 0; }
+  .crit h2 { font-size: 14px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: .03em; color: #9aa4b2; }
+  .crit .v { font-size: 18px; font-weight: 700; }
+  .crit.pass { border-left: 3px solid #4ade80; } .crit.pass .v { color: #4ade80; }
+  .crit.fail { border-left: 3px solid #f87171; } .crit.fail .v { color: #f87171; }
+  .crit.warn { border-left: 3px solid #fbbf24; } .crit.warn .v { color: #fbbf24; }
 </style></head>
 <body>
   <nav class="tab-bar" id="topnav" data-meta="🚦 Tier-1 launch gate · SV46"></nav>
 <script src="nav.js"></script>
   <div class="wrap">
-    <h1>Launch Gate — PRNG-free non-heavy official roster</h1>
-    <div class="verdict pass">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
+    <h1>Launch Gate</h1>
+    <div class="verdict pass">Overall: ✅ PASS</div>
+    <div class="crit pass">
+      <h2>Criterion 1 — PRNG-free non-heavy official roster</h2>
+      <div class="v">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
+    </div>
+    <div class="crit pass">
+      <h2>Criterion 2 — Differential matrix <span class="detail">(#469 · construct×context×position vs desktop · dharana §36)</span></h2>
+      <div class="v">✅ GREEN</div>
+      <p class="detail">52/52 cells structure-match · 0 diverge/timing/empty/error. · captured 2026-06-04T14:30:35.208Z, 8000ms window — <a href="diff-matrix.html" style="color:#9aa4b2">open matrix →</a></p>
+    </div>
     <p class="note">Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly <b>projection</b> that exercises the same engine logic (<code>tools/gate-reproducers/</code>). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation. Projection verdicts depend on #405 + #409 (merged), re-captured live on merged main.</p>
     <table>
       <thead><tr><th>Row</th><th>Raw sweep</th><th>Gate verdict</th><th>Graded via</th><th>Detail</th></tr></thead>

--- a/test_results/launch-gate.json
+++ b/test_results/launch-gate.json
@@ -1,10 +1,37 @@
 {
-  "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json",
+  "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json + test_results/diff-matrix.json",
+  "passed": true,
+  "roster": {
+    "denominator": 7,
+    "passCount": 5,
+    "pct": 71.4,
+    "thresholdPct": 70,
+    "passed": true
+  },
+  "differentialMatrix": {
+    "present": true,
+    "green": true,
+    "generatedAt": "2026-06-04T14:30:35.208Z",
+    "window": 8000,
+    "counts": {
+      "match": 52,
+      "diverge": 0,
+      "timing": 0,
+      "webEmpty": 0,
+      "desktopEmpty": 0,
+      "error": 0,
+      "skipped": 8,
+      "pending": 0,
+      "active": 52,
+      "total": 60
+    },
+    "diverged": [],
+    "note": "52/52 cells structure-match · 0 diverge/timing/empty/error."
+  },
   "denominator": 7,
   "passCount": 5,
   "pct": 71.4,
   "thresholdPct": 70,
-  "passed": true,
   "rows": [
     {
       "example": "chord_inversions",

--- a/test_results/launch-gate.md
+++ b/test_results/launch-gate.md
@@ -1,6 +1,14 @@
-# Launch Gate — PRNG-free non-heavy official roster
+# Launch Gate
+
+## Overall: **✅ PASS** — roster pass · differential matrix green
+
+### Criterion 1 — PRNG-free non-heavy official roster
 
 **5/7 = 71.4%** · threshold ≥70% · **✅ PASS**
+
+### Criterion 2 — Differential matrix ✅ (#469 · dharana §36)
+
+52/52 cells structure-match · 0 diverge/timing/empty/error. _(captured 2026-06-04T14:30:35.208Z, 8000ms window)_
 
 > Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly projection that exercises the same engine logic (see `tools/gate-reproducers/`). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation.
 


### PR DESCRIPTION
## Summary

Completes the merge-order follow-up noted in #470. That PR was tool-only (added the differential-matrix gate criterion without committing a snapshot, to avoid shipping a transient NOT-MET while main's matrix data was stale). Now that #468 (fresh 52/52 `diff-matrix.json`) and #470 are both on main, this refreshes the committed dashboard snapshots.

Re-ran (pure JSON read — no capture / scsynth needed):
- `npx tsx tools/gate-report.ts`
- `npx tsx tools/build-aggregate-index.ts`

## Result

```
Launch gate OVERALL: PASS
  Criterion 1 — roster:     5/7 = 71.4% — PASS
  Criterion 2 — diff matrix: GREEN — 52/52 cells structure-match · 0 diverge/timing/empty/error
```

`launch-gate.json` now carries `roster` + `differentialMatrix`; aggregate hero renders `roster PASS` + `matrix ✓ 52/52`. Tool-derived snapshot only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)