### PR TITLE
🐛 fix(transpiler): wrap gate is structural, not name-enumerated — closes the sole-statement block class (#484)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -984,6 +984,48 @@ const BARE_DSL_CALLS = new Set([
   // virtual time.
   'recording_start', 'recording_stop', 'recording_save', 'recording_delete',
 ])
+
+// #484/SP130: block constructs that carry their OWN ProgramBuilder — their body's
+// bare DSL calls bind to that block's `__b`, NOT the top-level `__run_once` wrapper.
+// The bare-DSL scan below STOPS at these (does not descend into their bodies):
+//  - live_loop / in_thread / define / ndefine / defonce: own scheduled task / fn scope.
+//  - at: emits its own `(__b) => …` closure (self-contained).
+//  - loop: a bare `loop do` is hoisted to an auto-named live_loop (own builder),
+//    and is separately detected by `hasBareLoop` (which fires even for a DSL-free
+//    body, to avoid a bare `while(true)` at program root — SV16/#190).
+// `with_fx` is deliberately NOT here: a bare `with_fx` (one not wrapping a
+// live_loop/loop) routes its body to `bareCode`, so its bare play DOES need the
+// __run_once __b — the scan must descend into it. A `with_fx` that DOES wrap a
+// live_loop/loop is stopped deeper, when the scan reaches that inner construct.
+const REGISTERING_BLOCK_METHODS = new Set([
+  'live_loop', 'in_thread', 'define', 'ndefine', 'defonce', 'at', 'loop',
+])
+
+// #484/SP130: does this subtree contain a bare DSL call that would land in the
+// top-level `bareCode` bucket (and therefore need the `__run_once` wrapper's `__b`)?
+// Recurses generically through ALL node types — so `if`/`unless`/`case`/`while`
+// statements and `comment`/`uncomment`/`density` blocks are covered WITHOUT
+// enumerating their names — but STOPS at registering blocks (above), whose bodies
+// bind to their own builder. This replaces the old name-enumeration in
+// `hasBareCode` (`play`/`sleep`/…, `times`/`each`, `density`): the gate is now
+// STRUCTURAL ("a bare DSL call reaches top level") instead of nominal.
+function subtreeHasBareDslCall(node: any): boolean {
+  if (!node) return false
+  if (node.type === 'call' || node.type === 'method_call') {
+    const method = node.childForFieldName('method')?.text ?? node.namedChildren?.[0]?.text
+    if (method && BARE_DSL_CALLS.has(method)) return true
+    // Stop: this construct owns its builder — its body's bare calls are not
+    // top-level bareCode. Do not descend into its arguments/block.
+    if (method && REGISTERING_BLOCK_METHODS.has(method)) return false
+    // Stop: `comment` DROPS its body (transpiled to `/* commented out */`), so it
+    // emits no bare calls — descending would falsely trip the gate. NOTE: this is
+    // `comment` only; `uncomment` RUNS its body and must still be descended into.
+    if (method === 'comment') return false
+  }
+  const kids: any[] = node.namedChildren ?? []
+  return kids.some(subtreeHasBareDslCall)
+}
+
 // Top-level `loop do … end` is NOT bare code — it is its own scheduler-owned
 // live_loop (auto-named below). Wrapping it in `__run_once` would trap the
 // run_once iteration inside `while(true)` and the loop would never yield
