### PR TITLE
feat(comparator): event-parity onset-sequence as the authoritative EVENT-MATCH tiebreaker (#377/#378, SV61)

### DIFF
--- a/test_results/examples-sweep.html
+++ b/test_results/examples-sweep.html
@@ -104,6 +104,7 @@
       }
       .chip[data-on="1"] { color: var(--text); background: var(--bg-row-active); border-color: var(--accent-2); }
       .chip[data-on="1"][data-verdict="match"] { color: var(--pass); border-color: var(--pass); }
+      .chip[data-on="1"][data-verdict="event-match"] { color: var(--pass); border-color: var(--pass); }
       .chip[data-on="1"][data-verdict="diverge"] { color: var(--fail); border-color: var(--fail); }
       .chip[data-on="1"][data-verdict="prng-variant"] { color: var(--accent-2); border-color: var(--accent-2); }
       .chip[data-on="1"][data-verdict="invalid"] { color: var(--flag); border-color: var(--flag); }
@@ -132,6 +133,7 @@
 
       .badge { display: inline-block; padding: 1px 6px; border-radius: 3px; font-size: 9px; font-weight: 600; letter-spacing: 0.05em; font-family: var(--mono); }
       .badge.match { color: var(--pass); background: rgba(158,206,106,0.12); }
+      .badge.event-match { color: var(--pass); background: rgba(158,206,106,0.12); }
       .badge.diverge { color: var(--fail); background: rgba(247,118,142,0.12); }
       .badge.prng-variant { color: var(--accent-2); background: rgba(122,162,247,0.12); }
       .badge.invalid { color: var(--flag); background: rgba(224,175,104,0.12); }
@@ -230,6 +232,7 @@
       .stat .n { font-size: 24px; font-weight: 600; font-family: var(--mono); }
       .stat .label { font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 2px; }
       .stat.match .n { color: var(--pass); }
+      .stat.event-match .n { color: var(--pass); }
       .stat.diverge .n { color: var(--fail); }
       .stat.prng-variant .n { color: var(--accent-2); }
       .stat.invalid .n { color: var(--flag); }
@@ -269,6 +272,7 @@
             <input id="search" type="search" placeholder="search examples (e.g. ambient, acid)" autocomplete="off" spellcheck="false" />
             <div class="filters" id="filters">
               <button class="chip" data-verdict="match" data-on="1">✅ MATCH</button>
+              <button class="chip" data-verdict="event-match" data-on="1">✅ EVENT-MATCH</button>
               <button class="chip" data-verdict="prng-variant" data-on="1">≈ PRNG-VARIANT</button>
               <button class="chip" data-verdict="diverge" data-on="1">❌ DIVERGE</button>
               <button class="chip" data-verdict="invalid" data-on="1">⚠ INVALID</button>
@@ -478,6 +482,7 @@
             </div>
             <div class="stat-grid">
               <div class="stat match" data-only="match"><div class="n">${c.match}</div><div class="label">✅ match</div></div>
+              <div class="stat event-match" data-only="event-match"><div class="n">${c.eventMatch ?? 0}</div><div class="label">✅ event-match</div></div>
               <div class="stat prng-variant" data-only="prng-variant"><div class="n">${c.prngVariant ?? 0}</div><div class="label">≈ prng-variant</div></div>
               <div class="stat diverge" data-only="diverge"><div class="n">${c.diverge}</div><div class="label">❌ diverge</div></div>
               <div class="stat invalid" data-only="invalid"><div class="n">${c.invalid}</div><div class="label">⚠ invalid</div></div>

--- a/tools/__tests__/event-parity-parsers.test.ts
+++ b/tools/__tests__/event-parity-parsers.test.ts
@@ -260,3 +260,51 @@ describe('buildReport onset-sequence parity (SV61)', () => {
     expect(r.sequenceParity.match).toBeNull()
   })
 })
+
+// --- NOTE-value parity per timetag (closes the timing≠notes hole) -----------
+// onsets WITH note values for one synthdef
+function atN(synthdef: string, pairs: Array<[number, number]>): OscEvent[] {
+  return pairs.map(([t, note]) => ({ addr: '/s_new', synthdef, params: { note }, tRel: t, raw: '' }))
+}
+
+describe('buildReport onset-sequence parity — NOTE axis (SV61, deterministic)', () => {
+  it('checks notes on deterministic pieces (notesChecked=true) and matches identical note sequences', () => {
+    const seq: Array<[number, number]> = [[0, 60], [1, 62], [2, 64], [3, 65], [4, 67]]
+    const r = buildReport(atN('sonic-pi-tb303', seq), atN('sonic-pi-tb303', seq), 'play 60')
+    expect(r.sequenceParity.notesChecked).toBe(true)
+    expect(r.sequenceParity.match).toBe(true)
+    expect(r.sequenceParity.rows[0].noteMatched).toBe(true)
+  })
+
+  it('is order-invariant WITHIN a simultaneous cluster (octave stack) — the #378 fix', () => {
+    // bizet plays two beeps per tick (look, look-12). The intra-tick serialisation
+    // order is arbitrary per engine and inaudible; only the per-tick SET is musical.
+    const d = atN('sonic-pi-tb303', [[0, 60], [0, 48], [1, 62], [1, 50], [2, 64], [2, 52]])
+    const w = atN('sonic-pi-tb303', [[0, 48], [0, 60], [1, 50], [1, 62], [2, 52], [2, 64]]) // reordered within tick
+    const r = buildReport(d, w, 'play 60')
+    expect(r.sequenceParity.match).toBe(true)
+    expect(r.sequenceParity.rows[0].noteMatched).toBe(true)
+  })
+
+  // ── THE HOLE THIS CLOSES (negative control) ─────────────────────────────────
+  it('NEGATIVE CONTROL: same synthdef at the same TIMES but TRANSPOSED notes does NOT promote', () => {
+    const times: Array<[number, number]> = [[0, 60], [1, 62], [2, 64], [3, 65], [4, 67]]
+    const transposed: Array<[number, number]> = times.map(([t, n]) => [t, n + 7]) // up a fifth
+    const r = buildReport(atN('sonic-pi-tb303', times), atN('sonic-pi-tb303', transposed), 'play 60')
+    expect(r.sequenceParity.rows[0].timingMatched).toBe(true) // times identical
+    expect(r.sequenceParity.rows[0].noteMatched).toBe(false) // …but wrong notes
+    expect(r.sequenceParity.match).toBe(false) // → never EVENT-MATCH promoted
+    expect(r.sequenceParity.reasons.join(' ')).toMatch(/wrong notes|transposition/)
+  })
+
+  it('does NOT check notes on PRNG pieces (notesChecked=false) — SV49, values vary by construction', () => {
+    // Same times, different notes, but the source is PRNG → notes are not compared
+    // (the random walk legitimately differs); timing parity still holds.
+    const times: Array<[number, number]> = [[0, 60], [1, 62], [2, 64], [3, 65], [4, 67]]
+    const other: Array<[number, number]> = [[0, 72], [1, 48], [2, 55], [3, 90], [4, 53]]
+    const r = buildReport(atN('sonic-pi-tb303', times), atN('sonic-pi-tb303', other), 's = scale(:c, :major).choose')
+    expect(r.sequenceParity.notesChecked).toBe(false)
+    expect(r.sequenceParity.rows[0].noteMatched).toBeNull()
+    expect(r.sequenceParity.match).toBe(true) // timing matches; notes not a criterion for PRNG
+  })
+})

--- a/tools/__tests__/event-parity-parsers.test.ts
+++ b/tools/__tests__/event-parity-parsers.test.ts
@@ -176,3 +176,87 @@ describe('buildReport verdict', () => {
     expect(r.verdict).toBe('WEB-EMPTY')
   })
 })
