### PR TITLE
🐛 fix(engine): nested in_thread forks at spawner's cursor, not wall-clock (#475)

### DIFF
--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -213,6 +213,17 @@ export class VirtualTimeScheduler {
     bpm?: number
     synth?: string
     outBus?: number
+    // #475: anchor the new task's start virtual time to a specific cursor
+    // instead of the wall-clock getAudioTime(). A thread spawned mid-run by a
+    // nested `in_thread`/`at` (AudioInterpreter `case 'thread'`) must fork at
+    // the SPAWNING thread's current virtualTime — desktop SP semantics: a child
+    // thread inherits the spawner's clock (in_thread doesn't advance the
+    // spawner). Without this, the child starts at getAudioTime(), which lags
+    // the spawner's logical cursor by ~schedAheadTime → fires ~0.3s early.
+    // Launch-time registrations (top-level live_loop/in_thread via
+    // SonicPiEngine) omit it and keep getAudioTime() — their offset is handled
+    // by the #448 start-gate cue, not here.
+    virtualTime?: number
   }): void {
     const existing = this.tasks.get(name)
     if (existing && existing.running) {
@@ -223,7 +234,7 @@ export class VirtualTimeScheduler {
 
     const task: TaskState = {
       id: name,
-      virtualTime: this.getAudioTime(),
+      virtualTime: options?.virtualTime ?? this.getAudioTime(),
       bpm: options?.bpm ?? 60,
       density: 1,
       currentSynth: options?.synth ?? 'beep',

--- a/src/engine/__tests__/NestedInThreadFork.test.ts
+++ b/src/engine/__tests__/NestedInThreadFork.test.ts
@@ -1,0 +1,179 @@
+/**
+ * #475 — A nested `in_thread` (inside `with_fx` / a loop) must fork at the
+ * SPAWNING thread's current virtual-time cursor, not at the scheduler's
+ * wall-clock getAudioTime().
+ *
+ * Bug (found via the SV61 onset-sequence event-parity tiebreaker on
+ * tests/book-examples/e2e_03_fx.rb):
+ *
+ *   with_fx :distortion do
+ *     in_thread do
+ *       play 48; sleep 0.25; play 50
+ *     end
+ *     play 36; sleep 0.5
+ *   end
+ *
+ * Desktop SP forks the in_thread (48,50) AND runs main `play 36` ALL at the
+ * block cursor (an in_thread does NOT advance the spawning thread's time).
+ * Web's main `play 36` was correct, but the nested in_thread fired ~0.3s EARLY
+ * because `case 'thread'` → `registerLoop` seeded the child's virtualTime from
+ * `getAudioTime()` (wall clock), which lags the spawner's logical cursor by
+ * ~schedAheadTime.
+ *
+ * Root: VirtualTimeScheduler.registerLoop `virtualTime: this.getAudioTime()`.
+ * Fix: AudioInterpreter `case 'thread'` passes `virtualTime: task.virtualTime`
+ * (the spawning thread's cursor) so the child inherits the spawner's clock.
+ *
+ * #448 (top-level in_thread start-gate) is a DIFFERENT code path — top-level
+ * in_thread hoists to a separate gated registration and never reaches
+ * `case 'thread'`. The full suite is the regression guard for that path; the
+ * `at` test below guards the sibling that SHARES `case 'thread'`.
+ *
+ * Observation: the mock bridge's triggerSynth(name, audioTime, params) records
+ * the exact scheduled audioTime per note — a direct, deterministic measurement
+ * of the fork time (no audio hardware needed; the divergence is pure virtual
+ * time). getAudioTime is pinned to 0 while the program sleeps the cursor
+ * forward, so the pre-fix bug manifests as the child firing a full `schedAhead`
+ * + sleep early — same mechanism as the ~0.3s field divergence, exaggerated and
+ * deterministic.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { VirtualTimeScheduler } from '../VirtualTimeScheduler'
+import { ProgramBuilder } from '../ProgramBuilder'
+import { runProgram, type AudioContext as AudioCtx } from '../interpreters/AudioInterpreter'
+import { SoundEventStream } from '../SoundEventStream'
+import type { SuperSonicBridge } from '../SuperSonicBridge'
+import { initTreeSitter, autoTranspile } from '../TreeSitterTranspiler'
+
+async function flushMicrotasks(rounds = 20) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+const SCHED_AHEAD = 100
+
+/** Mock bridge recording per-note scheduled audioTime. */
+function createRecordingBridge(): SuperSonicBridge & { plays: { note: number; t: number }[] } {
+  let nextBus = 16
+  let nextNode = 5000
+  const plays: { note: number; t: number }[] = []
+  return {
+    plays,
+    allocateBus() { return nextBus++ },
+    freeBus() {},
+    async applyFx() { return nextNode++ },
+    async applyFxOrdered() { return nextNode++ },
+    flushImmediateFx() {},
+    freeNode() {},
+    createFxGroup() { return nextNode++ },
+    freeGroup() {},
+    flushMessages() {},
+    async triggerSynth(_name: string, time: number, params: Record<string, number>) {
+      plays.push({ note: params.note as number, t: time })
+      return nextNode++
+    },
+    async playSample() { return nextNode++ },
+    get audioContext() { return null as unknown as AudioContext },
+    send() {},
+    sendTimedControl() {},
+  } as unknown as SuperSonicBridge & { plays: { note: number; t: number }[] }
+}
+
+function makeAudioCtx(scheduler: VirtualTimeScheduler, taskId: string, bridge: SuperSonicBridge): AudioCtx {
+  return {
+    bridge,
+    scheduler,
+    taskId,
+    eventStream: new SoundEventStream(),
+    schedAheadTime: SCHED_AHEAD,
+    nodeRefMap: new Map<number, number>(),
+    reusableFx: new Map(),
+  } as AudioCtx
+}
+
+/** Run a ProgramBuilder program to completion under a pinned (lagging) clock. */
+async function runToCompletion(build: (b: ProgramBuilder) => ProgramBuilder) {
+  const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: SCHED_AHEAD })
+  const bridge = createRecordingBridge()
+  const program = build(new ProgramBuilder(0)).build()
+  scheduler.registerLoop('main', async () => {
+    await runProgram(program, makeAudioCtx(scheduler, 'main', bridge))
+  })
+  // Several ticks + microtask flushes so the main thread AND every child thread
+  // (registered mid-run) run their bodies to completion.
+  for (let i = 0; i < 6; i++) {
+    scheduler.tick(SCHED_AHEAD)
+    await flushMicrotasks()
+  }
+  return bridge.plays
+}
+
+describe('#475 nested in_thread fork timing', () => {
+  it('nested in_thread inside with_fx forks at the spawning cursor, not ~schedAhead early', async () => {
+    // sleep 2 advances the cursor to vt 2; the with_fx block then forks the
+    // in_thread and plays 36, all expected at the SAME audio time (vt 2 + sa).
+    const plays = await runToCompletion((b) =>
+      b
+        .sleep(2)
+        .with_fx('distortion', (fx) =>
+          fx
+            .in_thread((t) => { t.play(48, { release: 0.3 }).sleep(0.25).play(50, { release: 0.3 }) })
+            .play(36, { release: 0.5 })
+            .sleep(0.5)
+        )
+    )
+
+    const p48 = plays.find((p) => p.note === 48)
+    const p50 = plays.find((p) => p.note === 50)
+    const p36 = plays.find((p) => p.note === 36)
+    expect(p48, 'in_thread play 48 should fire').toBeDefined()
+    expect(p50, 'in_thread play 50 should fire').toBeDefined()
+    expect(p36, 'main play 36 should fire').toBeDefined()
+
+    // The block cursor is vt 2; every play schedules at cursor + schedAhead.
+    const blockCursorAudioTime = 2 + SCHED_AHEAD
+
+    // Main thread was always correct.
+    expect(p36!.t).toBeCloseTo(blockCursorAudioTime, 6)
+
+    // THE FIX: the nested in_thread forks at the SAME cursor as its spawner —
+    // 48 fires together with 36, not ~schedAhead (here a full vt-2) early.
+    expect(p48!.t).toBeCloseTo(blockCursorAudioTime, 6)
+    // sleep 0.25 inside the thread → 50 is 0.25 later.
+    expect(p50!.t).toBeCloseTo(blockCursorAudioTime + 0.25, 6)
+
+    // Onset SEQUENCE matches desktop: 48 and 36 simultaneous, then 50.
+    expect(p48!.t).toBeCloseTo(p36!.t, 6)
+    expect(p50!.t).toBeGreaterThan(p36!.t)
+  })
+
+  it('regression: `at` (shares case "thread") still forks at cursor + offset', async () => {
+    // `at 1 do play 72 end` after sleep 2 → fork at vt 2, sleep 1 → play 72 at vt 3.
+    const plays = await runToCompletion((b) =>
+      b.sleep(2).at(1, null, (t) => { (t as ProgramBuilder).play(72) })
+    )
+    const p72 = plays.find((p) => p.note === 72)
+    expect(p72, 'at-block play 72 should fire').toBeDefined()
+    expect(p72!.t).toBeCloseTo(3 + SCHED_AHEAD, 6)
+  })
+
+  it('regression: top-level in_thread does NOT route through case "thread"', async () => {
+    // Guards the #448 path: a top-level in_thread must hoist to a SEPARATE
+    // gated registration (`__startGate`), never an inline `__b.in_thread(...)`
+    // that would reach `case 'thread'`. If this ever changes, the #475 anchor
+    // would silently start interacting with the #448 start-gate.
+    const base = new URL('../../..', import.meta.url).pathname
+    await initTreeSitter({
+      treeSitterWasmUrl: base + 'node_modules/web-tree-sitter/tree-sitter.wasm',
+      rubyWasmUrl: base + 'node_modules/tree-sitter-wasms/out/tree-sitter-ruby.wasm',
+    })
+    const js = autoTranspile(`use_bpm 120
+sleep 2
+in_thread do
+  play 48
+end
+play 36`)
+    // Top-level in_thread is a gated standalone registration, NOT inside __run_once.
+    expect(js).toMatch(/in_thread\(\{\s*__startGate:/)
+    expect(js).not.toMatch(/__run_once[\s\S]*__b\.in_thread/)
+  })
+})

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -504,6 +504,15 @@ export async function runProgram(
           bpm: task.bpm,
           synth: task.currentSynth,
           outBus: task.outBus,
+          // #475: fork at the SPAWNING thread's current cursor, not the
+          // scheduler's wall-clock getAudioTime(). A nested `in_thread`/`at`
+          // reaches this step while `task` is at its logical virtualTime (e.g.
+          // a with_fx block cursor at vt 2.0); getAudioTime() lags that by
+          // ~schedAheadTime, so without this anchor the child fires ~0.3s early
+          // (SP118-family residual — #448's start-gate only covered TOP-LEVEL
+          // in_thread; the nested path forks here). Desktop SP: a child thread
+          // inherits the spawner's clock.
+          virtualTime: task.virtualTime,
         })
         break
       }


### PR DESCRIPTION
Closes #475.

> **Stacked on #476** (base = `feat/377-event-parity-tiebreaker`). #475's verification *uses* the SV61 onset-sequence event-parity tool that #476 ships. GitHub will auto-retarget this PR to `main` once #476 merges. The fix itself is `src/engine/`-only and independent of #476's tooling.

## Problem
A nested `in_thread` (inside `with_fx` / a loop) fired **~0.3s EARLY** on web. In `e2e_03_fx`'s final block:

```ruby
with_fx :distortion do
  in_thread do
    play 48, release: 0.3
    sleep 0.25
    play 50, release: 0.3
  end
  play 36, release: 0.5
  sleep 0.5
end
```

Desktop SP forks the `in_thread` (48, 50) **and** runs main `play 36` all at the block cursor (vt 2.0) — an `in_thread` does not advance the spawning thread's time. Web's `play 36`@2.0 was correct, but the nested `in_thread` forked early (48@1.701, 50@1.826 vs desktop 2.0/2.125).

Found by the **SV61 onset-sequence event-parity tiebreaker** (`✗ DIVERGE @beep#5, Δ299ms`). The audio comparator and the coarse first-onset event-parity both missed it (onsets rebase per-side), so #453's "comparator-side" close of `e2e_03_fx` was incomplete.

## Root cause
`AudioInterpreter` `case 'thread'` → `scheduler.registerLoop(...)` with **no time anchor**. `registerLoop` then seeds the child's `virtualTime` from `getAudioTime()` (the audio wall clock), which lags the spawning task's logical cursor by exactly `schedAheadTime` (`DEFAULT_SCHED_AHEAD_TIME = 0.3`) → the **0.299s** field divergence.

`case 'thread'` is reached **only** by nested `in_thread`/`at` (`ProgramBuilder` pushes a `{tag:'thread'}` step). #448's start-gate fix was **transpiler-only and top-level-only** — a top-level `in_thread` hoists to a separate gated registration and never reaches this path. This is the runtime sibling of SP118.

## Fix
- `VirtualTimeScheduler.registerLoop`: accept an optional `virtualTime?` anchor (defaults to `getAudioTime()` — every launch-time caller unchanged).
- `AudioInterpreter` `case 'thread'`: pass `virtualTime: task.virtualTime` (the spawning task's cursor) so a forked child inherits the spawner's clock — desktop SP semantics.

Safe because `runLoop` suspends at `await scheduleSleep(0)` before the body schedules anything, so the seed is honoured by the child's first `play`. The sibling `at` (shares `case 'thread'`) is corrected by the same anchor.

## Test plan
- **Deterministic differential test** (`NestedInThreadFork.test.ts`): pinned lagging clock; pre-fix the nested play fires at `0+schedAhead` instead of `2+schedAhead` (asserted to fail without the fix), post-fix 48 fires *with* 36 then 50 at +0.25. Includes an `at` regression and a top-level-path guard (asserts a top-level `in_thread` still hoists to `__startGate`, never an inline `__b.in_thread`).
- **Full suite:** 1175 passed; `tsc --noEmit` clean.
- **Level-2/3 desktop↔web** (`tools/event-parity.ts --file tests/book-examples/e2e_03_fx.rb`): onset-seq `✗ DIVERGE @beep#5 Δ299ms` → **`✓ MATCH`** (8 onsets, max Δ 0ms, notes ✓) → **EVENT-MATCH eligible**.

## Catalogue
hetvabhasa **SP127** (runtime sibling of SP118). Follow-up **#477**: wire `report.sequenceParity.match` into `tools/diff-matrix.ts` as a `'timing'` oracle so this class is caught in-grid.