### PR TITLE
🐛 fix(engine): inner with_fx creates a fresh FX node every iteration (#452)

### DIFF
--- a/src/engine/__tests__/WithFx.test.ts
+++ b/src/engine/__tests__/WithFx.test.ts
@@ -157,6 +157,49 @@ describe('with_fx', () => {
     expect(bridge.calls).toContain('free:16')
   })
 
+  it('inner with_fx creates a FRESH node every iteration — no cross-iteration reuse (#452)', async () => {
+    // Pre-#452 an inner with_fx node was REUSED across loop iterations when its
+    // kill timer hadn't fired yet (issue #70 anti-stacking). For a long-release
+    // inner synth (release ≥ loop period) the kill never fired, so the node was
+    // created ONCE and the remaining iterations skipped creation — diverging
+    // from desktop SP (which instantiates a fresh FX synth every pass) and
+    // dropping the per-iteration LFO reset for wobble/slicer. dark_neon: web
+    // fx_wobble 1× vs desktop 5×; long-release reverb diverged identically, so
+    // it is lifetime- not FX-name-specific.
+    //
+    // Post-#452: every iteration creates a new node (unique nodeId-suffixed key),
+    // overlapping nodes freed by their own kill timers (desktop parity). Asserted
+    // by counting createFxGroup calls across two iterations of the SAME with_fx
+    // at a loop period (1 beat) SHORTER than the inner release (4 beats) — the
+    // exact condition that made the old code reuse.
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    const eventStream = new SoundEventStream()
+    const nodeRefMap = new Map<number, number>()
+    const bridge = createMockBridge()
+    // ONE shared ctx so reusableFx persists across iterations (as in the engine).
+    const ctx = makeAudioCtx(scheduler, 'test', eventStream, nodeRefMap, bridge)
+
+    const program = new ProgramBuilder(0)
+      .with_fx('wobble', (b) => b.play(60, { release: 4 }))
+      .sleep(1)
+      .build()
+
+    scheduler.registerLoop('test', async () => {
+      await runProgram(program, ctx)
+    })
+
+    // Drive ≥2 iterations (loop period 1 beat). The old code would reuse on
+    // iteration 2 (kill timer at vt+5 not yet fired) → exactly one createGroup.
+    scheduler.tick(100); await flushMicrotasks()
+    scheduler.tick(100); await flushMicrotasks()
+    scheduler.tick(100); await flushMicrotasks()
+
+    const creates = bridge.calls.filter(c => c.startsWith('createGroup:'))
+    expect(creates.length).toBeGreaterThanOrEqual(2)
+    // Each instance is a DISTINCT node (no shared reuse) — group ids differ.
+    expect(new Set(creates).size).toBe(creates.length)
+  })
+
   it('nested FX chains buses correctly', async () => {
     const scheduler = new VirtualTimeScheduler({
       getAudioTime: () => 0,

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -20,7 +20,13 @@ import type { SuperSonicBridge } from '../SuperSonicBridge'
 import type { SoundEventStream, SoundEvent } from '../SoundEventStream'
 import type { MidiBridge } from '../MidiBridge'
 
-/** State for a reusable inner FX node (persists across loop iterations). */
+/**
+ * State for one live inner FX node. Pre-#452 this was REUSED across loop
+ * iterations (one node per loop position); since #452 each iteration creates a
+ * fresh node (desktop parity) and this tracks one live INSTANCE — overlapping
+ * instances coexist in `reusableFx` under nodeId-suffixed keys, each freed by
+ * its own kill timer kill_delay after its inner audio finishes.
+ */
 interface ReusableFxState {
   bus: number
   groupId: number
@@ -56,18 +62,22 @@ export interface AudioContext {
   printHandler?: (msg: string) => void
   nodeRefMap: Map<number, number>
   /**
-   * Reusable inner FX nodes — keyed by "taskId:fxIndex".
-   * with_fx inside a live_loop reuses the same FX node across iterations
-   * instead of creating a new one each time. This prevents additive signal
-   * stacking from overlapping echo/delay/reverb nodes. See issue #70.
+   * Live inner FX node instances — keyed by "taskId:fxIndex#nodeId".
+   * Since #452 a with_fx inside a live_loop creates a FRESH FX node every
+   * iteration (matching desktop SP), so several instances of the same loop
+   * position can be alive at once (overlapping, bounded by kill_delay). The
+   * nodeId suffix keeps them distinct so iteration N+1 can't overwrite N's
+   * entry. Used for inner-play `aliveUntil` bumping + hot-swap teardown.
+   * (Pre-#452 this reused one node per loop position to avoid additive
+   * stacking — issue #70 — but that diverged from desktop, which overlaps.)
    */
   reusableFx: Map<string, ReusableFxState>
   /**
-   * Stack of currently-active with_fx scopes (innermost last), keyed by
-   * `${taskId}:fx${fxIndex}` matching `reusableFx`. Lazily initialised in
-   * `case 'fx'`; absent in paths that never enter an FX. When a play/sample
-   * fires, every enclosing FX's `aliveUntil` is extended so the FX bus
-   * outlives the audible synth (mirrors desktop sound.rb:1817-1822).
+   * Stack of currently-active with_fx scopes (innermost last), holding the
+   * per-instance keys ("taskId:fxIndex#nodeId") that index `reusableFx`.
+   * Lazily initialised in `case 'fx'`; absent in paths that never enter an FX.
+   * When a play/sample fires, every enclosing FX's `aliveUntil` is extended so
+   * the FX bus outlives the audible synth (mirrors desktop sound.rb:1817-1822).
    */
   currentFxStack?: string[]
   /**
@@ -350,76 +360,32 @@ export async function runProgram(
           break
         }
         const fxIndex = fxCounter.value++
-        const fxKey = `${ctx.taskId}:fx${fxIndex}`
+        const baseKey = `${ctx.taskId}:fx${fxIndex}`
         const prevOutBus = task.outBus
 
-        // Reuse FX node across loop iterations (issue #70).
-        // First iteration: create FX node + bus, store in reusableFx map.
-        // Subsequent iterations: reuse the same node — inner synths write
-        // to the same bus, FX processes a continuous stream.
-        // This prevents additive signal stacking from overlapping echo nodes.
-        // Lazy-init the FX scope stack so non-FX paths pay nothing. Each entry
-        // is a key into `ctx.reusableFx` and lives only for this block's body.
+        // #452: create a FRESH inner FX node EVERY iteration — desktop parity.
+        // Desktop SP's with_fx block instantiates a new FX synth each pass and
+        // frees it kill_delay after its inner audio finishes (block_until_finished
+        // then Kernel.sleep(kill_delay), sound.rb:1817-1822); overlapping
+        // iterations therefore overlap FX nodes. Pre-#452 we REUSED one node per
+        // loop position (issue #70 anti-stacking), but that diverged: when an
+        // inner synth's release ran past the next iteration the kill timer never
+        // fired, collapsing N desktop nodes to 1 and skipping the per-iteration
+        // LFO reset on modulating FX (wobble/slicer/panslicer). Now every pass
+        // re-creates; overlap is bounded by the same kill_delay desktop uses.
+        // Lazy-init the FX scope stack so non-FX paths pay nothing; each entry is
+        // a per-INSTANCE key into `ctx.reusableFx` (nodeId-suffixed) so concurrent
+        // live instances of the same loop position never collide.
         const fxStack = (ctx.currentFxStack ??= [])
 
-        const existing = ctx.reusableFx.get(fxKey)
-        if (existing) {
-          // Reuse — cancel pending kill timer, route through existing FX bus
-          if (existing.killTimer) {
-            existing.killTimer.cancel()
-            existing.killTimer = undefined
-          }
-          if (step.nodeRef && existing.nodeId !== undefined) {
-            ctx.nodeRefMap.set(step.nodeRef, existing.nodeId)
-          }
-          task.outBus = existing.bus
-          // Reset aliveUntil for THIS iteration's plays/samples; the prior
-          // iteration's value is no longer load-bearing (we just cancelled
-          // that kill timer above). aliveUntil is a floor — `case 'play'`
-          // bumps it up as inner synths dispatch.
-          existing.aliveUntil = task.virtualTime
-          fxStack.push(fxKey)
-          try {
-            for (let rep = 0; rep < reps; rep++) await runProgram(step.body, ctx, fxCounter)
-          } finally {
-            fxStack.pop()
-            task.outBus = prevOutBus
-            ctx.bridge.flushMessages()
-            // Schedule kill in VIRTUAL TIME (SV41) — cancelled if next iter
-            // reuses before its horizon. setTimeout-based (real-time) scheduling
-            // raced post-SV40-purge real-time-paced iterations (SP87).
-            //
-            // GUARD: only schedule if our `existing` state is STILL the active
-            // entry in the Map. After SonicPiEngine's hot-swap reusableFx.clear,
-            // this iter's `existing` reference becomes stale (resources already
-            // freed by clear); a scheduled kill would (a) leak an uncancellable
-            // callback and (b) eventually run /n_free + freeBus on the freed
-            // (and possibly re-allocated) resources. The next iter will hit
-            // CREATE branch and own the new state's killTimer.
-            if (ctx.reusableFx.get(fxKey) === existing) {
-              const killDelay = (step.opts.kill_delay as number) ?? 1.0
-              // Wait for inner audio to finish (aliveUntil) THEN add kill_delay —
-              // matches desktop sound.rb:1817-1822 (tracker.block_until_finished
-              // then Kernel.sleep(kill_delay)). Without this, a sustained synth
-              // inside this FX (e.g. `play release: 60`) was truncated to ~1s
-              // (mod_303_phade).
-              const killAt = Math.max(task.virtualTime, existing.aliveUntil) + killDelay
-              existing.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
-                // /n_free the FX synth itself — applyFxImmediate puts it in
-                // root group 101 (not the container group), so freeGroup
-                // alone leaves the synth running and ringing into outer FX.
-                ctx.bridge!.freeNode(existing.nodeId)
-                ctx.bridge!.freeGroup(existing.groupId)
-                ctx.bridge!.freeBus(existing.bus)
-                ctx.reusableFx.delete(fxKey)
-              })
-            }
-          }
-        } else {
-          // First iteration — create FX node
+        {
           const newBus = ctx.bridge.allocateBus()
           const fxGroupId = ctx.bridge.createFxGroup()
           let fxNodeId: number | undefined
+          // Per-instance key — finalised to `${baseKey}#${nodeId}` once the node
+          // id is known (below). Until then `baseKey` is a harmless placeholder
+          // (only read by the kill scheduler, which no-ops if no state was set).
+          let instanceKey = baseKey
           try {
             // SP83/#423: create the FX node with an IMMEDIATE timetag (0), not
             // the future `vt + schedAhead`. A future timetag puts the /s_new in
@@ -466,7 +432,13 @@ export async function runProgram(
               ctx.nodeRefMap.set(step.nodeRef, fxNodeId)
             }
             task.outBus = newBus
-            // Store for reuse — with pending kill timer as safety net.
+            // Finalise the per-instance key now that the node id exists. nodeId
+            // is globally unique, so overlapping iterations of THIS loop position
+            // get distinct keys — iteration N+1 can't overwrite N's entry, and
+            // N's kill timer deletes only its own slot (a stable position key
+            // would mis-delete N+1's live entry → hot-swap leak / wrong free).
+            instanceKey = `${baseKey}#${fxNodeId}`
+            // Track this live instance — pending kill timer scheduled in finally.
             // aliveUntil starts at the current vt (no plays yet); `case 'play'`
             // bumps it as inner synths dispatch.
             const state: ReusableFxState = {
@@ -476,8 +448,8 @@ export async function runProgram(
               outBus: prevOutBus,
               aliveUntil: task.virtualTime,
             }
-            ctx.reusableFx.set(fxKey, state)
-            fxStack.push(fxKey)
+            ctx.reusableFx.set(instanceKey, state)
+            fxStack.push(instanceKey)
             try {
               for (let rep = 0; rep < reps; rep++) await runProgram(step.body, ctx, fxCounter)
             } finally {
@@ -491,17 +463,21 @@ export async function runProgram(
             // one ordered bundle. No-op once an inner synth already flushed it.
             ctx.bridge.flushImmediateFx()
             ctx.bridge.flushMessages()
-            // Schedule kill in VIRTUAL TIME (SV41) — if next iter reuses, cancelled.
-            // killAt = max(vt_at_block_exit, aliveUntil) + killDelay — see reuse branch.
+            // Schedule this instance's kill in VIRTUAL TIME (SV41). killAt =
+            // max(vt_at_block_exit, aliveUntil) + kill_delay — waits for inner
+            // audio (aliveUntil, bumped by inner plays/samples) THEN kill_delay,
+            // mirroring desktop block_until_finished + Kernel.sleep(kill_delay).
+            // Overlapping instances each free themselves under their own key;
+            // hot-swap cancels these timers before freeing (no double-free).
             const killDelay = (step.opts.kill_delay as number) ?? 1.0
-            const state = ctx.reusableFx.get(fxKey)
+            const state = ctx.reusableFx.get(instanceKey)
             if (state) {
               const killAt = Math.max(task.virtualTime, state.aliveUntil) + killDelay
               state.killTimer = ctx.scheduler.scheduleAtVirtualTime(killAt, () => {
                 ctx.bridge!.freeNode(state.nodeId)
                 ctx.bridge!.freeGroup(state.groupId)
                 ctx.bridge!.freeBus(state.bus)
-                ctx.reusableFx.delete(fxKey)
+                ctx.reusableFx.delete(instanceKey)
               })
             }
           }

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -46,6 +46,7 @@
     font-weight:700;font-size:14px}
   .gate-badge.pass{background:#243218;color:var(--pass)}
   .gate-badge.fail{background:#321820;color:var(--fail)}
+  .gate-badge.warn{background:#322a18;color:#fbbf24}
   .gate-badge small{font-weight:400;color:var(--text-mute);font-size:11px}
   .gate-excl{font-size:11px;color:var(--text-mute);font-family:var(--mono);margin-top:2px}
   .gate-rows{flex:1;display:grid;grid-template-columns:1fr 1fr;gap:4px 18px;align-content:center}
@@ -99,13 +100,14 @@
 <script src="nav.js"></script>
 <div class="wrap">
   <h1>SonicPi.js — Parity Dashboard</h1>
-  <p class="sub">Desktop Sonic Pi ↔ browser engine, every example pool. Built <b>2026-06-03 22:53 UTC</b> from the freshly-captured manifests. <b>Tier-1 pitch is the verdict</b> (SV46); consistency scores are timbre/level support only.</p>
+  <p class="sub">Desktop Sonic Pi ↔ browser engine, every example pool. Built <b>2026-06-04 15:18 UTC</b> from the freshly-captured manifests. <b>Tier-1 pitch is the verdict</b> (SV46); consistency scores are timbre/level support only.</p>
 
   <a class="gate-hero pass" href="launch-gate.html">
     <div class="gate-left">
-      <div class="gate-verdict">🚦 Tier-1 launch gate</div>
+      <div class="gate-verdict">🚦 Tier-1 launch gate — PASS</div>
       <div class="gate-big"><b>5/7</b> <span>= 71.4%</span></div>
-      <div class="gate-badge pass">PASS <small>(≥ 70%)</small></div>
+      <div class="gate-badge pass">roster PASS <small>(≥ 70%)</small></div>
+      <div class="gate-badge pass">matrix ✓ 52/52</div>
       <div class="gate-excl">excluded: ambient_experiment (PRNG non-goal SV49)</div>
     </div>
     <div class="gate-rows"><div class="grow p"><span>✓</span><code>chord_inversions</code><em>match · projection</em></div><div class="grow p"><span>✓</span><code>reich_phase</code><em>match · projection</em></div><div class="grow f"><span>✗</span><code>dark_neon</code><em>inconcl · documented-limitation</em></div><div class="grow p"><span>✓</span><code>mod_303_phade</code><em>match · raw-refreshed</em></div><div class="grow f"><span>✗</span><code>bach</code><em>inconcl · documented-limitation</em></div><div class="grow p"><span>✓</span><code>driving_pulse</code><em>match · projection</em></div><div class="grow p"><span>✓</span><code>monday_blues</code><em>match · projection</em></div></div>

--- a/test_results/launch-gate.html
+++ b/test_results/launch-gate.html
@@ -22,13 +22,28 @@
   code { background: #1b1f29; padding: 1px 5px; border-radius: 4px; font-size: 12px; }
   .detail { color: #9aa4b2; font-size: 12px; }
   .excl li { color: #9aa4b2; margin: 4px 0; }
+  .crit { border: 1px solid #262b36; border-radius: 8px; padding: 12px 16px; margin: 14px 0; }
+  .crit h2 { font-size: 14px; margin: 0 0 6px; text-transform: uppercase; letter-spacing: .03em; color: #9aa4b2; }
+  .crit .v { font-size: 18px; font-weight: 700; }
+  .crit.pass { border-left: 3px solid #4ade80; } .crit.pass .v { color: #4ade80; }
+  .crit.fail { border-left: 3px solid #f87171; } .crit.fail .v { color: #f87171; }
+  .crit.warn { border-left: 3px solid #fbbf24; } .crit.warn .v { color: #fbbf24; }
 </style></head>
 <body>
   <nav class="tab-bar" id="topnav" data-meta="🚦 Tier-1 launch gate · SV46"></nav>
 <script src="nav.js"></script>
   <div class="wrap">
-    <h1>Launch Gate — PRNG-free non-heavy official roster</h1>
-    <div class="verdict pass">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
+    <h1>Launch Gate</h1>
+    <div class="verdict pass">Overall: ✅ PASS</div>
+    <div class="crit pass">
+      <h2>Criterion 1 — PRNG-free non-heavy official roster</h2>
+      <div class="v">5/7 = 71.4% · threshold ≥70% · ✅ PASS</div>
+    </div>
+    <div class="crit pass">
+      <h2>Criterion 2 — Differential matrix <span class="detail">(#469 · construct×context×position vs desktop · dharana §36)</span></h2>
+      <div class="v">✅ GREEN</div>
+      <p class="detail">52/52 cells structure-match · 0 diverge/timing/empty/error. · captured 2026-06-04T14:30:35.208Z, 8000ms window — <a href="diff-matrix.html" style="color:#9aa4b2">open matrix →</a></p>
+    </div>
     <p class="note">Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly <b>projection</b> that exercises the same engine logic (<code>tools/gate-reproducers/</code>). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation. Projection verdicts depend on #405 + #409 (merged), re-captured live on merged main.</p>
     <table>
       <thead><tr><th>Row</th><th>Raw sweep</th><th>Gate verdict</th><th>Graded via</th><th>Detail</th></tr></thead>

--- a/test_results/launch-gate.json
+++ b/test_results/launch-gate.json
@@ -1,10 +1,37 @@
 {
-  "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json",
+  "generatedFrom": "examples-sweep.json + tools/gate-reproducers/manifest.json + test_results/diff-matrix.json",
+  "passed": true,
+  "roster": {
+    "denominator": 7,
+    "passCount": 5,
+    "pct": 71.4,
+    "thresholdPct": 70,
+    "passed": true
+  },
+  "differentialMatrix": {
+    "present": true,
+    "green": true,
+    "generatedAt": "2026-06-04T14:30:35.208Z",
+    "window": 8000,
+    "counts": {
+      "match": 52,
+      "diverge": 0,
+      "timing": 0,
+      "webEmpty": 0,
+      "desktopEmpty": 0,
+      "error": 0,
+      "skipped": 8,
+      "pending": 0,
+      "active": 52,
+      "total": 60
+    },
+    "diverged": [],
+    "note": "52/52 cells structure-match · 0 diverge/timing/empty/error."
+  },
   "denominator": 7,
   "passCount": 5,
   "pct": 71.4,
   "thresholdPct": 70,
-  "passed": true,
   "rows": [
     {
       "example": "chord_inversions",

--- a/test_results/launch-gate.md
+++ b/test_results/launch-gate.md
@@ -1,6 +1,14 @@
-# Launch Gate — PRNG-free non-heavy official roster
+# Launch Gate
+
+## Overall: **✅ PASS** — roster pass · differential matrix green
+
+### Criterion 1 — PRNG-free non-heavy official roster
 
 **5/7 = 71.4%** · threshold ≥70% · **✅ PASS**
+
+### Criterion 2 — Differential matrix ✅ (#469 · dharana §36)
+
+52/52 cells structure-match · 0 diverge/timing/empty/error. _(captured 2026-06-04T14:30:35.208Z, 8000ms window)_
 
 > Pass = MATCH or PRNG-VARIANT. Rows the pitch-trackers cannot grade are graded via an instrument-friendly projection that exercises the same engine logic (see `tools/gate-reproducers/`). The raw sweep keeps the unvarnished verdicts; this is the launch-gate computation.
 


### PR DESCRIPTION
## Summary

An inner `with_fx` inside a `live_loop` was **reused** across iterations (issue #70 anti-stacking) and only freed when its virtual-time kill timer fired. When the inner synth's lifetime outlived the gap to the next iteration, the kill never fired → the node was created **once** and later iterations skipped creation. dark_neon: web `fx_wobble` **1×** vs desktop **5×**.

### Grounded root cause — NOT wobble/LFO-specific

The issue hypothesized an LFO-FX persistence path. A 2×2 event-parity matrix disproved it — the discriminator is **inner-lifetime vs loop-period**, not FX type:

| inner lifetime | FX | web | desktop |
|---|---|---|---|
| short `release:0.1` | wobble | 5 | 5 ✓ |
| long `release:4` | wobble | 1 | 5 ✗ |
| long `release:4` | **reverb** | **1** | **5 ✗** |
| short (sample) | reverb/bitcrusher | 5 | 5 ✓ |

A long-release **reverb** diverges identically. Desktop SP instantiates a fresh FX synth every `with_fx` pass (`block_until_finished` + `kill_delay`, sound.rb:1817-1822), overlapping nodes; reuse also skipped the per-note LFO reset on wobble/slicer/panslicer.

## Fix (option **b** — full desktop parity, per your call)

`AudioInterpreter` `case 'fx'` now **always creates** per iteration — fresh node/bus/group keyed by a unique per-instance key `${taskId}:fx${fxIndex}#${nodeId}` so overlapping instances of the same loop position never collide (a stable position key let iteration N+1 overwrite N's map slot → N's kill mis-deletes N+1's live entry → hot-swap leak). Each instance frees itself at `max(vt, aliveUntil)+kill_delay`; hot-swap cancels timers before freeing (no double-free). The `#424` applyFxOrdered path, SP83 ordered-bundle creation, and SV41 virtual-time kill are unchanged. The reuse branch is removed.

## Verification (all 3 levels)

- **L1** — `tsc --noEmit` clean; suite **1161/1161** (+1 regression: 2 iterations → 2 distinct FX nodes, the exact long-release-reuse condition).
- **L2** — event-parity vs desktop scsynth: dark_neon `fx_wobble` **1→5** (reverb 5, bitcrusher 5); `reverb_long` **1→5**; `wobble_short` stays 5; **mod_303_phade clean** (tb303/reverb/slicer 1/1, not dropped → SP83 ordered-bundle intact).
- **L3** — dark_neon web WAV: **RMS 0.2105** (≈ ref 0.19, not silent → SP83 not regressed), **Peak 1.0 / Clipping 0%** (ref Peak 1.0 / Clip 0.01% → #70 stacking did not blow up), wobble recreated per iteration in the OSC trace.

Catalogues: hetvabhasa **SP124**, vyapti **SV59** (+ SV41 reuse-guard marked obsolete).

Closes #452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)