+
+// --- onset-SEQUENCE parity (SV61, #377/#378 — the EVENT-MATCH tiebreaker) ----
+//
+// The crux of the tiebreaker: STRUCTURE-MATCH (same layers) is necessary but not
+// sufficient — the layers must also fire at the same TIMES. These tests pin the
+// tolerance model (prefix-compare + ε≈15ms) AND the mandatory negative control
+// (a real mis-timed / dropped layer must STILL diverge — never be promoted).
+
+// onsets at explicit times for one synthdef
+function at(synthdef: string, times: number[]): OscEvent[] {
+  return times.map((t) => sNew(synthdef, t))
+}
+
+describe('buildReport onset-sequence parity (SV61)', () => {
+  it('MATCHES the #378 ch6_binary_bizet pattern: blade @0,2,4… + stereo_player spacing [0,0.5,0.5,0,…]', () => {
+    // Two non-commensurate live_loops; the audio pitch-tracker mis-orders the
+    // dense interleave (false DIVERGE), but per-synthdef onset sequences are
+    // identical desktop↔web — the engine schedules correctly.
+    const blade = [0, 2, 4, 6, 8, 10, 12]
+    const sp = [0, 0, 0.5, 1, 1, 1.5, 2, 2, 2.5, 3]
+    const d = [...at('sonic-pi-blade', blade), ...at('sonic-pi-basic_stereo_player', sp)]
+    const w = [...at('sonic-pi-blade', blade), ...at('sonic-pi-basic_stereo_player', sp)]
+    const r = buildReport(d, w, 'live_loop :bizet do; end\nlive_loop :drums do; end')
+    expect(r.verdict).toBe('STRUCTURE-MATCH')
+    expect(r.sequenceParity.match).toBe(true)
+  })
+
+  it('tolerates desktop ~2ms real-time jitter (1.998 vs 2.0) within ε', () => {
+    const d = at('sonic-pi-tb303', [0, 1.998, 3.997, 5.999])
+    const w = at('sonic-pi-tb303', [0, 2.0, 4.0, 6.0])
+    const r = buildReport(d, w, 'live_loop :a do; end')
+    expect(r.sequenceParity.match).toBe(true)
+    const row = r.sequenceParity.rows.find((s) => s.synthdef === 'sonic-pi-tb303')!
+    expect(row.maxDevMs).toBeLessThanOrEqual(15)
+  })
+
+  it('PREFIX-compares: web captures one fewer cycle (cold-start trim) — not penalised', () => {
+    const d = at('sonic-pi-tb303', [0, 2, 4, 6, 8, 10, 12]) // desktop last @12
+    const w = at('sonic-pi-tb303', [0, 2, 4, 6, 8, 10]) // web trimmed @10
+    const r = buildReport(d, w, 'live_loop :a do; end')
+    expect(r.sequenceParity.match).toBe(true)
+    const row = r.sequenceParity.rows.find((s) => s.synthdef === 'sonic-pi-tb303')!
+    expect(row.comparedLen).toBe(6) // common prefix only
+  })
+
+  // ── NEGATIVE CONTROL (MANDATORY, SV50) — a real bug must STILL diverge ──────
+  it('NEGATIVE CONTROL: a mis-timed loop period (2.0 vs 2.5) does NOT promote — sequenceParity.match=false', () => {
+    // Layers match (STRUCTURE-MATCH) but web runs the loop ~25% slow. The very
+    // first cycle already exceeds ε; deviation then grows unbounded. A tiebreaker
+    // that promoted this would mask a real engine timing bug.
+    const d = at('sonic-pi-tb303', [0, 2, 4, 6, 8])
+    const w = at('sonic-pi-tb303', [0, 2.5, 5, 7.5, 10])
+    const r = buildReport(d, w, 'live_loop :a do; end')
+    expect(r.verdict).toBe('STRUCTURE-MATCH') // same layer multiset
+    expect(r.sequenceParity.match).toBe(false) // …but timing diverges → real bug
+    expect(r.sequenceParity.reasons.join(' ')).toMatch(/mis-timed/)
+  })
+
+  it('NEGATIVE CONTROL: a single mis-timed onset (one beat fires 80ms late) still diverges', () => {
+    // Survives rebasing (a pure constant offset would not) — models a real
+    // dropped/late beat. Anchored at 0 on both sides; the 3rd onset is late.
+    const d = at('sonic-pi-tb303', [0, 1, 2, 3, 4])
+    const w = at('sonic-pi-tb303', [0, 1, 2.08, 3, 4])
+    const r = buildReport(d, w, 'live_loop :a do; end')
+    expect(r.sequenceParity.match).toBe(false)
+    const row = r.sequenceParity.rows.find((s) => s.synthdef === 'sonic-pi-tb303')!
+    expect(row.firstMismatchIdx).toBe(2)
+  })
+
+  it('NEGATIVE CONTROL: a dropped significant layer is STRUCTURE-DIVERGE (never reaches event-match)', () => {
+    const d = [...at('sonic-pi-mod_saw', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), ...at('sonic-pi-beep', [0, 1, 2, 3, 4])]
+    const w = at('sonic-pi-mod_saw', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) // beep dropped
+    const r = buildReport(d, w, 'live_loop :a do; end')
+    expect(r.verdict).toBe('STRUCTURE-DIVERGE')
+  })
+
+  it('returns match=null (not false) when there is no judgeable shared significant layer', () => {
+    // Below the significance floor (≥3 and ≥5% of side total) → cannot judge.
+    const d = at('sonic-pi-tb303', [0, 5])
+    const w = at('sonic-pi-tb303', [0, 5])
+    const r = buildReport(d, w, 'play 60')
+    expect(r.sequenceParity.match).toBeNull()
+  })
+})

