### PR TITLE
🐛 fix(engine): nested live_loop forks at parent thread's cursor, not deferred-registration clock (#480)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -177,6 +177,20 @@ export class SonicPiEngine {
    * code wrapped in `in_thread` by capture tools).
    */
   private currentBuildBuilder: ProgramBuilder | null = null
+  /**
+   * #480: the absolute scheduler virtualTime of the task whose builderFn is
+   * currently running. Companion to `currentBuildBuilder` — a nested `live_loop`
+   * that registers from inside this builderFn anchors its OWN start vtime to this
+   * value instead of `getAudioTime()`. Launch-registered loops (the anchor,
+   * top-level live_loops) get `getAudioTime()` at launch; a nested live_loop's
+   * registration is DEFERRED to its parent's first-tick body execution, so
+   * `getAudioTime()` there is ~1-3 ticks (≈27ms) later → a fixed onset skew vs
+   * desktop, which forks the child at the parent thread's current vtime. Same
+   * wall-clock-seed root as #475 (`case 'thread'`), here for the global-live_loop
+   * registration path. The #460 `__itg` start-gate (preceding-sleep case)
+   * overrides this via `cueVirtualTime`, so the two compose.
+   */
+  private currentBuildTaskVt: number | null = null
   /** Persistent top-level FX state — keyed by scope ID, shared across loops in same with_fx. */
   private persistentFx = new Map<string, { buses: number[]; groups: number[]; nodeIds: number[]; outBus: number }>()
   /** Maps loop name → FX scope ID (loops under same with_fx share a scope). */
@@ -853,6 +867,11 @@ export class SonicPiEngine {
           // ANOTHER live_loop's body still see the correct (innermost) parent.
           const prevBuildBuilder = this.currentBuildBuilder
           this.currentBuildBuilder = builder
+          // #480: stash this task's absolute virtualTime so a nested live_loop
+          // registering inside builderFn forks at this thread's cursor, not the
+          // deferred-registration getAudioTime(). Push/restore like the builder.
+          const prevBuildTaskVt = this.currentBuildTaskVt
+          this.currentBuildTaskVt = task.virtualTime
           // SP95(d) #393: wire the scheduler so `b.sync()` awaits the cue
           // payload mid-build (build-time resolution → post-sync get/e[:val]
           // read fresh state). Only this audio build path wires it; the
@@ -888,6 +907,7 @@ export class SonicPiEngine {
             await builderFn(builder)
           } finally {
             this.currentBuildBuilder = prevBuildBuilder
+            this.currentBuildTaskVt = prevBuildTaskVt
             this.buildNestingDepth--
             scopeHandle?.exitScope()
           }
@@ -931,6 +951,14 @@ export class SonicPiEngine {
           ? parentBuilder.currentBpm : defaultBpm
         const inheritedSynth = (this.buildNestingDepth > 0 && parentBuilder)
           ? parentBuilder.currentDefaultSynth : defaultSynth
+        // #480: a nested registration (depth>0) forks at the parent thread's
+        // current vtime, not the deferred-registration getAudioTime(). Top-level
+        // (depth 0) registrations keep getAudioTime() (undefined anchor) — their
+        // launch-time seed is correct, and the #448 start-gate handles any
+        // source-position offset. A preceding-sleep nested loop is additionally
+        // #460-`__itg`-gated, which overrides this anchor via cueVirtualTime.
+        const nestedAnchorVt = (this.buildNestingDepth > 0 && this.currentBuildTaskVt !== null)
+          ? this.currentBuildTaskVt : undefined
 
         if (this.buildNestingDepth > 0 && isReEvaluate) {
           // Nested hot-swap (issue #199): this call is firing from inside an
@@ -952,7 +980,7 @@ export class SonicPiEngine {
             existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
-            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth })
+            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth, virtualTime: nestedAnchorVt })
             const task = scheduler.getTask(name)
             if (task) task.outBus = loopBus
           }