@@ -1010,24 +1052,16 @@ function extractLiteralSynthArg(callNode: any): string | null {
 function transpileProgram(node: any, ctx: TranspileContext): string {
   const children = node.namedChildren
 
-  // Check if there are bare DSL calls at the top level
-  // Also detect .times do, .each do, density blocks, and bare with_fx (no live_loop inside)
-  const hasBareCode = children.some((c: any) => {
-    if (c.type === 'call' || c.type === 'method_call') {
-      const method = c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text
-      if (BARE_DSL_CALLS.has(method)) return true
-      // .times do / .each do — method_call on a receiver
-      if (method === 'times' || method === 'each') return true
-      // #473: a top-level `density`/`with_density` block routes to bareCode and
-      // emits bare play/sleep — it MUST trip the wrap gate so its body gets the
-      // `__b.` prefix. Without this, a program whose ONLY statement is a density
-      // block bypasses the __run_once wrapper and the inner `play` is undefined
-      // (`play is not a function`). Sibling of the times/each case above; density
-      // already lands in `bareCode` (the else branch below) once wrapping is on.
-      if (method === 'density' || method === 'with_density') return true
-    }
-    return false
-  })
+  // #473/#484/SP130: STRUCTURAL detection — a top-level child needs the
+  // `__run_once` wrapper iff its subtree contains a bare DSL call that would land
+  // in `bareCode` (recursing into structural blocks like density / .times / .each /
+  // `if`/`unless`/`case`/`while` / uncomment, but STOPPING at registering blocks
+  // that carry their own `__b`). This replaces the old name-enumeration (`play`/
+  // `sleep`/…, `times`/`each`, `density`), which kept missing constructs whose body
+  // emitted bare `play`/`sleep` — e.g. a program whose ONLY statement was a
+  // `density` (#473) / `uncomment` / `if` block crashed with `play is not a
+  // function` because the gate stayed false and the body had no `__b` in scope.
+  const hasBareCode = children.some(subtreeHasBareDslCall)
   // Also check for bare with_fx that doesn't contain live_loops
   const hasBareFx = children.some((c: any) => {
     if (c.type !== 'call' && c.type !== 'method_call') return false

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -2349,3 +2349,60 @@ end`)
     })
   })
 })
+
+describe('#484/SP130 — __run_once wrap gate is structural (bare DSL reaching top level), not name-enumerated', () => {
+  // A top-level block whose body emits bare play/sleep must trip the gate so the
+  // body gets `__b` in scope. Previously the gate enumerated construct names
+  // (play/sleep/…, times/each, density) → a program whose ONLY statement was a
+  // density (#473) / uncomment / if block bypassed the wrapper → `play is not a
+  // function`. The fix scans each top-level child's subtree for a bare DSL call,
+  // stopping at registering blocks (live_loop/in_thread/with_fx-w-loop/define/at/
+  // loop) and at `comment` (dead body).
+
+  const wraps = (code: string) => /__run_once/.test(autoTranspile(code))
+  const hasBarePlay = (code: string) => /(^|\n)\s*play\(/.test(autoTranspile(code))
+
+  it('uncomment block as the SOLE statement wraps (its body RUNS)', () => {
+    expect(wraps('uncomment do\n  play 60\nend')).toBe(true)
+    expect(hasBarePlay('uncomment do\n  play 60\nend')).toBe(false)
+    expect(autoTranspile('uncomment do\n  play 60\nend')).toMatch(/__b\.play\(60/)
+  })
+
+  it.each([
+    ['if', 'if true\n  play 60\nend'],
+    ['unless', 'unless false\n  play 60\nend'],
+    ['case', 'case 1\nwhen 1\n  play 60\nend'],
+    ['while', 'while false\n  play 60\nend'],
+  ])('%s control-flow block with a bare play as the sole statement wraps', (_label, code) => {
+    expect(wraps(code)).toBe(true)
+    expect(hasBarePlay(code)).toBe(false)
+  })
+
+  it('a deeply nested bare play (if inside density) still reaches the gate', () => {
+    const code = 'density 2 do\n  if true\n    play 60\n  end\nend'
+    expect(wraps(code)).toBe(true)
+    expect(hasBarePlay(code)).toBe(false)
+  })
+
+  // Registering blocks own their builder → must NOT trip the gate (no __run_once).
+  it.each([
+    ['live_loop', 'live_loop :x do\n  play 60\n  sleep 1\nend'],
+    ['in_thread', 'in_thread do\n  play 60\nend'],
+    ['define-only', 'define :foo do\n  play 60\nend'],
+    ['with_fx wrapping live_loop', 'with_fx :reverb do\n  live_loop :x do\n    play 60\n    sleep 1\n  end\nend'],
+    ['at (self-building closure)', 'at [0, 1] do\n  play 60\nend'],
+  ])('%s does NOT trip the wrap gate (carries its own builder)', (_label, code) => {
+    expect(wraps(code)).toBe(false)
+    expect(hasBarePlay(code)).toBe(false)
+  })
+
+  it('comment block (dead body) does NOT trip the gate — but uncomment does', () => {
+    expect(wraps('comment do\n  play 60\nend')).toBe(false)
+    expect(wraps('uncomment do\n  play 60\nend')).toBe(true)
+  })
+
+  it('a bare with_fx wrapping a bare play DOES wrap (its body is bareCode)', () => {
+    expect(wraps('with_fx :reverb do\n  play 60\nend')).toBe(true)
+    expect(hasBarePlay('with_fx :reverb do\n  play 60\nend')).toBe(false)
+  })
+})


### PR DESCRIPTION
> Stacked on #483 (#473). Base auto-retargets to `main` when #483 merges. The diff here is only the #484 change.

## Problem
The `__run_once` wrap gate (`transpileProgram`) *enumerated* construct method-names (`play`/`sleep`/…, `times`/`each`, `density`) to decide whether a program needs the bare-code wrapper. Any top-level block whose body emits bare `play`/`sleep` but whose name wasn't enumerated bypassed the wrapper → its bare `play` had no `__b` in scope → `play is not a function`. #473 patched one name (`density`); `uncomment` and the `if`/`unless`/`case`/`while` control-flow blocks were the remaining holes — **both confirmed crashing at runtime** (Level-2). This is **SP32 recurring** in the tree-sitter layer for block constructs.

## Fix
Replace the enumeration with a **structural scan**: `subtreeHasBareDslCall` recurses each top-level child for a bare DSL call — generically covering `density` / `.times` / `.each` / `if` / `unless` / `case` / `while` / `uncomment` **without naming them** — and STOPS at:
- **registering blocks** that own their builder (`live_loop`, `in_thread`, `define`/`ndefine`/`defonce`, `at`, `loop`), and
- **`comment`** (dead body — emits nothing; `uncomment` still descends).

This subsumes the #473 `density` special-case (removed). `hasBareFx` / `hasBareLoop` are unchanged — they detect *hoist-needing* constructs independent of body content (a DSL-free bare `loop` must still hoist to avoid a `while(true)` at program root, SV16/#190).

## Verification
- **15-case structural matrix:** `uncomment`/`if`/`unless`/`case`/`density`/`with_density`/bare-`with_fx`/`.times`/plain → all wrap; `live_loop`/`in_thread`/`with_fx`-wrapping-`live_loop`/`define`/`at`/`comment` → do NOT wrap. None leave a bare top-level `play(`.
- **Level 2 (capture of the reproducers):** `uncomment do play 60 end` and `if true; play 60; end` → `## Errors: None`, each fires its `play` (`/s_new` ×1).
- **Tests:** +13 regression tests (`TreeSitterTranspiler.test.ts`). Suite **1211/1211**, `tsc --noEmit` clean. `RubyExamples.test.ts` (real-program transpiles) all green — the structural gate change regresses nothing.

Closes #484