### PR TITLE
🎏 GAP A1: additive hierarchical thread-id path (idPath) on every task

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1,4 +1,4 @@
-import { VirtualTimeScheduler, DEFAULT_SCHED_AHEAD_TIME } from './VirtualTimeScheduler'
+import { VirtualTimeScheduler, DEFAULT_SCHED_AHEAD_TIME, type TaskState } from './VirtualTimeScheduler'
 import { ProgramBuilder } from './ProgramBuilder'
 import { TimeState } from './TimeState'
 import { runProgram, type AudioContext as AudioCtx } from './interpreters/AudioInterpreter'
@@ -88,6 +88,17 @@ export class SonicPiEngine {
    * the user-visible top-level `current_time` reader subtracts this origin.
    */
   private _spiderTimeOrigin = 0
+  /**
+   * GAP A — the main/run thread's child-spawn counter. Every TOP-LEVEL forking
+   * construct (a `live_loop`, top-level `in_thread`/`at`) takes the current value
+   * as its spawn index then post-increments it, so its idPath is `[0, n]` in
+   * registration order (= source order; `__run_once`/inline loops don't fork, so
+   * they don't consume an index). This is "main"'s `n_threads_spawned`
+   * (`runtime.rb:1072`); nested forks use their own parent task's
+   * `childSpawnCount` instead. Reset to 0 on every fresh Run (beside
+   * `_spiderTimeOrigin`) so idPaths reproduce deterministically across Runs.
+   */
+  private _topSpawnCount = 0
   private runtimeErrorHandler: ((err: Error) => void) | null = null
   private printHandler: ((msg: string) => void) | null = null
   private cueHandler: ((name: string, time: number) => void) | null = null
@@ -191,6 +202,15 @@ export class SonicPiEngine {
    * overrides this via `cueVirtualTime`, so the two compose.
    */
   private currentBuildTaskVt: number | null = null
+  /**
+   * GAP A — companion to `currentBuildTaskVt`: the TaskState whose builderFn is
+   * currently running. A nested `live_loop` that registers from inside this
+   * builderFn derives its idPath from this parent (`parent.idPath ++
+   * [parent.childSpawnCount++]`), mirroring desktop's fork-from-the-spawning-
+   * thread (`runtime.rb:1071-1074`). Pushed/restored around `builderFn` like
+   * `currentBuildBuilder`.
+   */
+  private currentBuildTask: TaskState | null = null
   /** Persistent top-level FX state — keyed by scope ID, shared across loops in same with_fx. */
   private persistentFx = new Map<string, { buses: number[]; groups: number[]; nodeIds: number[]; outBus: number }>()
   /** Maps loop name → FX scope ID (loops under same with_fx share a scope). */
@@ -448,6 +468,9 @@ export class SonicPiEngine {
         // Verified: V1=1.616s on first Run, V2=8.677s on Run after Stop+5s
         // wait, Δ=+7.061s (`tools/test_current_time_reset.ts`).
         this._spiderTimeOrigin = audioCtx?.currentTime ?? 0
+        // GAP A: reset main's child-spawn counter so top-level idPaths reproduce
+        // deterministically each fresh Run (same source order ⇒ same `[0, n]`).
+        this._topSpawnCount = 0
         this.scheduler = new VirtualTimeScheduler({
           getAudioTime: () => audioCtx?.currentTime ?? 0,
           schedAheadTime: this.schedAheadTime,
@@ -691,12 +714,19 @@ export class SonicPiEngine {
         // vtime instead of vt 0. Engine-injected (transpiler), distinct from the
         // user-facing `sync:`; awaited BEFORE `sync:` (desktop forks, then syncs).
         let startGate: string | null = null
+        // GAP A: transpiler-injected `__inline: true` marks a construct that runs
+        // INLINE in the main thread (`__run_once`, a hoisted bare `loop`, a
+        // `with_fx`-wrapped bare loop) → idPath `[0]`. Absent ⇒ a top-level fork
+        // (`live_loop`/`in_thread`/`at`) → idPath `[0, n]`. Explicit marker, not
+        // name-sniffing (mirrors `__startGate`; PARITY-GAPS GAP A §2 decision).
+        let isInline = false
         if (typeof builderFnOrOpts === 'function') {
           builderFn = builderFnOrOpts
         } else {
           syncTarget = (builderFnOrOpts.sync as string) ?? null
           delayBeats = typeof builderFnOrOpts.delay === 'number' ? builderFnOrOpts.delay : 0
           startGate = (builderFnOrOpts.__startGate as string) ?? null
+          isInline = builderFnOrOpts.__inline === true
           builderFn = maybeFn!
         }
 
@@ -872,6 +902,10 @@ export class SonicPiEngine {
           // deferred-registration getAudioTime(). Push/restore like the builder.
           const prevBuildTaskVt = this.currentBuildTaskVt
           this.currentBuildTaskVt = task.virtualTime
+          // GAP A: expose this task as the parent for any nested live_loop that
+          // registers inside builderFn — it forks `parent.idPath ++ [spawnIdx]`.
+          const prevBuildTask = this.currentBuildTask
+          this.currentBuildTask = task
           // SP95(d) #393: wire the scheduler so `b.sync()` awaits the cue
           // payload mid-build (build-time resolution → post-sync get/e[:val]
           // read fresh state). Only this audio build path wires it; the
@@ -908,6 +942,7 @@ export class SonicPiEngine {
           } finally {
             this.currentBuildBuilder = prevBuildBuilder
             this.currentBuildTaskVt = prevBuildTaskVt
+            this.currentBuildTask = prevBuildTask
             this.buildNestingDepth--
             scopeHandle?.exitScope()
           }
@@ -959,6 +994,25 @@ export class SonicPiEngine {
         // #460-`__itg`-gated, which overrides this anchor via cueVirtualTime.
         const nestedAnchorVt = (this.buildNestingDepth > 0 && this.currentBuildTaskVt !== null)
           ? this.currentBuildTaskVt : undefined
+        // GAP A: compute this task's thread-id path at registration. Lazy (called
+        // only on the branches that actually registerLoop) so the re-eval
+        // pendingLoops branch never consumes a spawn index — otherwise a hot-swap
+        // Run would drift `_topSpawnCount` even though existing tasks keep their
+        // idPath via SV6. Each call post-increments its counter, so this MUST run
+        // exactly once per fresh registration.
+        //  - nested (depth>0, inside a parent builderFn) → fork from that parent:
+        //    `parent.idPath ++ [parent.childSpawnCount++]` (desktop fork-from-
+        //    spawner, runtime.rb:1071-1074).
+        //  - top-level inline (`__inline`: __run_once / bare loop / fx-wrapped
+        //    bare loop) → `[0]` (runs in main, doesn't fork).
+        //  - top-level fork (live_loop / in_thread / at) → `[0, n]` from main's
+        //    `_topSpawnCount` in registration (= source) order.
+        const consumeIdPath = (): number[] =>
+          (this.buildNestingDepth > 0 && this.currentBuildTask)
+            ? [...this.currentBuildTask.idPath, this.currentBuildTask.childSpawnCount++]
+            : isInline
+              ? [0]
+              : [0, this._topSpawnCount++]
 
         if (this.buildNestingDepth > 0 && isReEvaluate) {
           // Nested hot-swap (issue #199): this call is firing from inside an
@@ -980,7 +1034,7 @@ export class SonicPiEngine {
             existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
-            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth, virtualTime: nestedAnchorVt })
+            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth, virtualTime: nestedAnchorVt, idPath: consumeIdPath() })
             const task = scheduler.getTask(name)
             if (task) task.outBus = loopBus
           }
@@ -992,7 +1046,7 @@ export class SonicPiEngine {
           // getAudioTime() (top-level launch seed, unchanged). At depth>0 it
           // forks the child at the parent thread's vtime (fixes the ~27ms
           // deferred-registration skew vs desktop).
-          scheduler.registerLoop(name, asyncFn, { virtualTime: nestedAnchorVt })
+          scheduler.registerLoop(name, asyncFn, { virtualTime: nestedAnchorVt, idPath: consumeIdPath() })
           const task = scheduler.getTask(name)
           if (task) {
             // SP72: nested initial registration inherits parent builder's bpm

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1271,7 +1271,12 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
         // advancing bare code (blockGate set in classification) so it forks at
         // the source-position vtime, not vt 0 — same start-gate as live_loop.
         const gate = blockGate.get(c)
-        const optsArg = gate ? `{__startGate: ${JSON.stringify(gate)}}, ` : ''
+        // GAP A: a hoisted bare `loop do` runs INLINE in the main thread (desktop
+        // never forks it) → `__inline: true` ⇒ idPath `[0]`. Merge with the
+        // optional start-gate cue.
+        const optsArg = gate
+          ? `{__startGate: ${JSON.stringify(gate)}, __inline: true}, `
+          : `{__inline: true}, `
         return `${eagerPrefix}live_loop("${name}", ${optsArg}async (__b) => {\n${bodyStr}\n${ctx.indent}})`
       }
     }
@@ -1286,7 +1291,10 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   const parts: string[] = []
   if (topJS.length > 0) parts.push(topJS.join('\n'))
   if (bareJS.length > 0) {
-    parts.push(`live_loop("__run_once", async (__b) => {\n${bareJS.join('\n')}\n  __b.stop()\n})`)
+    // GAP A: `__inline: true` → idPath `[0]`. __run_once IS the main/run thread
+    // (desktop runs bare top-level code inline in the spider thread; we wrap it
+    // in a one-shot live_loop). It does not fork, so it carries no spawn index.
+    parts.push(`live_loop("__run_once", {__inline: true}, async (__b) => {\n${bareJS.join('\n')}\n  __b.stop()\n})`)
   }
   if (blockJS.length > 0) parts.push(blockJS.join('\n'))
 
@@ -2118,7 +2126,13 @@ function transpileWithFxLoopBody(
       // with_fx's block ctx) onto the hoisted live_loop so it forks at the
       // source-position vtime, not vt 0.
       const gate = bodyCtx.startGate
-      const optsArg = gate ? `{__startGate: ${JSON.stringify(gate)}}, ` : ''
+      // GAP A: a `with_fx`-wrapped bare `loop` hoists to `__fxloop_N` but still
+      // runs INLINE in the main thread (the FX wraps it; it never forks) →
+      // `__inline: true` ⇒ idPath `[0]`. (An explicit `live_loop` inside a
+      // with_fx takes transpileLiveLoop's fork path, NOT this one.)
+      const optsArg = gate
+        ? `{__startGate: ${JSON.stringify(gate)}, __inline: true}, `
+        : `{__inline: true}, `
       parts.push(`${ctx.indent}  live_loop("__fxloop_${idx}", ${optsArg}async (__b) => {\n${innerStr}\n${ctx.indent}  })`)
       sawLoop = true
     } else if (sawLoop) {

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -100,6 +100,27 @@ export interface TaskState {
   asyncFn: () => Promise<void>
   /** Whether this task is actively running */
   running: boolean
+  /**
+   * GAP A — hierarchical thread-id path (desktop's `ThreadId`, `thread_id.rb`).
+   * The main/run thread is `[0]`; a forked child appends its parent's spawn index
+   * (`parentPath ++ [spawnIdx]`, mirroring `runtime.rb:1071-1074`
+   * `parent_path << n_threads_spawned`). Used at equal virtual time as the
+   * cross-thread tiebreak — `(t, idPath)` lexicographic, longer-prefix-greater
+   * (`cueevent.rb:64-74` → `thread_id.rb:41-55`). Inline top-level constructs
+   * (`__run_once` / bare `loop` / `with_fx`-wrapped bare loop) stay `[0]`; they
+   * run in the main thread, they don't fork (PARITY-GAPS GAP A §2 table).
+   *
+   * A1 plumbs this additively (assigned everywhere, read NOWHERE) — the
+   * comparator flip is A2. Default `[0]` keeps any un-tagged path inert.
+   */
+  idPath: number[]
+  /**
+   * GAP A — count of child threads this task has forked. A child's spawn index
+   * is this counter's value at fork time; it post-increments (desktop
+   * `n_threads_spawned`, `runtime.rb:1072`). Per-task so each parent numbers its
+   * own children independently.
+   */
+  childSpawnCount: number
 }
 
 export interface SchedulerEvent {
@@ -224,6 +245,11 @@ export class VirtualTimeScheduler {
     // SonicPiEngine) omit it and keep getAudioTime() — their offset is handled
     // by the #448 start-gate cue, not here.
     virtualTime?: number
+    // GAP A: the hierarchical thread-id path for this task (see TaskState.idPath).
+    // The caller (spawn site) computes it: `[0]` for the main/inline thread,
+    // `[0, n]` for a top-level fork, `parentPath ++ [spawnIdx]` for a nested fork.
+    // Omitted → `[0]` (treat as main/inline — inert under A2's compare).
+    idPath?: number[]
   }): void {
     const existing = this.tasks.get(name)
     if (existing && existing.running) {
@@ -241,6 +267,9 @@ export class VirtualTimeScheduler {
       outBus: options?.outBus ?? 0,
       asyncFn,
       running: true,
+      // GAP A: caller-supplied thread-id path; `[0]` (main/inline) when omitted.
+      idPath: options?.idPath ?? [0],
+      childSpawnCount: 0,
     }
     this.tasks.set(name, task)
 

--- a/src/engine/__tests__/ThreadIdPath.test.ts
+++ b/src/engine/__tests__/ThreadIdPath.test.ts
@@ -1,0 +1,228 @@
+/**
+ * GAP A / A1 — the thread-identity tree (idPath) CONTRACT.
+ *
+ * This is the falsifier for the §2 idPath scheme in `ref/PARITY-GAPS.md`
+ * (GAP A) before A2 consumes it. A1 plumbs a hierarchical `idPath: number[]`
+ * onto every scheduler task — desktop's `ThreadId` (`thread_id.rb`): the main /
+ * run thread is `[0]`; a forked child appends its parent's spawn index
+ * (`parentPath ++ [spawnIdx]`, mirroring `runtime.rb:1071-1074`
+ * `parent_path << n_threads_spawned`). A1 reads idPath NOWHERE — behaviour is
+ * unchanged (the full suite is that guard); this test asserts ONLY that the
+ * assignment matches the table the A2 comparator will rely on.
+ *
+ * §2 table (top level):
+ *   main / bare top-level code (`__run_once`)        → [0]   (inline in main)
+ *   bare `loop do` (hoisted `__loop_N`)              → [0]   (inline in main)
+ *   `with_fx { bare loop }` (hoisted `__fxloop_N`)   → [0]   (inline in main)
+ *   `with_fx { sync; play }` (bare → __run_once)     → [0]   (inline in main)
+ *   `live_loop :x`                                   → [0, n] (FORK, source order)
+ *   `in_thread { … }`                                → [0, n] (FORK, source order)
+ *   nested `in_thread` (inside a loop body)          → [parent ++ [k]]
+ *
+ * Why the inline-vs-fork split matters (the #481 root): desktop runs some
+ * top-level constructs INLINE in the main spider thread and FORKS others; the
+ * synced-first-onset split in #481 is exactly that difference. Assignment is
+ * driven by an explicit transpiler `__inline` marker, not name-sniffing.
+ */
+import { describe, it, expect } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+type Task = { id: string; idPath: number[] }
+type Sched = {
+  tick: (t: number) => void
+  getTask: (n: string) => Task | undefined
+  getRunningLoopNames: () => string[]
+  tasks: Map<string, Task>
+}
+
+async function flush(rounds = 8) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+function sched(engine: SonicPiEngine): Sched {
+  return (engine as unknown as { scheduler: Sched }).scheduler
+}
+
+/** Map every registered task name → its idPath. */
+function idPaths(engine: SonicPiEngine): Map<string, number[]> {
+  const out = new Map<string, number[]>()
+  for (const [name, task] of sched(engine).tasks) out.set(name, task.idPath)
+  return out
+}
+
+/** Find the single task whose name starts with `prefix` (dynamic thread/at names). */
+function findByPrefix(engine: SonicPiEngine, prefix: string): number[] | undefined {
+  for (const [name, task] of sched(engine).tasks) {
+    if (name.startsWith(prefix)) return task.idPath
+  }
+  return undefined
+}
+
+describe('GAP A / A1 — thread-id path (idPath) assignment', () => {
+  it('top-level live_loops fork from main in source order: [0,0], [0,1], [0,2]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :alpha do; sleep 1; end
+      live_loop :beta  do; sleep 1; end
+      live_loop :gamma do; sleep 1; end
+    `)
+    expect(sched(engine).getTask('alpha')!.idPath).toEqual([0, 0])
+    expect(sched(engine).getTask('beta')!.idPath).toEqual([0, 1])
+    expect(sched(engine).getTask('gamma')!.idPath).toEqual([0, 2])
+    engine.dispose()
+  })
+
+  it('bare top-level code (`__run_once`) is the main thread → [0]; a following live_loop forks [0,0]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      play 60
+      sleep 1
+      live_loop :foo do; sleep 1; end
+    `)
+    expect(sched(engine).getTask('__run_once')!.idPath).toEqual([0])
+    // __run_once is inline (no spawn index consumed) → foo is the FIRST fork.
+    expect(sched(engine).getTask('foo')!.idPath).toEqual([0, 0])
+    engine.dispose()
+  })
+
+  it('a hoisted bare `loop do` runs inline in main → [0]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      loop do
+        play 60
+        sleep 1
+      end
+    `)
+    expect(sched(engine).getTask('__loop_0')!.idPath).toEqual([0])
+    engine.dispose()
+  })
+
+  it('a `with_fx`-wrapped bare loop (`__fxloop_N`) is inline → [0]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      with_fx :reverb do
+        loop do
+          play 60
+          sleep 1
+        end
+      end
+    `)
+    expect(sched(engine).getTask('__fxloop_0')!.idPath).toEqual([0])
+    engine.dispose()
+  })
+
+  it('a top-level `in_thread` forks from main → [0, n]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :driver do; sleep 1; end
+      in_thread do; play 60; end
+    `)
+    expect(sched(engine).getTask('driver')!.idPath).toEqual([0, 0])
+    // Top-level in_thread hoists to a dynamic `__thread_<ts>` task — second fork.
+    expect(findByPrefix(engine, '__thread_')).toEqual([0, 1])
+    engine.dispose()
+  })
+
+  it('#481 shape: driver [0,0]; forked in_thread waiter [0,1]; inline with_fx waiter (in __run_once) [0]', async () => {
+    // The three #481 cells in miniature — the idPath split that drives the
+    // onset split (forked sibling waits a cycle; inline/main catches vt0).
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :driver do
+        cue :tick
+        sleep 0.5
+      end
+      in_thread do
+        sync :tick
+        play 60
+      end
+      with_fx :reverb do
+        sync :tick
+        play 67
+      end
+    `)
+    // driver is the first (and only) fork; the with_fx wraps bare code (no inner
+    // live_loop) so it lands in __run_once = main = [0]; the in_thread forks.
+    expect(sched(engine).getTask('driver')!.idPath).toEqual([0, 0])
+    expect(sched(engine).getTask('__run_once')!.idPath).toEqual([0])
+    expect(findByPrefix(engine, '__thread_')).toEqual([0, 1])
+    engine.dispose()
+  })
+
+  it('#400 reorder: source order determines the fork index (director-first)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :director do; sleep 1; end
+      live_loop :player   do; sleep 1; end
+    `)
+    expect(sched(engine).getTask('director')!.idPath).toEqual([0, 0])
+    expect(sched(engine).getTask('player')!.idPath).toEqual([0, 1])
+    engine.dispose()
+  })
+
+  it('#400 reorder: player-first FLIPS the indices (the A2 falsifier for {52,57})', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :player   do; sleep 1; end
+      live_loop :director do; sleep 1; end
+    `)
+    // Reversed declaration ⇒ player now holds [0,0], director [0,1]. Under A2's
+    // (t, idPath) TimeState read this is what makes the reversed program read
+    // {52,57} instead of {55,59} — desktop parity (#400 / #350-reversed).
+    expect(sched(engine).getTask('player')!.idPath).toEqual([0, 0])
+    expect(sched(engine).getTask('director')!.idPath).toEqual([0, 1])
+    engine.dispose()
+  })
+
+  it('a nested `in_thread` forks from its spawning loop → [parent ++ [k]]', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    await engine.evaluate(`
+      live_loop :outer do
+        in_thread do
+          play 72
+        end
+        sleep 1
+      end
+    `)
+    expect(sched(engine).getTask('outer')!.idPath).toEqual([0, 0])
+
+    // The nested in_thread forks via AudioInterpreter `case 'thread'` during the
+    // outer loop's first body run — materialise it by ticking.
+    engine.play()
+    for (let i = 0; i < 3; i++) { sched(engine).tick(20); await flush() }
+
+    // Nested thread task is named `outer__thread_<ts>`; it forks from outer [0,0]
+    // → [0, 0, 0] (outer's first child).
+    expect(findByPrefix(engine, 'outer__thread_')).toEqual([0, 0, 0])
+    engine.dispose()
+  })
+
+  it('idPath is deterministic across a fresh Run (counter resets in evaluate)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const code = `
+      live_loop :a do; sleep 1; end
+      live_loop :b do; sleep 1; end
+    `
+    await engine.evaluate(code)
+    const first = idPaths(engine)
+    // Fresh Run (Stop then Run) rebuilds the scheduler and resets _topSpawnCount.
+    engine.stop()
+    await engine.evaluate(code)
+    const second = idPaths(engine)
+    expect(second.get('a')).toEqual(first.get('a'))
+    expect(second.get('b')).toEqual(first.get('b'))
+    expect(second.get('a')).toEqual([0, 0])
+    expect(second.get('b')).toEqual([0, 1])
+    engine.dispose()
+  })
+})

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -513,6 +513,15 @@ export async function runProgram(
           // in_thread; the nested path forks here). Desktop SP: a child thread
           // inherits the spawner's clock.
           virtualTime: task.virtualTime,
+          // GAP A: a nested `in_thread`/`at` forks from the spawning task —
+          // child idPath = `spawner.idPath ++ [spawner.childSpawnCount++]`
+          // (desktop runtime.rb:1071-1074). The spawner is `task` (ctx.taskId),
+          // already fetched above; its own idPath/counter were set at its
+          // registration, so the tree composes to any depth without plumbing
+          // through ctx. Counter post-increments, so each iteration's fork (a
+          // live_loop body re-runs `in_thread` per cycle) gets a fresh distinct
+          // index — matching desktop's per-spawn `n_threads_spawned`.
+          idPath: [...task.idPath, task.childSpawnCount++],
         })
         break
       }


### PR DESCRIPTION
Part 1 of 2 for the **GAP A** flagship parity gap (umbrella #487). Targets the integration branch `fix-parity-gap`, **not main** — A2 lands here too, then one PR merges to main.

## Problem
`TaskState` carries only a flat `id`. Desktop Sonic Pi resolves equal-virtual-time cross-thread events by a hierarchical `ThreadId` total order (`cueevent.rb:64-74` → `thread_id.rb:41-55`; `runtime.rb:1071-1074` `parent_path << n_threads_spawned`). Without that id on our tasks there is no tiebreak mirroring `ce > matcher.ce` — the shared root of **#481** (synced first-onset off one driver cycle) and **#400 / #350-reversed** (reversed loop order reads WRONG NOTES).

## Fix — A1 is PURE PLUMBING (behaviour identical; idPath assigned everywhere, read NOWHERE; the comparator flip is A2)
- `TaskState` gains `idPath: number[]` + per-task `childSpawnCount`; `registerLoop` takes an `idPath?` option (mirrors the #475 `virtualTime` arg).
- **Inline vs fork** driven by an explicit transpiler `__inline: true` marker (not name-sniffing): `__run_once` / hoisted `loop` (`__loop_N`) / `with_fx`-wrapped bare loop (`__fxloop_N`) run inline in main → `[0]`. `live_loop` / `in_thread` / `at` carry no marker → top-level fork `[0, n]` from the per-run `_topSpawnCount` (reset each fresh Run for deterministic idPaths).
- **Nested forks**: a nested `live_loop` reads the parent via `currentBuildTask`; `AudioInterpreter case 'thread'` derives the child path from the spawning task it already fetches — `parent.idPath ++ [k]`, composing to any depth.

## Verification
New `ThreadIdPath.test.ts` asserts the §2 table on the **real engine**: forks `[0,0]/[0,1]/[0,2]`, inline stays `[0]`, #481 shape (driver `[0,0]`, `__run_once` `[0]`, forked in_thread `[0,1]`), #400 reorder flips, nested in_thread `[0,0,0]`, deterministic across a fresh Run.

- ✅ Full suite **1221/1221** (+10), `tsc --noEmit` clean
- ✅ Zero behaviour change (A1 reads idPath nowhere)

Refs: `ref/PARITY-GAPS.md` GAP A §2 · SP129 · SV47 Slice 3 · #487 #481 #400