@@ -960,7 +988,11 @@ export class SonicPiEngine {
           pendingLoops.set(name, asyncFn)
           pendingDefaults.set(name, { bpm: defaultBpm, synth: defaultSynth })
         } else {
-          scheduler.registerLoop(name, asyncFn)
+          // #480: nestedAnchorVt is undefined at depth 0 → registerLoop keeps
+          // getAudioTime() (top-level launch seed, unchanged). At depth>0 it
+          // forks the child at the parent thread's vtime (fixes the ~27ms
+          // deferred-registration skew vs desktop).
+          scheduler.registerLoop(name, asyncFn, { virtualTime: nestedAnchorVt })
           const task = scheduler.getTask(name)
           if (task) {
             // SP72: nested initial registration inherits parent builder's bpm

--- a/src/engine/__tests__/NestedLiveLoopForkVt.test.ts
+++ b/src/engine/__tests__/NestedLiveLoopForkVt.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #480 — a `live_loop` nested inside a user `in_thread` must fork at the parent
+ * thread's virtualTime, not the `getAudioTime()` at its DEFERRED registration.
+ *
+ * Surfaced by the #477 onset-sequence diff-matrix oracle: `live_loop__*__nested`
+ * cells started ~27ms late on web vs desktop. Root: the nested `live_loop`
+ * registers as a global loop during the outer in_thread's first-tick body
+ * execution; `registerLoop` seeded its virtualTime from `getAudioTime()` at that
+ * deferred moment — ~1-3 ticks past launch — while the anchor / top-level loops
+ * registered at launch (~getAudioTime 0). Same wall-clock-seed root as #475
+ * (`case 'thread'`), here for the global-live_loop path (SonicPiEngine
+ * wrappedLiveLoop). Fix: anchor the nested registration to the parent task's
+ * virtualTime via `currentBuildTaskVt` (SV28 — build-phase state visible to
+ * synchronous registrations inside builderFn).
+ *
+ * The skew is a WALL-CLOCK-ADVANCE artifact: it only manifests when
+ * getAudioTime() advances between launch and the deferred registration. The
+ * vitest env has no AudioContext, so getAudioTime() is normally frozen at 0 (why
+ * the existing unit suite never caught it). This test reproduces it
+ * deterministically by overriding the scheduler's getAudioTime to ADVANCE
+ * between evaluate() (outer in_thread registers at 0) and the tick that runs the
+ * outer body (nested live_loop registers). Pre-fix the nested loop's virtualTime
+ * == the advanced clock; post-fix it == the parent's 0.
+ *
+ * Timing PARITY itself is Level-3-verified (tools/event-parity.ts on the 4
+ * live_loop__*__nested cells: 27ms DIVERGE → 0ms MATCH vs desktop).
+ */
+import { describe, it, expect } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+type Task = { virtualTime: number }
+type Sched = {
+  tick: (t: number) => void
+  getTask: (n: string) => Task | undefined
+  getAudioTime: () => number
+  registerLoop: (name: string, fn: () => Promise<void>, opts?: Record<string, unknown>) => void
+}
+
+async function flush(rounds = 8) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+describe('#480 nested live_loop fork virtualTime', () => {
+  it('nested live_loop anchors to the parent in_thread vtime, not the advanced clock', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    // Outer in_thread registers during evaluate() (getAudioTime still 0).
+    await engine.evaluate(`
+      in_thread do
+        live_loop :test do
+          play 60
+          sleep 1
+        end
+      end
+    `)
+
+    const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+    // Simulate the real browser clock having advanced past launch by the time
+    // the outer in_thread's body runs and registers the nested live_loop. This
+    // is what produces the ~27ms skew with a live AudioContext.
+    const ADVANCED = 5.0
+    scheduler.getAudioTime = () => ADVANCED
+
+    // Capture `:test`'s virtualTime AT REGISTRATION (the seed). runLoop suspends
+    // at scheduleSleep(0) before iterating, so the value right after register is
+    // the seed — before `sleep 1` advances it.
+    const origRegister = scheduler.registerLoop.bind(scheduler)
+    let testSeedVt: number | undefined
+    scheduler.registerLoop = (name, fn, opts) => {
+      origRegister(name, fn, opts)
+      if (name === 'test') testSeedVt = scheduler.getTask('test')?.virtualTime
+    }
+
+    engine.play()
+    // Run the outer in_thread's (one-shot) body → it registers `:test`.
+    for (let i = 0; i < 3; i++) {
+      scheduler.tick(20)
+      await flush()
+    }
+
+    expect(testSeedVt, 'nested live_loop :test should have registered').toBeDefined()
+    // THE FIX: seeded from the parent in_thread's vtime (0 — it registered at
+    // launch and never slept), NOT the advanced getAudioTime() (5.0) at the
+    // deferred registration moment. Pre-fix testSeedVt === ADVANCED.
+    expect(testSeedVt!).toBeCloseTo(0, 6)
+    expect(testSeedVt!).not.toBeCloseTo(ADVANCED, 3)
+
+    engine.dispose()
+  })
+
+  it('regression: a TOP-LEVEL live_loop still seeds from getAudioTime (depth 0, unchanged)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+
+    // Top-level live_loop registers at launch (depth 0) — must keep the
+    // getAudioTime() seed (the #480 anchor only applies to nested depth>0).
+    await engine.evaluate(`
+      live_loop :solo do
+        play 60
+        sleep 1
+      end
+    `)
+
+    const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+    const ATLAUNCH = scheduler.getTask('solo')?.virtualTime
+    expect(ATLAUNCH, 'top-level loop registered at launch').toBeDefined()
+    // Registered during evaluate() with the un-advanced clock (0 in the test env).
+    expect(ATLAUNCH).toBeCloseTo(0, 6)
+
+    engine.dispose()
+  })
+})


