### PR TITLE
🥅 feat(diff-matrix): onset-sequence parity as a 'timing' oracle (#477)

### DIFF
--- a/tools/__tests__/matrix-status.test.ts
+++ b/tools/__tests__/matrix-status.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #477 — the diff-matrix status classifier must flag a mis-timed-but-
+ * count-correct cell as 'timing' via the SV61 onset-sequence signal, so the
+ * #475 class (nested in_thread forking 0.3s early — well below the coarse 3s
+ * first-onset gap) is caught in-grid and blocks the launch gate.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  deriveStatus,
+  isSequenceMistimed,
+  hasCoarseOnsetGap,
+  ONSET_GAP,
+  type StatusCell,
+  type StatusReport,
+} from '../lib/matrix-status.ts'
+
+const row = (o: Partial<StatusReport['rows'][number]> = {}): StatusReport['rows'][number] => ({
+  significant: true,
+  status: 'count-match',
+  desktopOnset: 2.0,
+  webOnset: 2.0,
+  ...o,
+})
+
+const report = (o: Partial<StatusReport> = {}): StatusReport => ({
+  verdict: 'STRUCTURE-MATCH',
+  rows: [row()],
+  sequenceParity: { match: true },
+  ...o,
+})
+
+const cell = (report: StatusReport | null, o: Partial<StatusCell> = {}): StatusCell => ({
+  skip: null,
+  status: 'ok',
+  report,
+  ...o,
+})
+
+describe('#477 matrix status — onset-sequence as a timing oracle', () => {
+  describe('isSequenceMistimed', () => {
+    it('true when sequenceParity.match === false', () => {
+      expect(isSequenceMistimed(report({ sequenceParity: { match: false } }))).toBe(true)
+    })
+    it('false when match === true', () => {
+      expect(isSequenceMistimed(report({ sequenceParity: { match: true } }))).toBe(false)
+    })
+    it('false when match === null (no judgeable layer — SV50 conservative)', () => {
+      expect(isSequenceMistimed(report({ sequenceParity: { match: null } }))).toBe(false)
+    })
+    it('false when sequenceParity absent (pre-#476 results) or report null', () => {
+      expect(isSequenceMistimed(report({ sequenceParity: undefined }))).toBe(false)
+      expect(isSequenceMistimed(null)).toBe(false)
+    })
+  })
+
+  describe('deriveStatus', () => {
+    it("#475 shape: STRUCTURE-MATCH + onset-seq DIVERGE (0.3s, no coarse gap) → 'timing'", () => {
+      // Onsets within ONSET_GAP (no coarse gap) but the fine-grained sequence
+      // parity failed — exactly the signal the 3s heuristic missed.
+      const r = report({
+        rows: [row({ desktopOnset: 2.0, webOnset: 1.7 })], // 0.3s — below ONSET_GAP
+        sequenceParity: { match: false },
+      })
+      expect(hasCoarseOnsetGap(r)).toBe(false) // coarse heuristic alone would say 'match'
+      expect(deriveStatus(cell(r))).toBe('timing')
+    })
+
+    it("well-timed count-match → 'match'", () => {
+      expect(deriveStatus(cell(report()))).toBe('match')
+    })
+
+    it("coarse ≥ONSET_GAP first-onset gap (no seq signal) still → 'timing' (fallback intact)", () => {
+      const r = report({
+        rows: [row({ desktopOnset: 5, webOnset: 5 + ONSET_GAP })],
+        sequenceParity: { match: null }, // unjudgeable — only the coarse gap fires
+      })
+      expect(deriveStatus(cell(r))).toBe('timing')
+    })
+
+    it("STRUCTURE-DIVERGE verdict → 'diverge' (verdict takes precedence)", () => {
+      expect(deriveStatus(cell(report({ verdict: 'STRUCTURE-DIVERGE', sequenceParity: { match: false } })))).toBe('diverge')
+    })
+
+    it("WEB-EMPTY → 'web_empty', DESKTOP-EMPTY → 'desktop_empty'", () => {
+      expect(deriveStatus(cell(report({ verdict: 'WEB-EMPTY' })))).toBe('web_empty')
+      expect(deriveStatus(cell(report({ verdict: 'DESKTOP-EMPTY' })))).toBe('desktop_empty')
+    })
+
+    it("skip → 'skipped', error → 'error', no report → 'pending'", () => {
+      expect(deriveStatus(cell(report(), { skip: 'no-op cell' }))).toBe('skipped')
+      expect(deriveStatus(cell(null, { status: 'error' }))).toBe('error')
+      expect(deriveStatus(cell(null))).toBe('pending')
+    })
+  })
+})

