### PR TITLE
🐛 fix(transpiler): density must squash AND repeat the block (#379)

### DIFF
--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -37,11 +37,29 @@ export interface Sp95Warning {
 }
 
 /**
- * Run all SP95-loud detectors over the given Ruby source. All SP95 idioms are
- * now implemented (see module header), so this returns `[]`. Retained as the
- * integration point for the warning channel so a future build-time lint can
- * slot in here without re-wiring SonicPiEngine / App / capture.ts. Pure, O(1).
+ * Run all build-time DSL lints over the given Ruby source. The SP95 detectors
+ * are retired (see module header); this is the retained integration point for
+ * non-fatal build-time warnings (the channel a future lint slots into). Pure.
  */
-export function detectSp95Limitations(_src: string): Sp95Warning[] {
-  return []
+export function detectSp95Limitations(src: string): Sp95Warning[] {
+  const warnings: Sp95Warning[] = []
+
+  // `with_density` is NOT a Sonic Pi function — desktop has only `density`
+  // (core.rb:3973) and RAISES on `with_density` (the thread dies, halting all
+  // code after it). Our transpiler instead runs it AS `density` (squash AND
+  // repeat). This warning makes the divergence-from-desktop visible and guides
+  // the user to the real name rather than letting it pass silently (#379,
+  // loud-not-silent / SV50). The `^[^#\n]*` guard matches a call position only,
+  // skipping pure-comment lines and inline `# … with_density` comments.
+  if (/^[^#\n]*\bwith_density\b/m.test(src)) {
+    warnings.push({
+      pattern: 'with_density',
+      title: 'with_density is not a Sonic Pi function',
+      message:
+        'Did you mean `density`? Running `with_density` as `density` (squash and repeat). ' +
+        'Desktop Sonic Pi has only `density` and errors on `with_density`.',
+    })
+  }
+
+  return warnings
 }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1296,7 +1296,7 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
     }
 
     // with_fx :name, opts do ... end
-    if (methodName === 'with_fx' || methodName === 'with_synth' || methodName === 'with_bpm' || methodName === 'with_transpose' || methodName === 'with_arg_bpm_scaling' || methodName === 'with_synth_defaults' || methodName === 'with_sample_defaults' || methodName === 'with_random_seed' || methodName === 'with_octave' || methodName === 'with_density' || methodName === 'with_arg_checks' || methodName === 'with_debug' || methodName === 'with_timing_guarantees' || methodName === 'with_merged_synth_defaults' || methodName === 'with_merged_sample_defaults') {
+    if (methodName === 'with_fx' || methodName === 'with_synth' || methodName === 'with_bpm' || methodName === 'with_transpose' || methodName === 'with_arg_bpm_scaling' || methodName === 'with_synth_defaults' || methodName === 'with_sample_defaults' || methodName === 'with_random_seed' || methodName === 'with_octave' || methodName === 'with_arg_checks' || methodName === 'with_debug' || methodName === 'with_timing_guarantees' || methodName === 'with_merged_synth_defaults' || methodName === 'with_merged_sample_defaults') {
       return transpileWithBlock(methodName, argsNode, blockNode, ctx)
     }
 
@@ -1327,8 +1327,13 @@ function transpileMethodCall(node: any, ctx: TranspileContext): string {
       return `assert_error((__b) => {\n${bodyStr}\n${ctx.indent}})`
     }
 
-    // density N do ... end
-    if (methodName === 'density') {
+    // density N do ... end   (+ `with_density` — NOT a real Sonic Pi function;
+    // desktop has only `density` (core.rb:3973) and errors on `with_density`.
+    // We run it AS density (compress+repeat) and surface a build-time warning via
+    // Sp95Lint so the user is guided to the real name — loud, not a silent crash.
+    // The internal ProgramBuilder.with_density (used by with_swing/at) is a
+    // distinct TS method, unaffected by this transpiler routing.)
+    if (methodName === 'density' || methodName === 'with_density') {
       return transpileDensity(argsNode, blockNode, ctx)
     }
 
@@ -2627,11 +2632,23 @@ function transpileDensity(
     : '1'
   const bodyStr = transpileBlockBody(blockNode, ctx)
   const bRef = ctx.insideLoop ? '__b' : '__densityB'
+  // Desktop `density(d)` (core.rb:3973-3987) does TWO things, not one: it
+  // compresses the block's bpm by `d` (our `bRef.density` factor → sleeps /d at
+  // ProgramBuilder.sleep) AND runs the block `reps` times (reps = d<1 ? 1 : d).
+  // "Squash AND repeat time." We previously only compressed and ran the body
+  // once → `density 2 do A; B end` played `A B` where desktop plays `A B A B`
+  // (#379). The for-loop below adds the repetition. Each emit gets its own `{}`
+  // block so the `__df`/`__prevDensity`/`__dreps`/`__di` consts are block-scoped
+  // → nested `density` blocks shadow cleanly without a counter.
   const lines = ['{']
   if (!ctx.insideLoop) lines.push(`  const ${bRef} = { density: 1 }`)
+  lines.push(`  const __df = ${factor}`)
   lines.push(`  const __prevDensity = ${bRef}.density`)
-  lines.push(`  ${bRef}.density = __prevDensity * ${factor}`)
+  lines.push(`  ${bRef}.density = __prevDensity * __df`)
+  lines.push(`  const __dreps = __df < 1 ? 1 : Math.floor(__df)`)
+  lines.push(`  for (let __di = 0; __di < __dreps; __di++) {`)
   lines.push(bodyStr)
+  lines.push(`  }`)
   lines.push(`  ${bRef}.density = __prevDensity`)
   lines.push('}')
   return lines.join('\n' + ctx.indent)

--- a/src/engine/__tests__/Density.test.ts
+++ b/src/engine/__tests__/Density.test.ts
@@ -1,0 +1,62 @@
+/**
+ * #379 — `density d do…end` must SQUASH AND REPEAT: desktop `density(d)`
+ * (core.rb:3973-3987) compresses the block's bpm by `d` AND runs the block
+ * `reps.times` (reps = d<1 ? 1 : d). Our transpiler previously only compressed
+ * time and ran the body ONCE, so `density 2 do A; B end` played `A B` where
+ * desktop plays `A B A B` (verified Level-2 event-parity desktop 6 / web was 4).
+ *
+ * Also: `with_density` is NOT a Sonic Pi function (desktop has only `density`
+ * and raises on `with_density`). We run it AS `density` and warn via Sp95Lint.
+ */
+import { describe, it, expect } from 'vitest'
+import { autoTranspile } from '../TreeSitterTranspiler'
+import { detectSp95Limitations } from '../Sp95Lint'
+
+describe('#379 density squash-AND-repeat', () => {
+  it('density 2 emits a reps loop (block runs Math.floor(d) times)', () => {
+    const out = autoTranspile('density 2 do\n  play 67\n  sleep 0.5\nend')
+    // reps computed at runtime from the factor; body wrapped in a for-loop
+    expect(out).toMatch(/const __dreps = __df < 1 \? 1 : Math\.floor\(__df\)/)
+    expect(out).toMatch(/for \(let __di = 0; __di < __dreps; __di\+\+\)/)
+    // still compresses time (density factor applied)
+    expect(out).toMatch(/\.density = __prevDensity \* __df/)
+  })
+
+  it('density passes the factor through to __df once (no double-eval)', () => {
+    const out = autoTranspile('density 2 do\n  play 60\nend')
+    expect(out).toMatch(/const __df = 2/)
+  })
+
+  it('with_density routes to density (NOT the compress-only __b.with_density)', () => {
+    const out = autoTranspile('with_density 2 do\n  play 67\n  sleep 0.5\nend')
+    // routed through transpileDensity → has the reps loop …
+    expect(out).toMatch(/for \(let __di = 0; __di < __dreps; __di\+\+\)/)
+    // … and does NOT emit a builder with_density call
+    expect(out).not.toMatch(/with_density\(/)
+  })
+
+  it('nested density blocks do not collide (block-scoped consts)', () => {
+    const out = autoTranspile(
+      'density 2 do\n  density 3 do\n    play 60\n  end\nend'
+    )
+    // two independent reps loops emitted
+    expect((out.match(/for \(let __di = 0; __di < __dreps; __di\+\+\)/g) ?? []).length).toBe(2)
+  })
+})
+
+describe('#379 with_density build-time warning (loud-not-silent)', () => {
+  it('warns that with_density is not a Sonic Pi function', () => {
+    const ws = detectSp95Limitations('with_density 2 do\n  play 60\nend')
+    expect(ws).toHaveLength(1)
+    expect(ws[0].pattern).toBe('with_density')
+    expect(ws[0].message).toMatch(/density/)
+  })
+
+  it('does NOT warn on the real density (negative control)', () => {
+    expect(detectSp95Limitations('density 2 do\n  play 60\nend')).toHaveLength(0)
+  })
+
+  it('does NOT warn when with_density appears only in a comment', () => {
+    expect(detectSp95Limitations('# with_density is not real\ndensity 2 do\n  play 60\nend')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Problem
`density d do … end` only **compressed time** (sleeps ÷ d) and ran the block **once**. Desktop `density(d)` (`core.rb:3973-3987`) compresses bpm by `d` **and** runs the block `reps.times` (reps = `d<1 ? 1 : d`) — *"squash AND repeat time."* So `density 2 do A; B end` played `A B` on web where desktop plays `A B A B`.

Surfaced by `e2e_07_scoping` (#379). The issue's reported "pitch divergence at note 7 (42 vs 43)" was a red herring — pitch-tracker noise on the unpitched `drum_heavy_kick` samples (#453-class). The fixture also used `with_density`, which is **not a Sonic Pi function** (desktop raises and halts the run), masking the real density bug.

## Fix
- **`transpileDensity`** wraps the (already time-compressed) body in a runtime `for (__di < reps)` loop, `reps = __df < 1 ? 1 : Math.floor(__df)`, matching `core.rb:3973`. Each emit gets its own `{}` block so the consts are block-scoped → nested `density` blocks shadow cleanly without a counter.
- **`with_density`** (user-facing) now routes to `transpileDensity` (runs *as* `density`, compress+repeat) instead of the compress-only builder method, and emits a build-time warning via the `Sp95Lint` channel (*"with_density is not a Sonic Pi function — did you mean density?"*) — loud-not-silent (SV50). The internal `ProgramBuilder.with_density` (used by `with_swing`/`at`) is unchanged.

## Verification
- **L1:** `tsc` clean · `1168/1168` (+7 `Density.test.ts`).
- **L2 (event-parity desktop↔web):** density reproducer **6/6 STRUCTURE-MATCH**; full `e2e_07_scoping` **21/21 events, 0 onset mismatches** (was desktop-halt 14 vs web 19). Warning confirmed surfacing in `capture.ts`.
- **Grounded:** `desktop-sp/core.rb:3973-3987`.

## Notes
- The `e2e_07_scoping.rb` fixture (`with_density` → `density`) is corrected locally; `tests/book-examples/` is gitignored, so it's not in this diff.
- Self-review found a **pre-existing, orthogonal** bug (filed **#473**): a program whose *only* top-level statement is a `density` block fails to wrap bare `play` calls. Not introduced here (reproduces on the parent commit); low impact (real programs have surrounding code).

Closes #379.