### PR DESCRIPTION
Closes #480. Found by the #477 onset-sequence diff-matrix oracle (its first real catch).

## Problem
A `live_loop` nested inside a user `in_thread` started **~27ms late** on web vs desktop — uniform across modifiers (`nothing`/`delay`/`var_read`/`use_synth`), onset #0 only, rate-correct, deterministic. The old 3s coarse onset-gap hid it; only the SV61 onset-sequence oracle (ε=15ms) flagged it.

## Root cause (grounded)
The transpiler emits the nested `live_loop("test", …)` **inside** the outer in_thread's builderFn:
```
in_thread((__b) => { live_loop("test", …) })
```
`topLevelInThread` registers the outer as a one-shot loop at **launch** (vt ≈ getAudioTime@launch ≈ 0); its body runs at the **first tick**, and the `live_loop("test")` call registers **during that deferred build**. `registerLoop` then seeded `:test`'s `virtualTime` from `getAudioTime()` at that moment — ~1–3 ticks (≈27ms) past launch — while the anchor / top-level loops seeded ~0 at launch. That asymmetry is the skew.

Same wall-clock-seed root as **#475** (`case 'thread'`), here for the **global-`live_loop`** registration path (which #475 didn't touch).

## Fix
Stash the parent task's absolute `virtualTime` in `currentBuildTaskVt` (companion to the existing SP72 `currentBuildBuilder`; push/restore around `builderFn`), and pass it as the `registerLoop({virtualTime})` anchor for nested (`buildNestingDepth>0`) registrations. Extends **SV28** (build-phase state visible to synchronous registrations inside builderFn).
- Top-level (depth 0) → anchor undefined → `registerLoop` keeps `getAudioTime()` (unchanged).
- The #460 `__itg` start-gate (preceding-sleep case) still overrides via `cueVirtualTime`, so the two compose.

## Verification
- **Level-3 desktop↔web** (`tools/event-parity.ts`): all 4 `live_loop__*__nested` cells onset-seq `✗ DIVERGE 27ms` → **`✓ MATCH` (max Δ 0ms, notes ✓)**, EVENT-MATCH eligible.
- **Deterministic test** (`NestedLiveLoopForkVt.test.ts`): override the scheduler's `getAudioTime` to advance to 5.0 between `evaluate()` (outer registers) and the tick that runs the outer body (nested registers); the nested loop seeds vt **0** (parent's), not 5.0 — **fails when the anchor is reverted** (seeds 5.0). Plus a top-level-loop depth-0 regression. The skew is a wall-clock-advance artifact, invisible to the frozen-clock vitest env unless the clock is advanced — which is why the prior suite never caught it.
- Full suite **1194 pass**, `tsc` clean.

## Catalogue
hetvabhasa **SP128** (sibling of SP127/#475). Note: the B1 hoist/fork boundary now has 7+ patterns (sustained fatality) — the unifying cure remains a single build-phase context object carrying all parent state (bpm/synth/transpose/vtime) into nested registrations.

This closes Class A of the #477 sweep's findings; **#481** (the 500ms sync class) remains open.