### PR TITLE
🐛 fix(transpiler): density-only top-level program no longer throws 'play is not a function' (#473)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1011,13 +1011,20 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   const children = node.namedChildren
 
   // Check if there are bare DSL calls at the top level
-  // Also detect .times do, .each do blocks, and bare with_fx (no live_loop inside)
+  // Also detect .times do, .each do, density blocks, and bare with_fx (no live_loop inside)
   const hasBareCode = children.some((c: any) => {
     if (c.type === 'call' || c.type === 'method_call') {
       const method = c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text
       if (BARE_DSL_CALLS.has(method)) return true
       // .times do / .each do — method_call on a receiver
       if (method === 'times' || method === 'each') return true
+      // #473: a top-level `density`/`with_density` block routes to bareCode and
+      // emits bare play/sleep — it MUST trip the wrap gate so its body gets the
+      // `__b.` prefix. Without this, a program whose ONLY statement is a density
+      // block bypasses the __run_once wrapper and the inner `play` is undefined
+      // (`play is not a function`). Sibling of the times/each case above; density
+      // already lands in `bareCode` (the else branch below) once wrapping is on.
+      if (method === 'density' || method === 'with_density') return true
     }
     return false
   })

--- a/src/engine/__tests__/Density.test.ts
+++ b/src/engine/__tests__/Density.test.ts
@@ -60,3 +60,45 @@ describe('#379 with_density build-time warning (loud-not-silent)', () => {
     expect(detectSp95Limitations('# with_density is not real\ndensity 2 do\n  play 60\nend')).toHaveLength(0)
   })
 })
+
+describe('#473 density block as the SOLE top-level statement', () => {
+  // A density block routes its body to `bareCode` and emits bare play/sleep,
+  // relying on the `__run_once` wrapper to rewrite them to `__b.play`/`__b.sleep`.
+  // When density is the ONLY top-level statement, nothing else trips the wrap
+  // gate → the body emitted bare `play(...)` with no `__b` in scope → runtime
+  // `play is not a function`. The fix makes `density`/`with_density` trip the
+  // gate, like the sibling `.times`/`.each` constructs.
+
+  it('wraps a density-only program in __run_once (so play has __b in scope)', () => {
+    const out = autoTranspile('density 2 do\n  play 67\n  sleep 0.5\nend')
+    // the body is rewritten through the builder, not left bare
+    expect(out).toMatch(/__run_once/)
+    expect(out).toMatch(/__b\.play\(67/)
+    expect(out).toMatch(/__b\.sleep\(0\.5\)/)
+    // the throwaway placeholder object must NOT be emitted at top level
+    expect(out).not.toMatch(/__densityB/)
+    // and there is no bare `play(` left dangling outside the builder
+    expect(out).not.toMatch(/(^|\n)\s*play\(/)
+  })
+
+  it('wraps a with_density-only program too (alias routes through density)', () => {
+    const out = autoTranspile('with_density 2 do\n  play 67\n  sleep 0.5\nend')
+    expect(out).toMatch(/__run_once/)
+    expect(out).toMatch(/__b\.play\(67/)
+    expect(out).not.toMatch(/(^|\n)\s*play\(/)
+  })
+
+  it('density preceded only by a top-level setting still wraps (use_bpm is hoisted, not bare)', () => {
+    const out = autoTranspile('use_bpm 120\ndensity 2 do\n  play 67\n  sleep 0.5\nend')
+    expect(out).toMatch(/__run_once/)
+    expect(out).toMatch(/__b\.play\(67/)
+    expect(out).not.toMatch(/(^|\n)\s*play\(/)
+  })
+
+  it('density WITH surrounding bare code is unchanged (no regression — still wraps)', () => {
+    const out = autoTranspile('play 60\ndensity 2 do\n  play 67\nend\nsleep 1')
+    expect(out).toMatch(/__run_once/)
+    expect(out).toMatch(/__b\.play\(60/)
+    expect(out).toMatch(/__b\.play\(67/)
+  })
+})


### PR DESCRIPTION
## Problem
A program whose **only** top-level statement is a `density` (or `with_density`) block failed at runtime with `play is not a function`:
```ruby
use_bpm 120
density 2 do
  play 67
  sleep 0.5
end
```
`transpileProgram` only triggers the implicit `live_loop :__run_once` wrapper when it detects bare DSL calls / `.times` / `.each` / bare `with_fx` / bare `loop`. A top-level `density` block routes its body to `bareCode` and emits bare `play(...)`/`sleep(...)`, relying on that wrapper to rewrite them to `__b.play`/`__b.sleep` — but `density` never tripped the wrap gate. With surrounding bare code, some other statement trips the gate and the density body rides along (works); when density is the **sole** statement the gate stays false → no wrapper → bare `play` is undefined.

Pre-existing (found during #379 self-review; confirmed on `c0396c1` and its parent).

## Fix
Recognise `density`/`with_density` in the `hasBareCode` detection, exactly like the sibling `.times`/`.each` constructs (`TreeSitterTranspiler.ts` ~1020). The density block already lands in `bareCode` once wrapping is on, so its body gets the `__b.` prefix. One-line gate change; no effect when other bare code is present (the OR is already true there) → no regression path.

## Verification
- **Observed transpile output:** density-only now emits `live_loop("__run_once", async (__b) => { … __b.play(67); __b.sleep(0.5) … })` (was `__densityB` placeholder + bare `play(67)`, no `__run_once`).
- **Level 2 (capture of the repro):** `## Errors: None` (was `play is not a function`); two `/s_new "sonic-pi-beep"` voices at note 67 (density 2 = squash-AND-repeat, #379).
- **Level 3:** WAV non-silent (peak 0.158, RMS 0.017).
- **Tests:** +4 regression tests (density-only, with_density-only, density-after-a-setting, density+surrounding no-regression). Suite **1198/1198**, `tsc --noEmit` clean.

Closes #473