--- a/tools/build-diff-matrix.ts
+++ b/tools/build-diff-matrix.ts
@@ -18,6 +18,7 @@ import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { navBlock } from './lib/dashboard-nav.ts'
 import { CONSTRUCTS, MODIFIERS, POSITIONS, enumerateCells } from './lib/matrix-cells.ts'
+import { deriveStatus, type Derived } from './lib/matrix-status.ts'
 
 // seam is a CLASSIFICATION (recomputed from the live enumeration), not measured
 // data — so the §36-corrected isSeam applies without re-capturing.
@@ -41,6 +42,8 @@ interface ParityReport {
   verdict: string; isPrng: boolean; reasons: string[]; rows: SynthRow[]; fxRows: SynthRow[]
   desktopTotal: number; webTotal: number; totalRatio: number | null
   orderMatch: boolean; desktopOrder: string[]; webOrder: string[]
+  // SV61 onset-sequence parity (#476) — drives the 'timing' status (#477).
+  sequenceParity?: { match: boolean | null } | null
 }
 interface OscEvent { addr: string; synthdef?: string; params: Record<string, number | string>; tRel: number | null }
 interface CellResult {
@@ -61,39 +64,11 @@ const cells = Object.values(rf.cells)
 const byId = new Map(cells.map((c) => [c.id, c]))
 
 // ── status helpers ───────────────────────────────────────────────────────────
-// A "timing" divergence is the §36-Finding-1 blind spot: the event-parity VERDICT
-// keys on a DROPPED layer (count) and only treats a first-onset gap as a
-// supplementary reason — it never flips MATCH→DIVERGE on timing alone. The matrix
-// exists to MEASURE that class, so we recompute a richer status from the stored
-// report: a count-MATCH with a significant shared layer whose first onsets differ
-// by ≥ ONSET_GAP is a TIMING divergence (a real bug the count-verdict hid).
-const ONSET_GAP = 3 // seconds — matches event-parity ONSET_GAP_SEC
-
-type Derived = 'match' | 'diverge' | 'timing' | 'web_empty' | 'desktop_empty' | 'error' | 'skipped' | 'pending'
-
-function deriveStatus(c: CellResult): Derived {
-  if (c.skip) return 'skipped'
-  if (c.status === 'error') return 'error'
-  if (!c.report) return 'pending'
-  if (c.report.verdict === 'STRUCTURE-DIVERGE') return 'diverge'
-  // WEB-EMPTY = web rendered nothing → an engine bug (a divergence). DESKTOP-EMPTY
-  // = desktop produced nothing → a harness/desktop-staleness issue, NOT an engine
-  // bug (flag for re-run, never counts against the engine).
-  if (c.report.verdict === 'WEB-EMPTY') return 'web_empty'
-  if (c.report.verdict === 'DESKTOP-EMPTY') return 'desktop_empty'
-  // STRUCTURE-MATCH → look for a hidden onset/timing gap.
-  const gapped = c.report.rows.some(
-    (r) =>
-      r.significant &&
-      r.status !== 'only-desktop' &&
-      r.status !== 'only-web' &&
-      Number.isFinite(r.desktopOnset as number) &&
-      Number.isFinite(r.webOnset as number) &&
-      Math.abs((r.desktopOnset as number) - (r.webOnset as number)) >= ONSET_GAP,
-  )
-  return gapped ? 'timing' : 'match'
-}
-
+// Classification (incl. the 'timing' blind-spot recompute) lives in the shared
+// tools/lib/matrix-status.ts so the driver and this viewer agree structurally
+// (#477). 'timing' now fires on the SV61 onset-sequence signal (ε=15ms) as well
+// as the coarse ≥ONSET_GAP first-onset gap — catching sub-second mis-timing like
+// the #475 nested-in_thread fork (0.3s) that the coarse gap alone missed.
 const derivedById = new Map(cells.map((c) => [c.id, deriveStatus(c)]))
 
 // 'timing' and 'diverge' are both real bugs per the desktop oracle (the seam read

--- a/tools/diff-matrix.ts
+++ b/tools/diff-matrix.ts
@@ -35,7 +35,7 @@ import { captureDesktopEvents, type OscEvent } from './lib/desktop-events.ts'
 import { captureWebEvents } from './lib/web-events.ts'
 import { buildReport } from './event-parity.ts'
 import { enumerateCells, summarizeCells, type Cell } from './lib/matrix-cells.ts'
-import { isSequenceMistimed } from './lib/matrix-status.ts'
+import { isSequenceMistimed, hasCoarseOnsetGap } from './lib/matrix-status.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -84,13 +84,15 @@ function saveResults(rf: ResultsFile): void {
   writeFileSync(RESULTS, JSON.stringify(rf, null, 2))
 }
 