--- a/tools/build-aggregate-index.ts
+++ b/tools/build-aggregate-index.ts
@@ -46,7 +46,7 @@ const esc = (s: unknown) => String(s ?? '').replace(/&/g, '&amp;').replace(/</g,
 // ── Manifest shapes (only the fields we read) ──────────────────────────────
 interface PitchManifest {
   generatedAt?: string
-  counts: { match: number; diverge: number; prngVariant: number; invalid: number; inconcl: number; error: number; engineSilent?: number; toolFail?: number; prng: number; prngFreeReal: number; heavy: number; totalRows: number }
+  counts: { match: number; eventMatch?: number; diverge: number; prngVariant: number; invalid: number; inconcl: number; error: number; engineSilent?: number; toolFail?: number; prng: number; prngFreeReal: number; heavy: number; totalRows: number }
 }
 interface ConsistencyManifest {
   generatedAt?: string
@@ -95,6 +95,7 @@ function pitchCard(title: string, count: number, viewer: string, m: PitchManifes
   // PRNG-free actionable divergences are the launch-relevant number.
   const chips = [
     chip('MATCH', c.match, 'pass'),
+    chip('EVENT-MATCH', c.eventMatch ?? 0, 'pass'), // SV61 tiebreaker pass (#377/#378)
     chip('PRNG-variant', c.prngVariant, 'accent'),
     chip('DIVERGE', c.diverge, 'fail'),
     chip('INCONCL', c.inconcl, 'incon'),

--- a/tools/build-examples-sweep.ts
+++ b/tools/build-examples-sweep.ts
@@ -75,7 +75,7 @@ interface SweepRow {
   category: string
   example: string
   path: string
-  verdict: 'match' | 'diverge' | 'prng-variant' | 'invalid' | 'inconcl' | 'error' | 'engine-silent' | 'tool-fail'
+  verdict: 'match' | 'event-match' | 'diverge' | 'prng-variant' | 'invalid' | 'inconcl' | 'error' | 'engine-silent' | 'tool-fail'
   verdictRaw: string
   tempoDesktop: number | null
   tempoWeb: number | null
@@ -157,9 +157,16 @@ function parseReport(reportPath: string): Partial<SweepRow> {
   const verdictLine = md.match(/^###\s+(.+)$/m)
   if (verdictLine) {
     row.verdictRaw = verdictLine[1].trim()
+    // SV61 (#377/#378): EVENT-MATCH MUST be matched FIRST. Its headline QUOTES
+    // the superseded audio verdict (e.g. `…said "PITCH DIVERGENCE at note 2…"`),
+    // so the PITCH DIVERGENCE / inconclusive branches below would mis-route it if
+    // they ran first. EVENT-MATCH = the /s_new onset-sequence parity tiebreaker
+    // promoted a false audio DIVERGE/INCONCL to a pass (engine plays the right
+    // notes at the right times; residual is stage-7 rendering / tracker noise).
+    if (/^✅ EVENT-MATCH\b/.test(row.verdictRaw)) row.verdict = 'event-match'
     // #371: match ERROR before INVALID — the ERROR header contains "❌" too,
     // and the ERROR root cause must NOT be re-bucketed as a generic INVALID.
-    if (/^❌ ERROR\b/.test(row.verdictRaw) || /\bERROR\b — Web engine threw/.test(row.verdictRaw)) row.verdict = 'error'
+    else if (/^❌ ERROR\b/.test(row.verdictRaw) || /\bERROR\b — Web engine threw/.test(row.verdictRaw)) row.verdict = 'error'
     else if (/PRNG-VARIANT/.test(row.verdictRaw)) row.verdict = 'prng-variant'
     else if (/PITCH-MATCH/.test(row.verdictRaw)) row.verdict = 'match'
     else if (/PITCH DIVERGENCE/.test(row.verdictRaw)) {
@@ -386,6 +393,7 @@ for (const examplePath of EXAMPLES) {
 // Counts and the headline sweep metadata
 const counts = {
   match: rows.filter(r => r.verdict === 'match').length,
+  eventMatch: rows.filter(r => r.verdict === 'event-match').length, // SV61 tiebreaker pass
   diverge: rows.filter(r => r.verdict === 'diverge').length,
   prngVariant: rows.filter(r => r.verdict === 'prng-variant').length,
   invalid: rows.filter(r => r.verdict === 'invalid').length,
@@ -429,7 +437,7 @@ if (existsSync(VIEWER_HTML)) {
 }
 
 console.log(`✓ Built ${rows.length} entries → ${OUT_JSON}`)
-console.log(`  match=${counts.match} · prng-variant=${counts.prngVariant} · diverge=${counts.diverge} · invalid=${counts.invalid} · inconcl=${counts.inconcl} · error=${counts.error}`)
+console.log(`  match=${counts.match} · event-match=${counts.eventMatch} · prng-variant=${counts.prngVariant} · diverge=${counts.diverge} · invalid=${counts.invalid} · inconcl=${counts.inconcl} · error=${counts.error}`)
 console.log(`  PRNG-driven=${counts.prng} · PRNG-free real divergences=${counts.prngFreeReal} (the actionable backlog) · heavy-tool-fail=${counts.heavy}`)
 const missingDesk = rows.filter(r => !r.artifacts.desktopWav).length
 const missingWeb = rows.filter(r => !r.artifacts.webWav).length

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -33,6 +33,9 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs'
 import { resolve, dirname, basename } from 'path'
 import { fileURLToPath } from 'url'
 import { spawn } from 'child_process'
+import { captureDesktopEvents } from './lib/desktop-events.ts'
+import { captureWebEvents } from './lib/web-events.ts'
+import { buildReport, type ParityReport } from './event-parity.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const CAPTURES_DIR = resolve(__dirname, '../.captures')
@@ -186,6 +189,22 @@ interface ComparisonResult {
   // yield a Tier-1 verdict (MATCH / PRNG-VARIANT) instead of an automatic
   // INCONCL. Populated only in the asymmetric case; null otherwise.
   reconciledPitch?: { desktop: PitchTrack | null; web: PitchTrack | null } | null
+  // Event-parity tiebreaker (SV61, #377/#378). Acquired ONLY on a DETERMINISTIC
+  // piece whose audio Tier-1 verdict is DIVERGE/INCONCL. The authoritative
+  // cross-engine correctness check is per-synthdef /s_new onset-sequence parity
+  // (the engine's deterministic output terminates at the OSC emission,
+  // server.rb:345,672 — audio is the lossy stage-7+ layer where the pitch
+  // tracker false-DIVERGEs). null when not applicable / not acquired / failed.
+  eventParity?: EventParityInfo | null
+}
+
+interface EventParityInfo {
+  report: ParityReport
+  // The EVENT-MATCH promotion decision is computed in writeComparisonReport (it
+  // needs the audio Tier-1 verdict, which lives there). This carries the raw
+  // event-parity result + a one-line note for the headline + diagnostics.
+  note: string
+  error?: string
 }
 
 function writeComparisonReport(r: ComparisonResult): void {
@@ -500,6 +519,30 @@ function writeComparisonReport(r: ComparisonResult): void {
     t1.push(`- ⚠ pitch-track unavailable (desktop=${dp ? 'ok' : 'none'}, web=${wp ? 'ok' : 'none'}) — Tier 1 verdict cannot be formed`)
   }
 
+  // ── Event-parity tiebreaker (SV61, #377/#378) ──────────────────────────────
+  // "Did the engine play the right notes?" is decided at desktop's /s_new
+  // EMISSION boundary (stages 1-6: eval→play→normalize→BPM-scale→trigger→bundle,
+  // server.rb:345,672,723) — NOT in the audio. So when the audio comparator
+  // flags a Tier-1 pitch DIVERGE/INCONCL on a DETERMINISTIC piece, the
+  // authoritative check is per-synthdef /s_new onset-sequence parity. A
+  // STRUCTURE-MATCH + onset-sequence MATCH means the engine emitted the right
+  // notes at the right times; the audio divergence is stage-7 scsynth-WASM-vs-
+  // native rendering (#417/#268/#273) or pitch-tracker noise (#453/#379/#378) —
+  // neither an engine bug. This supersedes the per-sub-class heuristics (#444
+  // PRNG-only, #428 projections, #377 multiLoopPhaseDrift) with ONE
+  // method-independent boundary check.
+  //
+  // It only PROMOTES a ✗/⚠ audio verdict (never demotes a ✓/≈), and only when
+  // BOTH structure AND onset sequences match — so a real mis-timed/dropped layer
+  // (sequenceParity.match=false / STRUCTURE-DIVERGE) is NEVER promoted (SV50).
+  let eventMatchPromoted = false
+  const ep = r.eventParity
+  const audioWasNonMatch = pitchVerdict.startsWith('✗') || pitchVerdict.startsWith('⚠')
+  if (ep && !ep.error && audioWasNonMatch && !invalid && !webEngineError && webNoWavClass === null) {
+    const epr = ep.report
+    if (epr.verdict === 'STRUCTURE-MATCH' && epr.sequenceParity.match === true) eventMatchPromoted = true
+  }
+
   // Headline verdict
   const softNote = aggregatesUnreliable ? '  · ⚠ Tier-0 SOFT: level/count aggregates unreliable (Tier 1 pitch unaffected)' : ''
   lines.push('## Verdict')
@@ -525,6 +568,13 @@ function writeComparisonReport(r: ComparisonResult): void {
     lines.push(`### ✅ Tier 1 ${pitchVerdict}  (the musical-correctness verdict)${softNote}`)
   } else if (pitchVerdict.startsWith('≈')) {
     lines.push(`### ≈ Tier 1 PRNG-VARIANT — musically equivalent (same composition, different random walk). ${pitchVerdict.slice(2)}${softNote}`)
+  } else if (eventMatchPromoted) {
+    // SV61 (#377/#378): the audio Tier-1 said DIVERGE/INCONCL, but per-synthdef
+    // /s_new onset-sequence parity STRUCTURE-MATCHES — the engine emitted the
+    // right notes at the right times. The audio divergence is stage-7 rendering
+    // or tracker noise, not an engine bug.
+    const audioSaid = pitchVerdict.replace(/^[✗⚠]\s*/, '')
+    lines.push(`### ✅ EVENT-MATCH — per-synthdef \`/s_new\` onset-sequence parity STRUCTURE-MATCHES desktop (SV61): the engine emitted the right notes at the right times. The audio Tier-1 said _"${audioSaid}"_, but that measures stage-7+ scsynth DSP (WASM-vs-native rendering / pitch-tracker noise), not the engine. Authoritative cross-engine check passes.${softNote}`)
   } else if (pitchVerdict.startsWith('✗')) {
     lines.push(`### ❌ Tier 1 ${pitchVerdict}  (musical correctness FAILED — Tier 2/3 cannot override this)`)
   } else {
@@ -544,6 +594,37 @@ function writeComparisonReport(r: ComparisonResult): void {
   lines.push('### Tier 1 — Musical correctness (THE verdict — energy/MFCC may never override)')
   for (const v of t1) lines.push(v)
   lines.push('')
+
+  // Event-parity tiebreaker section (SV61) — only present when acquired.
+  if (ep) {
+    lines.push('### Tier 1.0 — Event parity (`/s_new` onset-sequence vs desktop — SV61 authoritative tiebreaker)')
+    if (ep.error) {
+      lines.push(`- ⚠ event-parity acquisition failed: ${ep.error}`)
+    } else {
+      const epr = ep.report
+      const sp = epr.sequenceParity
+      const spWord = sp.match === null ? 'N/A (no judgeable shared layer)' : sp.match ? '✓ MATCH' : '✗ DIVERGE'
+      lines.push(`- **Structure (synthdef multiset):** ${epr.verdict} — desktop ${epr.desktopTotal} voice \`/s_new\`, web ${epr.webTotal}`)
+      lines.push(`- **Onset sequence (ε=${sp.epsilonMs}ms, prefix-compared):** ${spWord}`)
+      for (const row of sp.rows) {
+        const ic = row.comparedLen === 0 ? '◦' : row.matched ? '✓' : '✗'
+        const detail = row.comparedLen === 0
+          ? 'no comparable onsets'
+          : row.matched
+            ? `${row.comparedLen} onsets within ε (max Δ ${row.maxDevMs}ms)`
+            : `mismatch @onset #${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+        lines.push(`  - ${ic} \`${row.synthdef.replace(/^sonic-pi-/, '')}\` — ${detail}`)
+      }
+      if (eventMatchPromoted) {
+        lines.push(`- ✅ **EVENT-MATCH:** structure + onset sequences both match — the engine's deterministic output (stages 1-6, terminating at the OSC emission) is correct. The audio Tier-1 divergence is stage-7+ scsynth rendering or tracker noise, not an engine bug (SV61; #453/#379/#378 class).`)
+      } else if (epr.verdict === 'STRUCTURE-MATCH' && sp.match === false) {
+        lines.push(`- ❌ **NOT event-match:** layers match but onset timing diverges — a REAL engine timing bug (the audio DIVERGE stands).`)
+      } else if (epr.verdict !== 'STRUCTURE-MATCH') {
+        lines.push(`- ❌ **NOT event-match:** ${epr.verdict} — ${epr.reasons[0] ?? 'structure differs'} (real engine divergence; the audio verdict stands).`)
+      }
+    }
+    lines.push('')
+  }
   lines.push('### Tier 3 — Level / gain (reported; NOT a musical-correctness blocker — known ~0.5× web gain-staging)')
   if (aggregatesUnreliable) lines.push('> ⚠ Tier-0 SOFT failed — these ratios span misaligned windows; treat as indicative only.')
   if (dStats && wStats) {
@@ -815,6 +896,54 @@ async function main(): Promise<void> {
     reconciledPitch = { desktop: dRec, web: wRec }
   }
 
+  // ── Event-parity tiebreaker acquisition (SV61, #377/#378) ──────────────────
+  // On a DETERMINISTIC piece whose audio Tier-1 verdict is NOT a clean match,
+  // acquire the authoritative per-synthdef /s_new onset-sequence parity (a
+  // separate, lightweight event capture — no audio). Gated tightly so the cost
+  // (one extra desktop+web run) is paid ONLY on the rows that need a tiebreaker:
+  //   • deterministic only — PRNG rows are an SV49 non-goal (excluded), and a
+  //     different random walk legitimately changes the event stream too.
+  //   • both WAVs present — an INVALID/missing-WAV row is not a DIVERGE/INCONCL
+  //     the event layer can rescue.
+  //   • audio NOT a clean match — a clean PITCH-MATCH needs no tiebreaker.
+  // Over-triggering is SAFE: the tiebreaker only PROMOTES a STRUCTURE+sequence
+  // match; if it doesn't match, the original audio verdict stands (SV50).
+  const PRNG_RE = /(\b(?:rrand|rrand_i|rand|rand_i|one_in|dice|use_random_seed)\b|\.(?:choose|shuffle|pick)\b|\b(?:choose|shuffle|pick)\s*\()/
+  const isDeterministic = !PRNG_RE.test(args.code)
+  const audioNotCleanMatch = (): boolean => {
+    if (!desktopPitch || !webPitch) return false // verdict is INVALID, not DIVERGE/INCONCL
+    if (desktopPitch.inconclusive || webPitch.inconclusive) return true
+    if (desktopPitch.method !== webPitch.method) return true // method asymmetry → INCONCL (#376)
+    const pc = desktopPitch.compare === 'pitch_class' || webPitch.compare === 'pitch_class'
+    const dSeq = (pc ? desktopPitch.pc : desktopPitch.midi).filter(x => x !== null) as number[]
+    const wSeq = (pc ? webPitch.pc : webPitch.midi).filter(x => x !== null) as number[]
+    const n = Math.min(dSeq.length, wSeq.length)
+    if (n === 0) return false
+    for (let i = 0; i < n; i++) if (dSeq[i] !== wSeq[i]) return true // prefix divergence
+    return false
+  }
+  let eventParity: EventParityInfo | null = null
+  if (isDeterministic && desktopStats && webStats && audioNotCleanMatch()) {
+    console.log(`  Audio Tier-1 non-match on a deterministic source — acquiring /s_new event-parity tiebreaker (SV61)...`)
+    try {
+      const [dEv, wEv] = await Promise.all([
+        captureDesktopEvents(args.code, { duration: args.duration }),
+        captureWebEvents(args.code, { duration: args.duration }),
+      ])
+      const report = buildReport(dEv.events, wEv.events, args.code)
+      const sp = report.sequenceParity
+      eventParity = {
+        report,
+        note: `${report.verdict} · onset-seq ${sp.match === null ? 'n/a' : sp.match ? 'match' : 'diverge'} · d${report.desktopTotal}/w${report.webTotal}`,
+      }
+      console.log(`  event-parity: ${eventParity.note}`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      eventParity = { report: null as unknown as ParityReport, note: 'acquisition failed', error: msg }
+      console.log(`  ⚠ event-parity acquisition failed: ${msg}`)
+    }
+  }
+
   const result: ComparisonResult = {
     timestamp: new Date().toISOString(),
     code: args.code,
@@ -826,6 +955,7 @@ async function main(): Promise<void> {
     spectrogramError,
     reportPath,
     reconciledPitch,
+    eventParity,
   }
   writeComparisonReport(result)
 

--- a/tools/compare-desktop-vs-web.ts
+++ b/tools/compare-desktop-vs-web.ts
@@ -605,20 +605,22 @@ function writeComparisonReport(r: ComparisonResult): void {
       const sp = epr.sequenceParity
       const spWord = sp.match === null ? 'N/A (no judgeable shared layer)' : sp.match ? '✓ MATCH' : '✗ DIVERGE'
       lines.push(`- **Structure (synthdef multiset):** ${epr.verdict} — desktop ${epr.desktopTotal} voice \`/s_new\`, web ${epr.webTotal}`)
-      lines.push(`- **Onset sequence (ε=${sp.epsilonMs}ms, prefix-compared):** ${spWord}`)
+      lines.push(`- **Onset sequence (ε=${sp.epsilonMs}ms, prefix-compared${sp.notesChecked ? ', + per-tick NOTE multiset' : ', timing-only — PRNG, SV49'}):** ${spWord}`)
       for (const row of sp.rows) {
         const ic = row.comparedLen === 0 ? '◦' : row.matched ? '✓' : '✗'
         const detail = row.comparedLen === 0
           ? 'no comparable onsets'
-          : row.matched
-            ? `${row.comparedLen} onsets within ε (max Δ ${row.maxDevMs}ms)`
-            : `mismatch @onset #${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+          : !row.timingMatched
+            ? `mis-timed @onset #${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+            : row.noteMatched === false
+              ? `onset times match within ε but per-tick NOTE multiset differs — wrong notes (transposition?)`
+              : `${row.comparedLen} onsets within ε (max Δ ${row.maxDevMs}ms)${row.noteMatched ? ', notes match' : ''}`
         lines.push(`  - ${ic} \`${row.synthdef.replace(/^sonic-pi-/, '')}\` — ${detail}`)
       }
       if (eventMatchPromoted) {
         lines.push(`- ✅ **EVENT-MATCH:** structure + onset sequences both match — the engine's deterministic output (stages 1-6, terminating at the OSC emission) is correct. The audio Tier-1 divergence is stage-7+ scsynth rendering or tracker noise, not an engine bug (SV61; #453/#379/#378 class).`)
       } else if (epr.verdict === 'STRUCTURE-MATCH' && sp.match === false) {
-        lines.push(`- ❌ **NOT event-match:** layers match but onset timing diverges — a REAL engine timing bug (the audio DIVERGE stands).`)
+        lines.push(`- ❌ **NOT event-match:** layers match but the onset sequence (timing or per-tick notes) diverges — a REAL engine bug (the audio DIVERGE stands).`)
       } else if (epr.verdict !== 'STRUCTURE-MATCH') {
         lines.push(`- ❌ **NOT event-match:** ${epr.verdict} — ${epr.reasons[0] ?? 'structure differs'} (real engine divergence; the audio verdict stands).`)
       }

--- a/tools/event-parity.ts
+++ b/tools/event-parity.ts
@@ -123,9 +123,16 @@ export interface OnsetSeqRow {
   desktopOnsets: number[]
   webOnsets: number[]
   comparedLen: number // common-prefix length actually compared
-  matched: boolean
-  firstMismatchIdx: number // -1 when matched (or nothing to compare)
+  timingMatched: boolean // onset TIMES match within ε over the prefix
+  firstMismatchIdx: number // -1 when timing matched (or nothing to compare)
   maxDevMs: number // largest |Δ| over the compared prefix, in ms
+  // NOTE-value parity per timetag (deterministic pieces only — SV49: PRNG VALUES
+  // are expected to differ, so notes are NOT checked when isPrng). null = not
+  // checked (PRNG, or nothing to compare). false = same synthdef fires at the
+  // same times but with DIFFERENT notes (a real transposition/wrong-note bug).
+  noteMatched: boolean | null
+  // matched = timingMatched AND (noteMatched !== false). The promotion gate.
+  matched: boolean
 }
 
 export interface SequenceParity {
@@ -133,6 +140,7 @@ export interface SequenceParity {
   // a tiebreaker must NOT promote on null (conservative — SV50 discipline).
   match: boolean | null
   epsilonMs: number
+  notesChecked: boolean // false for PRNG pieces (SV49 — values expected to differ)
   rows: OnsetSeqRow[]
   reasons: string[]
 }
@@ -225,83 +233,138 @@ const ONSET_GAP_SEC = 3
 // PREFIX-compare below (not full-length) absorbs the cold-start window-trim.
 const ONSET_EPS_SEC = 0.015
 
-/** Voice-only /s_new onsets per synthdef, sorted ascending. FX/infra excluded
- *  (same `classify` partition the multiset diff uses); null tRel (immediate,
- *  unscheduled) dropped — only scheduled onsets are comparable across engines. */
-function voiceOnsetsBySynthdef(events: OscEvent[]): Record<string, number[]> {
-  const out: Record<string, number[]> = {}
+interface VoiceEvent { t: number; note: number | null }
+
+/** Voice-only /s_new {time, note} per synthdef, sorted by (time, note). FX/infra
+ *  excluded (same `classify` partition the multiset diff uses); null tRel
+ *  (immediate, unscheduled) dropped — only scheduled events are comparable. The
+ *  secondary sort by note canonicalises the order WITHIN a simultaneous cluster
+ *  (e.g. bizet plays two octave-stacked beeps at one tick) so the two engines'
+ *  intra-tick serialisation order — which is musically inaudible and arbitrary —
+ *  does not register as a divergence. */
+function voiceEventsBySynthdef(events: OscEvent[]): Record<string, VoiceEvent[]> {
+  const out: Record<string, VoiceEvent[]> = {}
   for (const e of events) {
     if (e.addr !== '/s_new' || !e.synthdef || e.tRel === null) continue
     if (classify(e.synthdef) !== 'voice') continue
-    ;(out[e.synthdef] ??= []).push(e.tRel)
+    const note = typeof e.params?.note === 'number' ? (e.params.note as number) : null
+    ;(out[e.synthdef] ??= []).push({ t: e.tRel, note })
   }
-  for (const k of Object.keys(out)) out[k].sort((a, b) => a - b)
+  for (const k of Object.keys(out))
+    out[k].sort((a, b) => a.t - b.t || (a.note ?? 0) - (b.note ?? 0))
   return out
+}
+
+// Bucket width for grouping near-simultaneous onsets into one "tick" when
+// comparing the per-tick NOTE multiset. Wider than ε so jitter never splits a
+// cluster, far below any musical inter-onset gap.
+const TICK_BUCKET_SEC = 0.02
+
+/** The sorted multiset of notes at each time-bucket, as a comparable string key
+ *  per bucket index (buckets ordered by time). */
+function noteBucketsByTime(evs: VoiceEvent[]): string[] {
+  const m = new Map<number, number[]>()
+  for (const e of evs) {
+    const k = Math.round(e.t / TICK_BUCKET_SEC)
+    if (!m.has(k)) m.set(k, [])
+    m.get(k)!.push(e.note ?? NaN)
+  }
+  return [...m.keys()].sort((a, b) => a - b).map((k) =>
+    JSON.stringify(m.get(k)!.slice().sort((a, b) => a - b)),
+  )
 }
 
 /**
  * Onset-SEQUENCE parity (SV61). For every SIGNIFICANT layer present on BOTH sides
- * (a dropped layer is already a STRUCTURE-DIVERGE; per-onset timing is only
- * meaningful for shared layers), compare the two sorted onset sequences:
- *  • PREFIX-compare the common-length prefix — web typically captures ~1 fewer
- *    cycle because cold-start warmup (SP22/SV15) trims the fixed wall-clock
- *    window; the shorter tail must NOT be penalised (mirrors the Tier-1 pitch
- *    prefix-compare).
- *  • per-onset match within ε (ONSET_EPS_SEC) to absorb desktop's ~2ms jitter.
- * match===true iff every judged shared layer's prefix matches within ε.
+ * (a dropped layer is already a STRUCTURE-DIVERGE; per-event parity is only
+ * meaningful for shared layers), the engine's deterministic output is verified on
+ * TWO axes:
+ *  1. TIMING — PREFIX-compare the sorted onset times. PREFIX because web captures
+ *     ~1 fewer cycle (cold-start warmup trims the fixed window, SP22/SV15); ε
+ *     (ONSET_EPS_SEC) absorbs desktop's ~2ms real-time jitter.
+ *  2. NOTES — per-timetag note MULTISET equality (deterministic pieces only —
+ *     SV49: PRNG note VALUES are expected to differ). This closes the hole that
+ *     timing+structure alone leaves: a real transposition bug (same synthdef at
+ *     the same times, WRONG notes) would otherwise be falsely EVENT-MATCHed.
+ *     Compared as multisets-per-tick because simultaneous onsets (octave stacks)
+ *     have arbitrary intra-tick order on each engine — only the set is musical.
+ * matched = timingMatched AND noteMatched !== false.
  * match===null when there is no judgeable shared significant layer.
  */
 function computeSequenceParity(
   desktop: OscEvent[],
   web: OscEvent[],
   rows: SynthRow[],
+  checkNotes: boolean,
   eps = ONSET_EPS_SEC,
 ): SequenceParity {
-  const dOn = voiceOnsetsBySynthdef(desktop)
-  const wOn = voiceOnsetsBySynthdef(web)
+  const dEv = voiceEventsBySynthdef(desktop)
+  const wEv = voiceEventsBySynthdef(web)
   const shared = rows.filter(
     (r) => r.significant && r.status !== 'only-desktop' && r.status !== 'only-web',
   )
   const seqRows: OnsetSeqRow[] = []
   const reasons: string[] = []
   for (const r of shared) {
-    const d = dOn[r.synthdef] ?? []
-    const w = wOn[r.synthdef] ?? []
-    const len = Math.min(d.length, w.length)
+    const d = dEv[r.synthdef] ?? []
+    const w = wEv[r.synthdef] ?? []
+    const dT = d.map((e) => e.t)
+    const wT = w.map((e) => e.t)
+    const len = Math.min(dT.length, wT.length)
+    // Axis 1 — timing.
     let firstMismatchIdx = -1
     let maxDevMs = 0
     for (let i = 0; i < len; i++) {
-      const devMs = Math.abs(d[i] - w[i]) * 1000
+      const devMs = Math.abs(dT[i] - wT[i]) * 1000
       if (devMs > maxDevMs) maxDevMs = devMs
       if (devMs > eps * 1000 && firstMismatchIdx < 0) firstMismatchIdx = i
     }
-    const matched = len > 0 && firstMismatchIdx < 0
+    const timingMatched = len > 0 && firstMismatchIdx < 0
+    // Axis 2 — notes (deterministic only). Per-tick multiset over the common
+    // prefix of buckets.
+    let noteMatched: boolean | null = null
+    if (checkNotes && len > 0) {
+      const dB = noteBucketsByTime(d)
+      const wB = noteBucketsByTime(w)
+      const bn = Math.min(dB.length, wB.length)
+      let ok = bn > 0
+      for (let i = 0; i < bn; i++) if (dB[i] !== wB[i]) { ok = false; break }
+      noteMatched = ok
+    }
+    const matched = timingMatched && noteMatched !== false
     seqRows.push({
       synthdef: r.synthdef,
-      desktopOnsets: d,
-      webOnsets: w,
+      desktopOnsets: dT,
+      webOnsets: wT,
       comparedLen: len,
-      matched,
+      timingMatched,
       firstMismatchIdx,
       maxDevMs: Math.round(maxDevMs * 10) / 10,
+      noteMatched,
+      matched,
     })
     if (len === 0) {
       reasons.push(`${short(r.synthdef)}: no scheduled onsets to compare on one side`)
-    } else if (!matched) {
+    } else if (!timingMatched) {
       const i = firstMismatchIdx
       reasons.push(
-        `${short(r.synthdef)}: onset #${i} desktop ${d[i]}s vs web ${w[i]}s ` +
-          `(Δ ${Math.round(Math.abs(d[i] - w[i]) * 1000)}ms > ${eps * 1000}ms ε) — mis-timed layer`,
+        `${short(r.synthdef)}: onset #${i} desktop ${dT[i]}s vs web ${wT[i]}s ` +
+          `(Δ ${Math.round(Math.abs(dT[i] - wT[i]) * 1000)}ms > ${eps * 1000}ms ε) — mis-timed layer`,
+      )
+    } else if (noteMatched === false) {
+      reasons.push(
+        `${short(r.synthdef)}: onset times match but per-tick NOTE multiset differs — wrong notes (transposition?)`,
       )
     } else {
       reasons.push(
-        `${short(r.synthdef)}: ${len} onsets match within ε (max Δ ${seqRows[seqRows.length - 1].maxDevMs}ms)`,
+        `${short(r.synthdef)}: ${len} onsets match within ε (max Δ ${Math.round(maxDevMs * 10) / 10}ms)` +
+          `${noteMatched ? ', notes match' : ''}`,
       )
     }
   }
   const judged = seqRows.filter((s) => s.comparedLen > 0)
   const match = judged.length === 0 ? null : judged.every((s) => s.matched)
-  return { match, epsilonMs: eps * 1000, rows: seqRows, reasons }
+  return { match, epsilonMs: eps * 1000, notesChecked: checkNotes, rows: seqRows, reasons }
 }
 
 export function buildReport(desktop: OscEvent[], web: OscEvent[], code: string): ParityReport {
@@ -392,7 +455,9 @@ export function buildReport(desktop: OscEvent[], web: OscEvent[], code: string):
     )
 
   // Onset-sequence parity (SV61) — orthogonal to the multiset verdict above.
-  const sequenceParity = computeSequenceParity(desktop, web, rows)
+  // Notes are checked only on deterministic pieces (SV49: PRNG note VALUES differ
+  // by construction; for PRNG we verify timing/structure, not note values).
+  const sequenceParity = computeSequenceParity(desktop, web, rows, !isPrng)
 
   return {
     verdict,
@@ -458,20 +523,22 @@ function printReport(name: string, r: ParityReport): void {
   const sp = r.sequenceParity
   const spIcon = sp.match === null ? '—' : sp.match ? '✓' : '✗'
   const spWord = sp.match === null ? 'N/A (no judgeable shared layer)' : sp.match ? 'MATCH' : 'DIVERGE'
-  console.log(`\nOnset-sequence parity (SV61, ε=${sp.epsilonMs}ms, prefix-compared): ${spIcon} ${spWord}`)
+  console.log(`\nOnset-sequence parity (SV61, ε=${sp.epsilonMs}ms, prefix-compared${sp.notesChecked ? ', +notes' : ', timing-only (PRNG)'}): ${spIcon} ${spWord}`)
   for (const row of sp.rows) {
     const ic = row.comparedLen === 0 ? '—' : row.matched ? '✓' : '✗'
     const detail = row.comparedLen === 0
       ? 'no comparable onsets'
-      : row.matched
-        ? `${row.comparedLen} onsets, max Δ ${row.maxDevMs}ms`
-        : `mismatch @#${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+      : !row.timingMatched
+        ? `mis-timed @#${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+        : row.noteMatched === false
+          ? `times match but NOTES differ (wrong notes)`
+          : `${row.comparedLen} onsets, max Δ ${row.maxDevMs}ms${row.noteMatched ? ', notes ✓' : ''}`
     console.log(`  ${ic} ${short(row.synthdef).padEnd(22)} ${detail}`)
   }
   if (r.verdict === 'STRUCTURE-MATCH' && sp.match === true)
     console.log(`  → EVENT-MATCH eligible: structure + onset sequences both match (engine plays right notes at right times).`)
   else if (r.verdict === 'STRUCTURE-MATCH' && sp.match === false)
-    console.log(`  → NOT event-match: layers match but onset timing diverges — real engine timing bug.`)
+    console.log(`  → NOT event-match: layers match but onset sequence (timing or notes) diverges — real engine bug.`)
 
   console.log(`\nNote: PRNG param VALUES are not diffed (SV49 non-goal). Structure + timing only.`)
   console.log(`A fixed wall-clock window counts more events on the faster-progressing engine;`)

--- a/tools/event-parity.ts
+++ b/tools/event-parity.ts
@@ -101,7 +101,43 @@ interface SynthRow {
   webOnset: number | null
 }
 
-interface ParityReport {
+// ---------------------------------------------------------------------------
+// Onset-SEQUENCE parity (SV61, #377/#378) — the authoritative tiebreaker.
+//
+// The multiset/verdict above answers "does web produce the same LAYERS?". The
+// onset-sequence parity below answers the stricter "does each shared layer fire
+// at the same TIMES?". Together they are the complete statement of the engine's
+// deterministic output (stages 1-6, terminating at the /s_new emission;
+// server.rb:345,672,723) — the layer that the engine OWNS, before scsynth's
+// stage-7+ DSP. Pitch-tracking the WAV measures stage 7+, which sums N voices
+// into one waveform and re-infers fundamentals frame-by-frame, losing per-event
+// identity. THAT loss is the false-DIVERGE class (#453 cymbal, #379 kicks, #378
+// multi-loop interleave). When the audio comparator flags DIVERGE/INCONCL on a
+// deterministic piece but the /s_new structure AND onset sequences match, the
+// engine played the right notes at the right times — the residual is scsynth
+// rendering (#417/#268/#273) or tracker noise, not an engine bug.
+// ---------------------------------------------------------------------------
+
+export interface OnsetSeqRow {
+  synthdef: string
+  desktopOnsets: number[]
+  webOnsets: number[]
+  comparedLen: number // common-prefix length actually compared
+  matched: boolean
+  firstMismatchIdx: number // -1 when matched (or nothing to compare)
+  maxDevMs: number // largest |Δ| over the compared prefix, in ms
+}
+
+export interface SequenceParity {
+  // null = no judgeable shared significant layer (can neither confirm nor deny);
+  // a tiebreaker must NOT promote on null (conservative — SV50 discipline).
+  match: boolean | null
+  epsilonMs: number
+  rows: OnsetSeqRow[]
+  reasons: string[]
+}
+
+export interface ParityReport {
   verdict: 'STRUCTURE-MATCH' | 'STRUCTURE-DIVERGE' | 'DESKTOP-EMPTY' | 'WEB-EMPTY'
   isPrng: boolean
   reasons: string[]
@@ -113,6 +149,12 @@ interface ParityReport {
   orderMatch: boolean
   desktopOrder: string[]
   webOrder: string[]
+  // Per-synthdef onset-sequence parity (SV61). Orthogonal to `verdict` (which is
+  // the multiset structure): a piece can STRUCTURE-MATCH the layers but mis-time
+  // them (wrong loop period) — that is a real engine bug and shows here as
+  // match=false. The EVENT-MATCH tiebreaker requires BOTH STRUCTURE-MATCH and
+  // sequenceParity.match===true.
+  sequenceParity: SequenceParity
 }
 
 // Count tolerance for shared synthdefs (PRNG walks vary run-to-run, SV49).
@@ -173,6 +215,94 @@ function diffCounts(
 // First-onset gap that counts as a gating divergence: a shared layer that
 // starts much later on one side (e.g. cue-gated on desktop, ungated on web).
 const ONSET_GAP_SEC = 3
+
+// Per-onset match tolerance for the onset-SEQUENCE parity (SV61). Desktop
+// schedules in real time and carries ~2ms scheduling jitter (observed on #378:
+// 1.998 vs web's exact 2.0). 15ms sits comfortably above that jitter floor and
+// far below any real timing bug (a wrong loop period drifts UNBOUNDED — the very
+// first cycle already exceeds 15ms, e.g. period 2.0 vs 2.5 ⇒ 500ms at onset 1).
+// Too loose masks real timing bugs; too tight makes jitter a false-DIVERGE. The
+// PREFIX-compare below (not full-length) absorbs the cold-start window-trim.
+const ONSET_EPS_SEC = 0.015
+
+/** Voice-only /s_new onsets per synthdef, sorted ascending. FX/infra excluded
+ *  (same `classify` partition the multiset diff uses); null tRel (immediate,
+ *  unscheduled) dropped — only scheduled onsets are comparable across engines. */
+function voiceOnsetsBySynthdef(events: OscEvent[]): Record<string, number[]> {
+  const out: Record<string, number[]> = {}
+  for (const e of events) {
+    if (e.addr !== '/s_new' || !e.synthdef || e.tRel === null) continue
+    if (classify(e.synthdef) !== 'voice') continue
+    ;(out[e.synthdef] ??= []).push(e.tRel)
+  }
+  for (const k of Object.keys(out)) out[k].sort((a, b) => a - b)
+  return out
+}
+
+/**
+ * Onset-SEQUENCE parity (SV61). For every SIGNIFICANT layer present on BOTH sides
+ * (a dropped layer is already a STRUCTURE-DIVERGE; per-onset timing is only
+ * meaningful for shared layers), compare the two sorted onset sequences:
+ *  • PREFIX-compare the common-length prefix — web typically captures ~1 fewer
+ *    cycle because cold-start warmup (SP22/SV15) trims the fixed wall-clock
+ *    window; the shorter tail must NOT be penalised (mirrors the Tier-1 pitch
+ *    prefix-compare).
+ *  • per-onset match within ε (ONSET_EPS_SEC) to absorb desktop's ~2ms jitter.
+ * match===true iff every judged shared layer's prefix matches within ε.
+ * match===null when there is no judgeable shared significant layer.
+ */
+function computeSequenceParity(
+  desktop: OscEvent[],
+  web: OscEvent[],
+  rows: SynthRow[],
+  eps = ONSET_EPS_SEC,
+): SequenceParity {
+  const dOn = voiceOnsetsBySynthdef(desktop)
+  const wOn = voiceOnsetsBySynthdef(web)
+  const shared = rows.filter(
+    (r) => r.significant && r.status !== 'only-desktop' && r.status !== 'only-web',
+  )
+  const seqRows: OnsetSeqRow[] = []
+  const reasons: string[] = []
+  for (const r of shared) {
+    const d = dOn[r.synthdef] ?? []
+    const w = wOn[r.synthdef] ?? []
+    const len = Math.min(d.length, w.length)
+    let firstMismatchIdx = -1
+    let maxDevMs = 0
+    for (let i = 0; i < len; i++) {
+      const devMs = Math.abs(d[i] - w[i]) * 1000
+      if (devMs > maxDevMs) maxDevMs = devMs
+      if (devMs > eps * 1000 && firstMismatchIdx < 0) firstMismatchIdx = i
+    }
+    const matched = len > 0 && firstMismatchIdx < 0
+    seqRows.push({
+      synthdef: r.synthdef,
+      desktopOnsets: d,
+      webOnsets: w,
+      comparedLen: len,
+      matched,
+      firstMismatchIdx,
+      maxDevMs: Math.round(maxDevMs * 10) / 10,
+    })
+    if (len === 0) {
+      reasons.push(`${short(r.synthdef)}: no scheduled onsets to compare on one side`)
+    } else if (!matched) {
+      const i = firstMismatchIdx
+      reasons.push(
+        `${short(r.synthdef)}: onset #${i} desktop ${d[i]}s vs web ${w[i]}s ` +
+          `(Δ ${Math.round(Math.abs(d[i] - w[i]) * 1000)}ms > ${eps * 1000}ms ε) — mis-timed layer`,
+      )
+    } else {
+      reasons.push(
+        `${short(r.synthdef)}: ${len} onsets match within ε (max Δ ${seqRows[seqRows.length - 1].maxDevMs}ms)`,
+      )
+    }
+  }
+  const judged = seqRows.filter((s) => s.comparedLen > 0)
+  const match = judged.length === 0 ? null : judged.every((s) => s.matched)
+  return { match, epsilonMs: eps * 1000, rows: seqRows, reasons }
+}
 
 export function buildReport(desktop: OscEvent[], web: OscEvent[], code: string): ParityReport {
   const ds = summarize(desktop)
@@ -261,6 +391,9 @@ export function buildReport(desktop: OscEvent[], web: OscEvent[], code: string):
         `web: ${wSig.map(short).join('→')})${isPrng ? ' — common for PRNG layer selection' : ' — thread-start timing'}.`,
     )
 
+  // Onset-sequence parity (SV61) — orthogonal to the multiset verdict above.
+  const sequenceParity = computeSequenceParity(desktop, web, rows)
+
   return {
     verdict,
     isPrng,
@@ -273,6 +406,7 @@ export function buildReport(desktop: OscEvent[], web: OscEvent[], code: string):
     orderMatch,
     desktopOrder: dSig.map(short),
     webOrder: wSig.map(short),
+    sequenceParity,
   }
 }
 
@@ -320,6 +454,25 @@ function printReport(name: string, r: ParityReport): void {
       console.log(`  ${short(row.synthdef).padEnd(22)} ${String(row.desktop).padStart(7)} ${String(row.web).padStart(6)}  ${flag}`)
     }
   }
+  // Onset-sequence parity (SV61) — the stricter "same times?" check.
+  const sp = r.sequenceParity
+  const spIcon = sp.match === null ? '—' : sp.match ? '✓' : '✗'
+  const spWord = sp.match === null ? 'N/A (no judgeable shared layer)' : sp.match ? 'MATCH' : 'DIVERGE'
+  console.log(`\nOnset-sequence parity (SV61, ε=${sp.epsilonMs}ms, prefix-compared): ${spIcon} ${spWord}`)
+  for (const row of sp.rows) {
+    const ic = row.comparedLen === 0 ? '—' : row.matched ? '✓' : '✗'
+    const detail = row.comparedLen === 0
+      ? 'no comparable onsets'
+      : row.matched
+        ? `${row.comparedLen} onsets, max Δ ${row.maxDevMs}ms`
+        : `mismatch @#${row.firstMismatchIdx} (max Δ ${row.maxDevMs}ms)`
+    console.log(`  ${ic} ${short(row.synthdef).padEnd(22)} ${detail}`)
+  }
+  if (r.verdict === 'STRUCTURE-MATCH' && sp.match === true)
+    console.log(`  → EVENT-MATCH eligible: structure + onset sequences both match (engine plays right notes at right times).`)
+  else if (r.verdict === 'STRUCTURE-MATCH' && sp.match === false)
+    console.log(`  → NOT event-match: layers match but onset timing diverges — real engine timing bug.`)
+
   console.log(`\nNote: PRNG param VALUES are not diffed (SV49 non-goal). Structure + timing only.`)
   console.log(`A fixed wall-clock window counts more events on the faster-progressing engine;`)
   console.log(`"DROPPED" = a significant desktop layer web never produces (the robust divergence).`)

--- a/tools/gate-report.ts
+++ b/tools/gate-report.ts
@@ -49,7 +49,12 @@ const sweep = JSON.parse(readFileSync(SWEEP, 'utf8'))
 const rows: SweepRow[] = sweep.entries
 const manifest: Manifest = JSON.parse(readFileSync(MANIFEST, 'utf8'))
 
-const isPass = (v: string) => v === 'match' || v === 'prng-variant' || v === 'prngVariant'
+// SV61 (#377/#378): EVENT-MATCH is a PASS. On a deterministic piece, per-synthdef
+// /s_new onset-sequence parity is the AUTHORITATIVE cross-engine correctness check
+// (the engine's output terminates at the OSC emission, server.rb:345,672; audio is
+// the lossy stage-7+ layer). A STRUCTURE + onset-sequence match means the engine
+// played the right notes at the right times — a real DIVERGE is never promoted.
+const isPass = (v: string) => v === 'match' || v === 'event-match' || v === 'prng-variant' || v === 'prngVariant'
 
 // Denominator: PRNG-free, non-heavy official rows.
 const denom = rows.filter(r => !r.prng && !r.heavy)


### PR DESCRIPTION
## What & why

"Did the engine play the right notes?" is decided at desktop's **`/s_new` emission boundary** (stages 1-6: eval→play→normalize→BPM-scale→trigger→bundle, `server.rb:345,672,723`) — **not** in the audio. Pitch-tracking the WAV measures stage 7+ (DSP→FFT→contour), which sums N voices into one waveform and re-infers fundamentals frame-by-frame, losing per-event identity. **That loss is the false-DIVERGE class:** #453 (cymbal), #379-layer-1 (kicks), #378 (multi-loop interleave) — all STRUCTURE-MATCH at stage 6, all mis-read by the tracker at stage 7+.

This PR makes per-synthdef **`/s_new` onset-SEQUENCE parity** the authoritative, method-independent tiebreaker (vyapti **SV61**), replacing three per-sub-class heuristics (#444 PRNG-only reconciliation, #428 projections, #377 `multiLoopPhaseDrift`) with **one** boundary check.

## How

- **`event-parity.ts`** — `computeSequenceParity()` → `report.sequenceParity`. For every SIGNIFICANT shared layer, compare sorted onset sequences with **PREFIX-compare** (web trims ~1 cold-start cycle, SV15) + **per-onset ε=15ms** (absorbs desktop's ~2ms real-time jitter; far below any real period drift). Orthogonal to the multiset `verdict`, so the diff-matrix consumer is unchanged.
- **`compare-desktop-vs-web.ts`** — on a **deterministic** piece whose audio Tier-1 is DIVERGE/INCONCL, acquire event-parity (separate lightweight capture; happy path skips it). STRUCTURE-MATCH **+** onset-seq match ⇒ headline `### ✅ EVENT-MATCH`. Only **promotes** ✗/⚠ (never demotes ✓/≈); a real mis-timed (`sequenceParity.match=false`) or dropped (STRUCTURE-DIVERGE) layer is **never** promoted (SV50).
- **`build-examples-sweep.ts` / `gate-report.ts` / dashboard** — `event-match` token (parsed FIRST — the headline quotes the superseded audio verdict), counted as a launch-gate PASS, rendered green.

## Test plan (Level-1 → Level-3, observed not inferred)

- **Unit (Level-1):** +8 tests incl. the mandatory **negative controls** (SV50): mis-timed loop period, single late onset, dropped layer — all STILL diverge. Full suite **1168 pass**, `tsc` clean.
- **#378 ch6_binary_bizet (Level-3):** audio said _"✗ PITCH DIVERGENCE at note 0"_ → **EVENT-MATCH** (beep 143 onsets maxΔ1ms, stereo_player 44 onsets maxΔ1ms). Token parses as `event-match`.
- **Negative controls on REAL capture data:** doctored bizet — beep loop 10% slow → onset-seq DIVERGE (Δ1399ms), **not promoted**; dropped stereo_player → STRUCTURE-DIVERGE, **not promoted**.
- **Bonus — the discipline works on real data:** `e2e_03_fx` (#453) onset-seq DIVERGE at beep #5 (Δ299ms) → **not promoted**. Diffing the sequences surfaced a **real** residual: a nested `in_thread` inside `with_fx` forks ~0.3s early on web — an SP118-family bug the audio comparator and coarse event-parity both missed. Filed as **#475**. (So #453's "comparator-side" close was incomplete.)
- **Happy path:** clean PITCH-MATCH skips acquisition entirely — no regression.
- **Gate:** unchanged **5/7 PASS**, differential matrix GREEN (isPass change is additive).

## Notes
- Supersedes #377 (the narrow `multiLoopPhaseDrift` ask) with the general check.
- Recommends closing **#378** onto this (bizet was the canonical false-DIVERGE; now EVENT-MATCH).
- A full official-sweep refresh (to convert deterministic blind rows from projection-graded to directly EVENT-MATCH) is a separate dashboard-refresh chore.

Closes #377
Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)