-// Coarse console/resume status for the driver. The VIEWER (build-diff-matrix.ts
-// → diff-matrix.json) is the gate-authoritative classifier and additionally
-// applies the coarse ≥ONSET_GAP fallback + web/desktop-empty split; the driver
-// shares the SV61 onset-sequence signal (#477) so a mis-timed cell — e.g. the
-// #475 nested-in_thread 0.3s drift — shows '✗ timing' live instead of a false ✓.
+// Console/resume status for the driver. The VIEWER (build-diff-matrix.ts →
+// diff-matrix.json) is the gate-authoritative classifier (it additionally splits
+// web/desktop-empty); the driver shares the SAME 'timing' predicates (#477) so a
+// mis-timed cell — e.g. the #475 nested-in_thread 0.3s drift — shows '✗ timing'
+// live instead of a false ✓, agreeing with the viewer's grid.
 function statusFromReport(report: ReturnType<typeof buildReport>): Status {
-  if (report.verdict === 'STRUCTURE-MATCH') return isSequenceMistimed(report) ? 'timing' : 'match'
+  if (report.verdict === 'STRUCTURE-MATCH') {
+    return isSequenceMistimed(report) || hasCoarseOnsetGap(report) ? 'timing' : 'match'
+  }
   if (report.verdict === 'STRUCTURE-DIVERGE') return 'diverge'
   return 'empty' // DESKTOP-EMPTY / WEB-EMPTY
 }

--- a/tools/diff-matrix.ts
+++ b/tools/diff-matrix.ts
@@ -35,13 +35,14 @@ import { captureDesktopEvents, type OscEvent } from './lib/desktop-events.ts'
 import { captureWebEvents } from './lib/web-events.ts'
 import { buildReport } from './event-parity.ts'
 import { enumerateCells, summarizeCells, type Cell } from './lib/matrix-cells.ts'
+import { isSequenceMistimed } from './lib/matrix-status.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
 const TR = resolve(ROOT, 'test_results')
 const RESULTS = resolve(TR, 'diff-matrix-results.json')
 
-type Status = 'match' | 'diverge' | 'empty' | 'skipped' | 'error'
+type Status = 'match' | 'diverge' | 'timing' | 'empty' | 'skipped' | 'error'
 
 interface CellResult {
   id: string
@@ -83,9 +84,14 @@ function saveResults(rf: ResultsFile): void {
   writeFileSync(RESULTS, JSON.stringify(rf, null, 2))
 }
 
-function statusFromVerdict(v: string): Status {
-  if (v === 'STRUCTURE-MATCH') return 'match'
-  if (v === 'STRUCTURE-DIVERGE') return 'diverge'
+// Coarse console/resume status for the driver. The VIEWER (build-diff-matrix.ts
+// → diff-matrix.json) is the gate-authoritative classifier and additionally
+// applies the coarse ≥ONSET_GAP fallback + web/desktop-empty split; the driver
+// shares the SV61 onset-sequence signal (#477) so a mis-timed cell — e.g. the
+// #475 nested-in_thread 0.3s drift — shows '✗ timing' live instead of a false ✓.
+function statusFromReport(report: ReturnType<typeof buildReport>): Status {
+  if (report.verdict === 'STRUCTURE-MATCH') return isSequenceMistimed(report) ? 'timing' : 'match'
+  if (report.verdict === 'STRUCTURE-DIVERGE') return 'diverge'
   return 'empty' // DESKTOP-EMPTY / WEB-EMPTY
 }
 
@@ -121,7 +127,7 @@ async function runCell(cell: Cell, duration: number): Promise<CellResult> {
     const report = buildReport(dc.events, wc.events, cell.code)
     return {
       ...base,
-      status: statusFromVerdict(report.verdict),
+      status: statusFromReport(report),
       verdict: report.verdict,
       report,
       desktop: dc.events,
@@ -205,8 +211,11 @@ async function main(): Promise<void> {
     const detail =
       res.status === 'error'
         ? `ERROR ${res.error}`
-        : `${res.verdict} (d${res.report?.desktopTotal ?? '?'}/w${res.report?.webTotal ?? '?'})`
-    console.log(`${res.status === 'match' ? '✓' : res.status === 'diverge' ? '✗' : '⚠'} ${detail}`)
+        : res.status === 'timing'
+          ? `${res.verdict} + onset-seq DIVERGE (d${res.report?.desktopTotal ?? '?'}/w${res.report?.webTotal ?? '?'})`
+          : `${res.verdict} (d${res.report?.desktopTotal ?? '?'}/w${res.report?.webTotal ?? '?'})`
+    const icon = res.status === 'match' ? '✓' : res.status === 'diverge' || res.status === 'timing' ? '✗' : '⚠'
+    console.log(`${icon} ${detail}`)
   }
 
   // Final tally over ALL active cells present in results.
@@ -216,15 +225,22 @@ async function main(): Promise<void> {
   console.log(`MATRIX TALLY — ${active.length} active cells captured`)
   console.log(`  ✓ match    ${tally('match')}`)
   console.log(`  ✗ diverge  ${tally('diverge')}`)
+  console.log(`  ✗ timing   ${tally('timing')}`)
   console.log(`  ⚠ empty    ${tally('empty')}`)
   console.log(`  ! error    ${tally('error')}`)
-  const diverged = active.filter((c) => c.status === 'diverge')
+  // Both diverge (dropped layer) and timing (mis-timed layer) are real engine
+  // bugs per the desktop oracle — list both as offenders.
+  const diverged = active.filter((c) => c.status === 'diverge' || c.status === 'timing')
   if (diverged.length) {
     console.log(`\nDIVERGENT cells (real bugs per the desktop oracle):`)
     for (const c of diverged) {
       const seam = c.seam ? '[seam] ' : ''
-      console.log(`  ✗ ${seam}${c.id}`)
-      for (const r of c.report?.reasons ?? []) console.log(`      • ${r}`)
+      const kind = c.status === 'timing' ? ' (onset-seq)' : ''
+      console.log(`  ✗ ${seam}${c.id}${kind}`)
+      // For a timing cell the multiset reasons are benign (counts match); the
+      // onset-sequence reasons carry the divergence.
+      const reasons = c.status === 'timing' ? c.report?.sequenceParity?.reasons ?? [] : c.report?.reasons ?? []
+      for (const r of reasons) console.log(`      • ${r}`)
     }
   }
   console.log(`${'='.repeat(64)}`)

--- a/tools/lib/matrix-status.ts
+++ b/tools/lib/matrix-status.ts
@@ -1,0 +1,94 @@
+/**
+ * matrix-status.ts — the SINGLE source of truth for classifying a diff-matrix
+ * cell's verdict into a status (issue #477).
+ *
+ * Before #477 the classification lived in TWO places that had to agree by hand:
+ * the driver (`diff-matrix.ts statusFromVerdict`, coarse) and the viewer
+ * (`build-diff-matrix.ts deriveStatus`, rich — it feeds `counts` → the launch
+ * gate). Consolidating here makes them agree STRUCTURALLY, not coincidentally,
+ * and makes the logic unit-testable (both scripts are side-effecting at import).
+ *
+ * The §36-Finding-1 blind spot: the event-parity multiset VERDICT keys on a
+ * DROPPED/extra layer (count). A cell where every layer is present and correctly
+ * counted but MIS-TIMED is STRUCTURE-MATCH — invisible to the verdict. The
+ * matrix exists to measure that class, so we recompute a richer status:
+ *
+ *   (a) SV61 onset-SEQUENCE parity (#476, ε=15ms) — the FINE-GRAINED signal.
+ *       Catches sub-second mis-timing the coarse gap below misses (e.g. #475's
+ *       0.3s nested-`in_thread` fork drift). `sequenceParity.match === false`.
+ *       `null` (no judgeable significant shared layer) is NOT a divergence —
+ *       conservative, SV50 discipline.
+ *   (b) A ≥ ONSET_GAP first-onset gap on any significant shared layer — the
+ *       COARSE fallback, covers layers the SV61 significance floor excludes.
+ *
+ * Either ⇒ a TIMING divergence (a real engine bug the count-verdict hid).
+ */
+
+/** Minimal structural shape of a parity report's timing-relevant fields. */
+export interface StatusSeqRow {
+  significant: boolean
+  status: string
+  desktopOnset: number | null
+  webOnset: number | null
+}
+export interface StatusReport {
+  verdict: string
+  rows: StatusSeqRow[]
+  // Optional so older results files (pre-#476, no sequenceParity) still classify
+  // via the coarse gap rather than throwing.
+  sequenceParity?: { match: boolean | null } | null
+}
+/** Minimal structural shape of a stored cell result. */
+export interface StatusCell {
+  skip: string | null
+  status: string
+  report: StatusReport | null
+}
+
+export type Derived =
+  | 'match' | 'diverge' | 'timing'
+  | 'web_empty' | 'desktop_empty'
+  | 'error' | 'skipped' | 'pending'
+
+export const ONSET_GAP = 3 // seconds — matches event-parity ONSET_GAP_SEC
+
+/**
+ * (a) SV61 onset-sequence mis-timing — STRUCTURE-MATCH but a significant shared
+ * layer's onset SEQUENCE diverges (ε=15ms). `null` match ⇒ not mis-timed.
+ */
+export function isSequenceMistimed(report: StatusReport | null): boolean {
+  return report?.sequenceParity?.match === false
+}
+
+/**
+ * (b) Coarse first-onset gap — a significant shared layer whose first onsets
+ * differ by ≥ ONSET_GAP seconds. Covers layers below the SV61 significance floor.
+ */
+export function hasCoarseOnsetGap(report: StatusReport | null): boolean {
+  if (!report) return false
+  return report.rows.some(
+    (r) =>
+      r.significant &&
+      r.status !== 'only-desktop' &&
+      r.status !== 'only-web' &&
+      Number.isFinite(r.desktopOnset as number) &&
+      Number.isFinite(r.webOnset as number) &&
+      Math.abs((r.desktopOnset as number) - (r.webOnset as number)) >= ONSET_GAP,
+  )
+}
+
+/**
+ * Rich status used by the viewer (feeds `counts` → launch gate). WEB-EMPTY = web
+ * rendered nothing → an engine bug. DESKTOP-EMPTY = desktop produced nothing →
+ * a harness/staleness issue, never counted against the engine.
+ */
+export function deriveStatus(c: StatusCell): Derived {
+  if (c.skip) return 'skipped'
+  if (c.status === 'error') return 'error'
+  if (!c.report) return 'pending'
+  if (c.report.verdict === 'STRUCTURE-DIVERGE') return 'diverge'
+  if (c.report.verdict === 'WEB-EMPTY') return 'web_empty'
+  if (c.report.verdict === 'DESKTOP-EMPTY') return 'desktop_empty'
+  // STRUCTURE-MATCH → look for a hidden timing divergence (a) fine then (b) coarse.
+  return isSequenceMistimed(c.report) || hasCoarseOnsetGap(c.report) ? 'timing' : 'match'
+}


### PR DESCRIPTION
Closes #477. Follow-up from PR #476 (SV61 event-parity tiebreaker) / #475.

## Problem
The differential matrix (launch-gate **Criterion 2**) mapped only the event-parity **multiset verdict** — `STRUCTURE-MATCH ⇒ 'match'`. It caught dropped/extra layers but was **blind to mis-timed layers** (every layer present and correctly counted, but fired at the wrong vtime). The viewer's only timing recompute used a coarse **3-second** first-onset gap — so a sub-second drift like **#475** (nested `in_thread` forking 0.3s early) classified as `'match'` and would **not** have blocked the gate. `gate-report.ts` already counts a `timing` offender; the producer just never emitted one.

## Fix
Wire the **SV61 onset-sequence parity** (#476, ε=15ms) into the status classification:
- `sequenceParity.match === false` on a `STRUCTURE-MATCH` cell ⇒ **`'timing'`** (a real engine bug the count-verdict hid).
- `null` match (no judgeable significant shared layer) is **not** flagged — conservative, SV50.

The classification was **duplicated** across the driver (`statusFromVerdict`, coarse) and the viewer (`deriveStatus`, gate-feeding). Consolidated into one pure module **`tools/lib/matrix-status.ts`** used by both — so they agree structurally (not by hand) and the logic is unit-testable (both scripts are side-effecting at import). The coarse `≥ONSET_GAP` gap is retained as a fallback for layers below the SV61 significance floor.

- `diff-matrix.ts`: `Status` gains `'timing'`; `statusFromVerdict → statusFromReport` (shares `isSequenceMistimed`); console icon/tally/offenders surface it.
- `build-diff-matrix.ts`: imports `deriveStatus` from the lib (drops its local copy); its local `ParityReport` interface gains `sequenceParity`.

Once a #475-pattern cell exists in the grid, a mis-timed render now flows `timing → counts.timing → offenders → gate NOT-GREEN` — the matrix becomes a **strict engine-correctness oracle**, not just a layer-presence oracle.

## Test plan
- **`tools/__tests__/matrix-status.test.ts`** (10 tests): the #475 shape (`STRUCTURE-MATCH` + onset-seq DIVERGE, 0.3s, no coarse gap) classifies **`'timing'`**; well-timed → `'match'`; `null`/absent `sequenceParity` → not flagged; coarse-gap fallback intact; `STRUCTURE-DIVERGE` precedence; web/desktop-empty splits.
- Full suite **1192 pass**, `tsc --noEmit` clean.
- Viewer re-derived from the **existing** results: **52/52 still match** (no regression), gate **Criterion 2 GREEN**. Committed data snapshot unchanged — **tool-only PR** (a fresh-sweep snapshot refresh, incl. adding a nested-`in_thread`-in-`with_fx` grid cell, is a separate chore).

## Known limitation (low severity, from the issue)
`computeSequenceParity` checks only **significant** shared layers (≥3 onsets AND ≥5% of side total, SV49). A sub-5% layer that is mis-timed but count-correct isn't covered. For single-construct grid cells the construct under test is always dominant, so this floor is a non-issue there.