### PR TITLE
GAP A2 — (t,idPath) EventHistory: unified cue/sync/set/get + in_thread runtime-step + last-consumed-cue guard (closes #400, #481, #489, #490)

### DIFF
--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -200,12 +200,21 @@ export class EventHistory {
    * and returning the first deliverable yields the smallest deliverable cue —
    * which at equal vt is the ancestor cue (with_fx race fix), and otherwise the
    * earliest strictly-later cue.
+   *
+   * `after` (#489) excludes any cue at or before a previously-consumed cue's
+   * `(t, idPath)` — desktop's re-sync matcher (`core.rb:4551-4571`,
+   * `:sonic_pi_local_last_sync`): the next delivered cue must be STRICTLY greater
+   * (`compareEvent > 0`) than the last one this waiter consumed, so an inline/main
+   * waiter that caught an equal-vt ancestor cue doesn't re-catch it forever. Only
+   * set on a RE-sync; a first sync passes `undefined` so the wake-phase is the
+   * pure `(t,idPath)` `cueDelivers` rule (#400 unaffected).
    */
-  getNextDelivered(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
+  getNextDelivered(key: string | symbol, t: number, idPath: number[], after?: { t: number; idPath: number[] }): CueEvent | null {
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
     for (let i = events.length - 1; i >= 0; i--) {
       const e = events[i]
+      if (after && compareEvent(e, after) <= 0) continue
       if (cueDelivers(e.t, e.idPath, t, idPath)) return e
     }
     return null

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -1,0 +1,174 @@
+/**
+ * EventHistory — a `(t, idPath)`-ordered event store, a port of desktop Sonic
+ * Pi's `event_history.rb` coordination layer (GAP A2 / Spike 2).
+ *
+ * Desktop resolves every cross-thread coordination event — `cue`, `sync`,
+ * `set`, `get` — through ONE `@event_history` of `CueEvent`s ordered by a total
+ * order (`cueevent.rb:64-74`): `time → priority → thread_id → delta`, all
+ * ascending. For our build-once model the moot fields collapse: all user spider
+ * threads share `priority = 0` (`runtime.rb:908`) and `delta` is GAP D
+ * (`time_warp`, out of scope), so the effective order is **`(t, idPath)`** — t
+ * first, then the hierarchical thread-id path as the equal-`t` tiebreak. This is
+ * the shared mechanism behind #481 (synced first-onset off one driver cycle) and
+ * #400/#350-reversed (reversed loop order reads WRONG NOTES).
+ *
+ * `idPath` is desktop's `ThreadId` (`thread_id.rb:41-55`): a lexicographic
+ * compare over the int-array path where, on a shared prefix, the LONGER path is
+ * GREATER (a forked child `[0,0]` sorts after its ancestor `[0]`).
+ *
+ * Two query modes mirror desktop exactly:
+ *  - `getMostRecent` (`find_most_recent_event`, event_history.rb:505-511) — the
+ *    INCLUSIVE `e <= ge` read backing `get :key`: the greatest event at or
+ *    before the reader's `(t, idPath)`.
+ *  - `getNext` (`find_next_event`, event_history.rb:513-545) — the STRICT
+ *    `e > ge` read backing `sync`/`get_next`: the SMALLEST event strictly after
+ *    the sync point. `sync` checks this against existing history first (the fix
+ *    for the with_fx registration race — a same-`t` higher-idPath cue that fired
+ *    before the waiter registered still matches), then blocks for a future one.
+ *
+ * SCOPE (GAP A, not GAP M): this is the `(t, i)` axis only. Desktop's path
+ * namespacing (`/cue` vs `/set` write roots + the `/{cue,set,live_loop}` read
+ * glob, core.rb:70-99) is GAP M and deliberately NOT modelled here — callers keep
+ * cue and set as separate stores/keys, so `set :foo` does NOT wake `sync :foo`
+ * (our current behaviour, preserved). `val_matcher`, `beat`, `bpm`, `delta` and
+ * history pruning (`@history_depth`, event_history.rb:163) are likewise deferred.
+ */
+
+/** A coordination event: a value recorded at virtual time `t` by thread `idPath`. */
+export interface CueEvent {
+  /** Virtual time (seconds) the event was recorded at. */
+  t: number
+  /** The recording thread's hierarchical id path (desktop `ThreadId`). */
+  idPath: number[]
+  /** The payload — cue args (an array) or a `set` value. */
+  value: unknown
+}
+
+/**
+ * Float epsilon for the `t` comparison so genuinely-simultaneous events compare
+ * EQUAL on time and fall through to the idPath tiebreak (matches the prior
+ * fireCue `+ 1e-9` guard against float noise).
+ */
+const T_EPSILON = 1e-9
+
+/**
+ * Lexicographic compare of two thread-id paths — a port of `ThreadId#<=>`
+ * (`thread_id.rb:41-55`). Element-wise over the shared prefix; if equal there,
+ * the LONGER path is GREATER (a forked child sorts after its ancestor).
+ * Returns -1 | 0 | 1.
+ */
+export function compareIdPath(a: number[], b: number[]): -1 | 0 | 1 {
+  const n = Math.min(a.length, b.length)
+  for (let k = 0; k < n; k++) {
+    if (a[k] < b[k]) return -1
+    if (a[k] > b[k]) return 1
+  }
+  if (a.length > b.length) return 1 // self longer at shared prefix ⇒ greater
+  if (a.length < b.length) return -1 // other longer ⇒ self lesser
+  return 0
+}
+
+/**
+ * Total order over events — a port of the user-thread-relevant fields of
+ * `CueEvent#<=>` (`cueevent.rb:64-74`): `t` first (with epsilon), then `idPath`.
+ * `priority` (always 0) and `delta` (GAP D) are omitted. Returns -1 | 0 | 1.
+ */
+export function compareEvent(
+  a: { t: number; idPath: number[] },
+  b: { t: number; idPath: number[] },
+): -1 | 0 | 1 {
+  if (a.t < b.t - T_EPSILON) return -1
+  if (a.t > b.t + T_EPSILON) return 1
+  return compareIdPath(a.idPath, b.idPath)
+}
+
+export class EventHistory {
+  /**
+   * Per-key event list, kept in DESCENDING `(t, idPath)` order (greatest first),
+   * mirroring desktop's `unshift` + `bubble_up_sort!` (event_history.rb:385-433).
+   * Descending order makes `getMostRecent`'s "first `e <= ge`" an O(k) scan from
+   * the front and matches the `find_next` index arithmetic 1:1.
+   */
+  private readonly store = new Map<string | symbol, CueEvent[]>()
+
+  /**
+   * Record an event for `key`, keeping the per-key list in descending
+   * `(t, idPath)` order. Mirrors `__insert_event!` (event_history.rb:385-418):
+   * the common case (monotonically advancing virtual time) prepends; a rare
+   * out-of-order arrival is inserted at its sorted position.
+   *
+   * NB: no `@history_depth` pruning yet (deferred, GAP L / #402) — v1 is bounded
+   * by run length and cleared on dispose, exactly like the TimeState it replaces.
+   */
+  insert(key: string | symbol, t: number, idPath: number[], value: unknown): void {
+    const ce: CueEvent = { t, idPath, value }
+    let events = this.store.get(key)
+    if (!events) {
+      this.store.set(key, [ce])
+      return
+    }
+    // Descending order: find the first existing event that is <= the new one and
+    // splice in front of it. The hot path (new event is the greatest) splices at
+    // index 0 (an unshift).
+    let i = 0
+    while (i < events.length && compareEvent(events[i], ce) > 0) i++
+    events.splice(i, 0, ce)
+  }
+
+  /**
+   * The INCLUSIVE read backing `get :key` — `find_most_recent_event`
+   * (event_history.rb:505-511): the greatest event with `e <= (t, idPath)`.
+   * Because the list is descending, that is the FIRST event `<= ge`. Returns
+   * `null` when nothing is at or before the reader's point.
+   */
+  getMostRecent(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
+    const events = this.store.get(key)
+    if (!events || events.length === 0) return null
+    const ge = { t, idPath }
+    for (let i = 0; i < events.length; i++) {
+      if (compareEvent(events[i], ge) <= 0) return events[i]
+    }
+    return null
+  }
+
+  /**
+   * The STRICT read backing `sync` / `get_next` — `find_next_event`
+   * (event_history.rb:513-545): the SMALLEST event strictly AFTER `(t, idPath)`
+   * (the "next event after my sync point"). Returns `null` when no event is
+   * strictly greater (the syncer must then block for a future one).
+   *
+   * Ported verbatim from the Ruby index arithmetic:
+   *   idx = first index where events[idx] <= ge   (descending list)
+   *   if idx > 0:        events[idx-1]  (smallest event still > ge)
+   *   else (idx 0 or -1): events.last if events.last > ge
+   * The `idx === -1` branch (NO event <= ge, i.e. ALL events are after ge) is the
+   * with_fx registration-race fix: a same-`t` higher-idPath cue already in
+   * history is delivered (`last > ge`), so a late syncer still catches it.
+   */
+  getNext(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
+    const events = this.store.get(key)
+    if (!events || events.length === 0) return null
+    const ge = { t, idPath }
+    const idx = events.findIndex((e) => compareEvent(e, ge) <= 0)
+    if (idx > 0) return events[idx - 1]
+    const last = events[events.length - 1]
+    if (last && compareEvent(last, ge) > 0) return last
+    return null
+  }
+
+  /** Latest value for `key` (greatest event), or `undefined` if never set. */
+  latest(key: string | symbol): unknown {
+    const events = this.store.get(key)
+    return events && events.length > 0 ? events[0].value : undefined
+  }
+
+  /** Number of distinct keys (facade parity with the prior TimeState). */
+  get size(): number {
+    return this.store.size
+  }
+
+  /** Clear all events. Dispose-only (SK14) — never on stop/run. */
+  clear(): void {
+    this.store.clear()
+  }
+}

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -85,6 +85,45 @@ export function compareEvent(
   return compareIdPath(a.idPath, b.idPath)
 }
 
+/** True iff `a` is a STRICT prefix (proper ancestor) of `b`: `[0]` of `[0,0]`. */
+export function isStrictPrefix(a: number[], b: number[]): boolean {
+  if (a.length >= b.length) return false
+  for (let k = 0; k < a.length; k++) if (a[k] !== b[k]) return false
+  return true
+}
+
+/**
+ * The cue WAKE-PHASE rule — whether a fired cue is delivered to a waiting `sync`
+ * — derived from OBSERVED desktop behaviour (#481 + #400, real-engine capture
+ * 2026-06-06), NOT from naive idPath-lexicographic ordering.
+ *
+ * Deliver iff the cue is strictly LATER in virtual time, OR — at EQUAL vt — the
+ * waiter is a strict ANCESTOR of the cuer (the waiter's thread SPAWNED the
+ * cuer's thread, then reached its sync, so it happens-AFTER the spawn and sees
+ * the cue). Concurrent SIBLING threads at equal vt MISS each other and wait a
+ * cycle (desktop's "a freshly-started synced loop waits a cycle", #350/#351).
+ *
+ * Why not plain `compareEvent > 0` (lexicographic, which would deliver to a
+ * lesser sibling): observation disproved it — desktop reversed director/player
+ * plays {52,57}, not the {52,55} lexicographic predicts. The five #481/#400 cells
+ * all fit this strict-prefix (happens-before) rule. (The exact desktop
+ * `event_history.rb` mechanism that yields this — priority/delta fields,
+ * matcher construction — is not fully reverse-engineered; the rule is grounded
+ * in the OUTPUT, the project's iron rule.) The set/get visibility side keeps
+ * `compareEvent` — it agrees with this for comparable pairs and the sibling
+ * read-prior is itself correct (#400 verified).
+ */
+export function cueDelivers(
+  cueT: number,
+  cueIdPath: number[],
+  waiterT: number,
+  waiterIdPath: number[],
+): boolean {
+  if (cueT > waiterT) return true
+  if (cueT < waiterT) return false
+  return isStrictPrefix(waiterIdPath, cueIdPath)
+}
+
 export class EventHistory {
   /**
    * Per-key event list, kept in DESCENDING `(t, idPath)` order (greatest first),
@@ -95,17 +134,31 @@ export class EventHistory {
   private readonly store = new Map<string | symbol, CueEvent[]>()
 
   /**
+   * Optional per-key cap on retained events (keep the `maxPerKey` GREATEST). A
+   * safety bound, NOT desktop's full `@history_depth` pruning (GAP L / #402,
+   * deferred) — it exists so the cue side (one auto-cue per loop iteration) does
+   * not grow unbounded the way the old single-entry `cueMap` never did. Old cues
+   * are irrelevant to `sync`/`getNext` (a syncer matches the NEXT cue after its
+   * point), so trimming the oldest is safe. `undefined` ⇒ unbounded (the
+   * set/get TimeState facade keeps its prior append-history behaviour).
+   */
+  private readonly maxPerKey?: number
+
+  constructor(opts?: { maxPerKey?: number }) {
+    this.maxPerKey = opts?.maxPerKey
+  }
+
+  /**
    * Record an event for `key`, keeping the per-key list in descending
    * `(t, idPath)` order. Mirrors `__insert_event!` (event_history.rb:385-418):
    * the common case (monotonically advancing virtual time) prepends; a rare
-   * out-of-order arrival is inserted at its sorted position.
-   *
-   * NB: no `@history_depth` pruning yet (deferred, GAP L / #402) — v1 is bounded
-   * by run length and cleared on dispose, exactly like the TimeState it replaces.
+   * out-of-order arrival is inserted at its sorted position. If `maxPerKey` is
+   * set, the oldest events past the cap are dropped (the tail of the descending
+   * list).
    */
   insert(key: string | symbol, t: number, idPath: number[], value: unknown): void {
     const ce: CueEvent = { t, idPath, value }
-    let events = this.store.get(key)
+    const events = this.store.get(key)
     if (!events) {
       this.store.set(key, [ce])
       return
@@ -116,6 +169,9 @@ export class EventHistory {
     let i = 0
     while (i < events.length && compareEvent(events[i], ce) > 0) i++
     events.splice(i, 0, ce)
+    if (this.maxPerKey !== undefined && events.length > this.maxPerKey) {
+      events.length = this.maxPerKey // drop the oldest (tail of the descending list)
+    }
   }
 
   /**
@@ -135,27 +191,23 @@ export class EventHistory {
   }
 
   /**
-   * The STRICT read backing `sync` / `get_next` — `find_next_event`
-   * (event_history.rb:513-545): the SMALLEST event strictly AFTER `(t, idPath)`
-   * (the "next event after my sync point"). Returns `null` when no event is
-   * strictly greater (the syncer must then block for a future one).
-   *
-   * Ported verbatim from the Ruby index arithmetic:
-   *   idx = first index where events[idx] <= ge   (descending list)
-   *   if idx > 0:        events[idx-1]  (smallest event still > ge)
-   *   else (idx 0 or -1): events.last if events.last > ge
-   * The `idx === -1` branch (NO event <= ge, i.e. ALL events are after ge) is the
-   * with_fx registration-race fix: a same-`t` higher-idPath cue already in
-   * history is delivered (`last > ge`), so a late syncer still catches it.
+   * The wake-phase read backing `sync` — the SMALLEST cue (earliest `t`, then
+   * idPath) that would be DELIVERED to a waiter at `(t, idPath)` under the
+   * {@link cueDelivers} rule (strictly-later, or equal-vt-strict-ancestor). This
+   * is the "next cue after my sync point" with desktop's observed happens-before
+   * wake-phase. Returns `null` when no cue is deliverable (the syncer blocks for a
+   * future one). The list is descending, so scanning from the tail (ascending t)
+   * and returning the first deliverable yields the smallest deliverable cue —
+   * which at equal vt is the ancestor cue (with_fx race fix), and otherwise the
+   * earliest strictly-later cue.
    */
-  getNext(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
+  getNextDelivered(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
-    const ge = { t, idPath }
-    const idx = events.findIndex((e) => compareEvent(e, ge) <= 0)
-    if (idx > 0) return events[idx - 1]
-    const last = events[events.length - 1]
-    if (last && compareEvent(last, ge) > 0) return last
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i]
+      if (cueDelivers(e.t, e.idPath, t, idPath)) return e
+    }
     return null
   }
 

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -45,13 +45,6 @@ export interface CueEvent {
 }
 
 /**
- * Float epsilon for the `t` comparison so genuinely-simultaneous events compare
- * EQUAL on time and fall through to the idPath tiebreak (matches the prior
- * fireCue `+ 1e-9` guard against float noise).
- */
-const T_EPSILON = 1e-9
-
-/**
  * Lexicographic compare of two thread-id paths — a port of `ThreadId#<=>`
  * (`thread_id.rb:41-55`). Element-wise over the shared prefix; if equal there,
  * the LONGER path is GREATER (a forked child sorts after its ancestor).
@@ -70,15 +63,25 @@ export function compareIdPath(a: number[], b: number[]): -1 | 0 | 1 {
 
 /**
  * Total order over events — a port of the user-thread-relevant fields of
- * `CueEvent#<=>` (`cueevent.rb:64-74`): `t` first (with epsilon), then `idPath`.
- * `priority` (always 0) and `delta` (GAP D) are omitted. Returns -1 | 0 | 1.
+ * `CueEvent#<=>` (`cueevent.rb:64-74`): `t` first, then `idPath`. `priority`
+ * (always 0) and `delta` (GAP D) are omitted. Returns -1 | 0 | 1.
+ *
+ * The `t` compare is EXACT — desktop compares `time_r` (an exact Rational,
+ * `cueevent.rb:28`), so genuinely-simultaneous events (e.g. a synced waiter that
+ * INHERITED the cuer's vt, or a top-level fork sharing a bit-exact launch origin)
+ * compare equal on `t` and fall through to the idPath tiebreak. The old fireCue
+ * `+ 1e-9` epsilon was a web-only float-noise guard that broke the exact
+ * "last ≤ t" boundary (a write at vt 0.5 must NOT be visible to a get at
+ * 0.5 − 1e-9); the faithful order is exact. (Float-accumulation drift between
+ * two independently-summed cursors is a known edge desktop sidesteps via
+ * Rational — out of scope here.)
  */
 export function compareEvent(
   a: { t: number; idPath: number[] },
   b: { t: number; idPath: number[] },
 ): -1 | 0 | 1 {
-  if (a.t < b.t - T_EPSILON) return -1
-  if (a.t > b.t + T_EPSILON) return 1
+  if (a.t < b.t) return -1
+  if (a.t > b.t) return 1
   return compareIdPath(a.idPath, b.idPath)
 }
 
@@ -160,6 +163,16 @@ export class EventHistory {
   latest(key: string | symbol): unknown {
     const events = this.store.get(key)
     return events && events.length > 0 ? events[0].value : undefined
+  }
+
+  /**
+   * The greatest event for `key` (or `undefined`). Exposed for the TimeState
+   * facade's idempotency guard (skip a re-applied identical write); the pure
+   * store itself never dedups (desktop `event_history.rb` just unshifts).
+   */
+  peekLatest(key: string | symbol): CueEvent | undefined {
+    const events = this.store.get(key)
+    return events && events.length > 0 ? events[0] : undefined
   }
 
   /** Number of distinct keys (facade parity with the prior TimeState). */

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -68,7 +68,16 @@ export class ProgramBuilder {
   // cross-loop post-sync `get` a write-before-read happens-before by causation,
   // not by scheduler wake order. Null on builders that were never wired (the
   // deferred {tag:'set'} step still records the write at interpret time).
-  private _timeState: { set(key: string | symbol, value: unknown, t: number): void; get(key: string | symbol, t: number): unknown } | null = null
+  private _timeState: {
+    set(key: string | symbol, value: unknown, t: number, writerIdPath?: number[]): void
+    get(key: string | symbol, t: number, readerIdPath?: number[]): unknown
+  } | null = null
+  // GAP A2 (#400): the owning task's thread-id path (desktop ThreadId). `b.set`
+  // tags its write with it and `b.get` reads at it, so a same-virtual-time
+  // cross-loop set/get resolves by the (t, idPath) total order (writer idPath ≤
+  // reader idPath is visible). Defaults to `[0]` (main) until the engine wires
+  // the real path via setTimeStateContext.
+  private _ownerIdPath: number[] = [0]
 
   constructor(seed: number = 0, initialTicks?: Map<string, number>) {
     this.rng = new SeededRandom(seed)
@@ -279,9 +288,14 @@ export class ProgramBuilder {
    * during the engine's build setup; null on builders that never wire it.
    */
   setTimeStateContext(
-    timeState: { set(key: string | symbol, value: unknown, t: number): void; get(key: string | symbol, t: number): unknown },
+    timeState: {
+      set(key: string | symbol, value: unknown, t: number, writerIdPath?: number[]): void
+      get(key: string | symbol, t: number, readerIdPath?: number[]): unknown
+    },
+    ownerIdPath: number[] = [0],
   ): void {
     this._timeState = timeState
+    this._ownerIdPath = ownerIdPath
   }
 
   /** Read the build-phase beat counter (engine persists this across iterations). */
@@ -859,7 +873,9 @@ export class ProgramBuilder {
    * write per (key, build-vt) — no phantom shadow entry at a different vt.
    */
   set(key: string | symbol, value: unknown): this {
-    this._timeState?.set(key, value, this.current_time())
+    // GAP A2: tag the write with the owning task's idPath so a same-vt reader
+    // resolves it by the (t, idPath) total order (#400).
+    this._timeState?.set(key, value, this.current_time(), this._ownerIdPath)
     this.steps.push({ tag: 'set', key, value })
     return this
   }
@@ -882,7 +898,9 @@ export class ProgramBuilder {
   get get(): ((key: string | symbol) => unknown) & Record<string | symbol, unknown> {
     const read = (key: string | symbol): unknown => {
       if (!this._timeState) return null
-      return this._timeState.get(key, this.current_time()) ?? null
+      // GAP A2: read at the owning task's idPath so the (t, idPath) tiebreak
+      // resolves a same-vt cross-loop write by writer-idPath ≤ reader-idPath (#400).
+      return this._timeState.get(key, this.current_time(), this._ownerIdPath) ?? null
     }
     return new Proxy(read, {
       apply(_target, _thisArg, args) {

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -720,6 +720,21 @@ export class SonicPiEngine {
         // (`live_loop`/`in_thread`/`at`) → idPath `[0, n]`. Explicit marker, not
         // name-sniffing (mirrors `__startGate`; PARITY-GAPS GAP A §2 decision).
         let isInline = false
+        // SP131/#481: a one-shot top-level in_thread (set by topLevelInThread).
+        // Such a thread builds its ENTIRE body in ONE pass, so the build-time
+        // `sync` await (which suspends the build until the cue) would batch every
+        // sync in the body and interpret all the deferred plays at the FINAL vt —
+        // `in_thread { 8.times { sync :tick; play } }` piles all 8 plays at vt 4
+        // instead of spreading them 0.5..4.0. A live_loop avoids this because it
+        // re-builds per iteration (one sync per build). For a one-shot thread we
+        // must take the RUNTIME-STEP sync path instead: skip setSyncContext below
+        // so `b.sync` pushes a `{tag:'sync'}` step that AudioInterpreter `case
+        // 'sync'` blocks on at INTERPRET time — interleaving each sync with the
+        // play after it, exactly like desktop's blocking thread (and like a NESTED
+        // in_thread, which already runs this path via forkBuilder). The trade-off
+        // (no build-time post-sync state read for `e = sync :x; play e[:val]`) is
+        // the same SV47 boundary nested in_thread already lives with.
+        let oneShotThread = false
         if (typeof builderFnOrOpts === 'function') {
           builderFn = builderFnOrOpts
         } else {
@@ -727,6 +742,7 @@ export class SonicPiEngine {
           delayBeats = typeof builderFnOrOpts.delay === 'number' ? builderFnOrOpts.delay : 0
           startGate = (builderFnOrOpts.__startGate as string) ?? null
           isInline = builderFnOrOpts.__inline === true
+          oneShotThread = builderFnOrOpts.__oneShotThread === true
           builderFn = maybeFn!
         }
 
@@ -911,7 +927,12 @@ export class SonicPiEngine {
           // read fresh state). Only this audio build path wires it; the
           // QueryInterpreter/capture build (S2-gated) never does, so an S3
           // sync loop cannot register a phantom waiter through capture.
-          builder.setSyncContext(scheduler, name)
+          // SP131/#481: skip for a one-shot in_thread so its `sync` takes the
+          // runtime-step path (interpret-time blocking) instead of build-time
+          // await — see the oneShotThread comment above. live_loops (and the
+          // single-iteration build per loop tick) keep the build-time await that
+          // #350/#400 depend on.
+          if (!oneShotThread) builder.setSyncContext(scheduler, name)
           // SP95(d) #350 slice 2: wire the Time State so `b.set` writes eagerly
           // at current_time() and `b.get` reads at the reader's current_time().
           builder.setTimeStateContext(this.globalStore, task.idPath)
@@ -1181,8 +1202,13 @@ export class SonicPiEngine {
           fn(b)
           b.stop()
         }
-        if (startGate) fxAwareWrappedLiveLoop(name, { __startGate: startGate }, wrapped)
-        else fxAwareWrappedLiveLoop(name, wrapped)
+        // SP131/#481: mark this as a one-shot thread so wrappedLiveLoop takes the
+        // runtime-step `sync` path (interpret-time blocking) — a single build pass
+        // of the whole body can't batch build-time sync awaits and pile every play
+        // at the final vt; the runtime path interleaves each sync with its play.
+        const itOpts: Record<string, unknown> = { __oneShotThread: true }
+        if (startGate) itOpts.__startGate = startGate
+        fxAwareWrappedLiveLoop(name, itOpts, wrapped)
       }
 
       // Top-level at: create one-shot loops with time offsets

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -914,7 +914,7 @@ export class SonicPiEngine {
           builder.setSyncContext(scheduler, name)
           // SP95(d) #350 slice 2: wire the Time State so `b.set` writes eagerly
           // at current_time() and `b.get` reads at the reader's current_time().
-          builder.setTimeStateContext(this.globalStore)
+          builder.setTimeStateContext(this.globalStore, task.idPath)
           // #447: live_loop `delay:` — sleep `delayBeats` beats before the FIRST
           // iteration only (desktop runtime.rb:1196 `sleep delay if delay`, in
           // beats, inside the forked thread before the body). Mark the loop's

--- a/src/engine/TimeState.ts
+++ b/src/engine/TimeState.ts
@@ -1,112 +1,84 @@
 /**
- * TimeState — a virtual-time-indexed key/value store for `set`/`get`.
+ * TimeState — the `set`/`get` facade over the unified {@link EventHistory}.
  *
  * Mirrors Desktop Sonic Pi's Time State layer (`event_history.rb`): a `get`
- * resolves "the last seen version at or before the reader's time" (the
- * inclusive "last ≤ t" lookup, `event_history.rb:180`), and a `set` appends a
- * timestamped entry rather than blindly overwriting. Desktop has a dedicated
- * layer for this; per CLAUDE.md's "Architecture Principle" we mirror that
- * boundary in a single standalone module instead of scattering Map-of-arrays
- * logic across SonicPiEngine / ProgramBuilder / AudioInterpreter.
+ * resolves "the last seen version at or before the reader's point" (the
+ * inclusive lookup, `event_history.rb:505-511 find_most_recent_event`), and a
+ * `set` records a timestamped event rather than blindly overwriting. Per
+ * CLAUDE.md's "Architecture Principle" the ordering lives in ONE module
+ * (`EventHistory`) that audits 1:1 against `event_history.rb`; this class is the
+ * thin namespaced facade for the `set`/`get` half (the scheduler holds another
+ * `EventHistory` for `cue`/`sync` — same mechanism, separate namespace).
  *
- * Why time-indexed (SP95 / SV47 / #350): under the plain `Map` the apply moment
- * WAS the visibility moment, so a cross-loop `set`/`get` at the same virtual
- * time raced on microtask ordering. With a time index each `set` carries its
- * OWN recorded virtual time, so visibility is defined by the recorded TIMESTAMP,
- * not by the moment of application — eager build-time application no longer
- * collapses the intra-loop timeline the way SP41 feared (`set :x,1; sleep 2;
- * set :x,2` records x=1@T and x=2@(T+2); a reader at vt T+1 reads 1).
+ * GAP A2 (#400/#350-reversed): the lookup is now the full `(t, idPath)` total
+ * order, not just `t` with append-order ties. At equal virtual time the WRITER's
+ * thread-id path is the tiebreak: a reader sees a same-`t` write iff the writer's
+ * idPath ≤ the reader's idPath (`event_history.rb` `e <= ge`). This is what makes
+ * a reversed director/player declaration read desktop's `{52,57}` instead of the
+ * old source-order-blind `{55,59}`. idPath defaults to `[0]` (main) so callers
+ * that don't yet thread it through keep the prior single-axis behaviour.
  *
- * v1 scope (Decision Q2/Q4): per-key append history without pruning (bounded by
- * run length, cleared only on dispose — SK14). No priority/thread fields; the
- * rare same-vt same-key two-writer case is resolved as last-write-wins (append
- * order among equal-t entries). The full desktop `(time, priority, thread_delta,
- * thread_id, beat, path)` total order is explicitly OUT of v1.
+ * Why time-indexed (SP95 / SV47 / #350): under a plain `Map` the apply moment WAS
+ * the visibility moment, so a cross-loop `set`/`get` at the same virtual time
+ * raced on microtask ordering. With the time index each `set` carries its OWN
+ * recorded virtual time, so visibility is defined by the recorded TIMESTAMP (and
+ * now the writer idPath), not the moment of application.
  */
-
-interface TimeEntry {
-  /** The virtual time (seconds) at which this value was written. */
-  t: number
-  value: unknown
-}
+import { EventHistory, compareIdPath } from './EventHistory'
 
 export class TimeState {
-  /**
-   * Per-key time-ordered entries. Entries are kept in ascending `t` order; for
-   * equal `t` the latest write is appended last (last-write-wins, Decision Q2).
-   */
-  private readonly store = new Map<string | symbol, TimeEntry[]>()
+  /** The single ordered store backing this namespace (GAP A2 — was a Map-of-arrays). */
+  private readonly history = new EventHistory()
 
   /**
-   * Append `{t, value}` for `key`.
+   * Record `value` for `key` at virtual time `t`, written by thread `writerIdPath`
+   * (defaults to `[0]` = main). Mirrors `EventHistory.set`/`__insert_event!`.
    *
-   * Idempotency requirement (Decision Q3): the interpreter's deferred `case
-   * 'set'` may re-apply the SAME (key, value) at the SAME `t` that the eager
-   * build-time write already recorded. A blind append would create a phantom
-   * duplicate that could shadow the eager entry, so a re-application of the
-   * identical (key, value, t) that is already the latest entry is a no-op —
-   * guaranteeing "exactly one entry per (key, build-vt, value)".
+   * Idempotency (Decision Q3): the eager build-time write and any re-application
+   * of the SAME `(key, value, t, idPath)` that is already the latest event is a
+   * no-op — guaranteeing one entry per `(key, build-vt, idPath, value)`. (The
+   * deferred interpreter `case 'set'` is already a no-op for this path; this is
+   * the defensive guard the prior Map-of-arrays implementation kept.)
    */
-  set(key: string | symbol, value: unknown, t: number): void {
-    const entries = this.store.get(key)
-    if (!entries) {
-      this.store.set(key, [{ t, value }])
+  set(key: string | symbol, value: unknown, t: number, writerIdPath: number[] = [0]): void {
+    const latest = this.history.peekLatest(key)
+    if (
+      latest !== undefined &&
+      latest.t === t &&
+      latest.value === value &&
+      compareIdPath(latest.idPath, writerIdPath) === 0
+    ) {
       return
     }
-    const last = entries[entries.length - 1]
-    // Idempotent re-apply: identical (key, value, t) already the latest entry.
-    if (last !== undefined && last.t === t && last.value === value) {
-      return
-    }
-    // Maintain ascending-t order. The common case is an append (writes advance
-    // monotonically with virtual time); a rare out-of-order write is inserted
-    // at the correct position so the "last ≤ t" lookup stays correct.
-    if (last === undefined || t >= last.t) {
-      entries.push({ t, value })
-      return
-    }
-    let i = entries.length
-    while (i > 0 && entries[i - 1].t > t) i--
-    entries.splice(i, 0, { t, value })
+    this.history.insert(key, t, writerIdPath, value)
   }
 
   /**
-   * Resolve the value of `key` at the reader's virtual time.
+   * Resolve the value of `key`.
    *
-   * - `get(key, t)` → value of the entry with the GREATEST `t` ≤ the argument
-   *   `t` (INCLUSIVE — a set recorded at vt t IS visible to a get at vt t), or
-   *   `null` if no entry is at or before `t` (matches the prior `?? null` at
-   *   SonicPiEngine.ts:1060).
-   * - `get(key)` (no `t`) → facade: the LATEST value (greatest t), or
+   * - `get(key, t, readerIdPath?)` → the greatest event with `(eventT, writerId)
+   *   ≤ (t, readerIdPath)` (INCLUSIVE — a write recorded at the reader's exact
+   *   `(t, idPath)` IS visible), or `null` if none is at or before that point.
+   * - `get(key)` (no `t`) → facade: the LATEST value (greatest event), or
    *   `undefined` if the key was never set (Map-compatible facade for tests).
    */
   get(key: string | symbol): unknown
-  get(key: string | symbol, t: number): unknown
-  get(key: string | symbol, t?: number): unknown {
-    const entries = this.store.get(key)
-    if (!entries || entries.length === 0) {
-      // No-vt facade returns `undefined` (Map.get parity); vt-aware lookup
-      // returns `null` to match the prior sandbox-get `?? null` behavior.
-      return t === undefined ? undefined : null
-    }
+  get(key: string | symbol, t: number, readerIdPath?: number[]): unknown
+  get(key: string | symbol, t?: number, readerIdPath: number[] = [0]): unknown {
     if (t === undefined) {
-      return entries[entries.length - 1].value
+      return this.history.latest(key)
     }
-    // Greatest entry with recorded vt ≤ t (inclusive). Linear scan from the end
-    // is fine for v1's bounded histories; entries are ascending-t ordered.
-    for (let i = entries.length - 1; i >= 0; i--) {
-      if (entries[i].t <= t) return entries[i].value
-    }
-    return null
+    const event = this.history.getMostRecent(key, t, readerIdPath)
+    return event ? event.value : null
   }
 
   /** Number of distinct keys (facade for tests that read `.size`). */
   get size(): number {
-    return this.store.size
+    return this.history.size
   }
 
   /** Clear all entries. Dispose-only (SK14) — never on stop/run. */
   clear(): void {
-    this.store.clear()
+    this.history.clear()
   }
 }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -131,7 +131,10 @@ export interface TaskState {
    * waiter (`[0]`) that catches an equal-vt ancestor cue (`[0,0]`) re-catches the
    * SAME cue every iteration (its vt never advances) → runaway. The FIRST sync
    * has no `lastSyncedCue`, so the `(t,idPath)` wake-phase (`cueDelivers`, #400)
-   * is unaffected. Cleared on Run (clear()) and at fresh registration.
+   * is unaffected. Lifecycle: a fresh Run registers a NEW task (undefined →
+   * first-sync semantics); a hot-swap KEEPS the task (and this field), matching
+   * desktop's persistent thread-local — virtual time continues monotonically so
+   * the next cue is still strictly-greater. No explicit reset needed.
    */
   lastSyncedCue?: { t: number; idPath: number[] }
 }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -1,4 +1,5 @@
 import { MinHeap } from './MinHeap'
+import { EventHistory, cueDelivers } from './EventHistory'
 
 // ---------------------------------------------------------------------------
 // Cue glob matching (#150) — supports * and ? wildcards in sync targets
@@ -189,18 +190,31 @@ export class VirtualTimeScheduler {
   /** Map from `${time}:${taskId}` to insertion order for stable sorting */
   // entryOrder Map removed — insertion order stored directly on SleepEntry (#75)
   private _running = false
-  /** Cue state: last cue per name with virtual time, args, and cuer's BPM. */
-  private cueMap = new Map<string, { time: number; args: unknown[]; bpm: number }>()
+  /**
+   * GAP A2 — cue history: the `(t, idPath)`-ordered store of fired cues (port of
+   * the cue side of `event_history.rb`), replacing the old single-entry cueMap.
+   * `sync` resolves over it (`getNext` = next cue strictly after the sync point),
+   * which (a) fixes the with_fx registration race — a same-`t` higher-idPath cue
+   * that fired before the waiter registered is still found in history — and (b)
+   * applies the `(t, idPath)` tiebreak at equal vt (#481). Capped per key
+   * (the auto-cue fires once per loop iteration; old cues are irrelevant to a
+   * forward-looking `sync`) so it does not grow unbounded the way cueMap never
+   * did. Value = `{ args, bpm }` (the cuer's BPM at fire time, for sync_bpm).
+   */
+  private cueHistory = new EventHistory({ maxPerKey: 256 })
   /** Tasks waiting for a cue */
   private syncWaiters = new Map<string, Array<{
     taskId: string
     resolve: (payload: SyncPayload) => void
     /**
-     * Virtual time at which this waiter began syncing. A cue is delivered only
-     * if it fires STRICTLY AFTER this (desktop SK15 wake-phase semantic) — see
-     * fireCue.
+     * The waiter's sync point `(virtualTime, idPath)`. A cue is delivered only if
+     * it is strictly GREATER in the `(t, idPath)` total order (desktop
+     * `ce > matcher.ce`, event_history.rb:139) — so at equal vt a same-or-lower
+     * idPath cue misses (the forked-sibling waiter waits a cycle, #481) while a
+     * higher-idPath cue catches (the inline/main waiter, #481 with_fx/bare_loop).
      */
     waiterVt: number
+    waiterIdPath: number[]
   }>>()
   /** One-shot audio-time-bound callbacks (SV41 — backs scheduleAtVirtualTime). */
   private pendingCallbacks: PendingCallback[] = []
@@ -447,8 +461,14 @@ export class VirtualTimeScheduler {
     // task — fall back to the engine's startup BPM so sync_bpm waiters still
     // get a defined value rather than NaN.
     const cueBpm = task?.bpm ?? DEFAULT_TASK_BPM
+    // GAP A2: the cuer's thread-id path — the equal-vt tiebreak. Synthetic
+    // external sources (no task) cue as main `[0]`.
+    const cueIdPath = task?.idPath ?? [0]
 
-    this.cueMap.set(name, { time: cueVirtualTime, args, bpm: cueBpm })
+    // Record the cue in the (t, idPath)-ordered history so a late or
+    // forked-sibling syncer resolves it correctly (replaces the single-entry
+    // cueMap). Value carries the cuer's BPM for sync_bpm waiters (#236).
+    this.cueHistory.insert(name, cueVirtualTime, cueIdPath, { args, bpm: cueBpm })
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({
@@ -465,17 +485,15 @@ export class VirtualTimeScheduler {
     for (const [pattern, waiters] of this.syncWaiters) {
       if (waiters.length === 0) continue
       if (!cueGlobMatch(pattern, name)) continue
-      // Desktop wake-phase semantic (SK15): deliver a cue only to waiters that
-      // began syncing STRICTLY BEFORE the cue fired. A cue at the same virtual
-      // instant a waiter registered (e.g. a cuer's first `cue` at vt=0 vs a
-      // synced loop that registered its sync at vt=0) is NOT delivered — the
-      // synced loop misses it and catches the NEXT cue. This reproduces
-      // desktop's "a freshly-started synced loop waits a cycle" behavior
-      // (#351 note-0, #350 every-other-tick). The 1e-9 epsilon guards against
-      // float noise so genuinely-simultaneous events compare equal.
+      // Wake-phase (cueDelivers, observed desktop #481/#400): deliver iff the cue
+      // is strictly LATER, or — at EQUAL vt — the waiter is a strict ANCESTOR of
+      // the cuer (its thread spawned the cuer, then synced → happens-after). A
+      // forked-SIBLING waiter ([0,1]) misses a driver cue ([0,0]) and waits a
+      // cycle (#481 in_thread / #350 met / #400 player); an inline/main waiter
+      // ([0]) catches a driver cue ([0,0]) at the same vt (#481 with_fx/bare_loop).
       const kept: typeof waiters = []
       for (const waiter of waiters) {
-        if (cueVirtualTime > waiter.waiterVt + 1e-9) {
+        if (cueDelivers(cueVirtualTime, cueIdPath, waiter.waiterVt, waiter.waiterIdPath)) {
           const waiterTask = this.tasks.get(waiter.taskId)
           if (waiterTask) {
             // Inherit cue's virtual time (SV5)
@@ -498,19 +516,36 @@ export class VirtualTimeScheduler {
    * (sync_bpm, #236) can mutate the waiter's task.bpm.
    */
   waitForSync(name: string, taskId: string): Promise<SyncPayload> {
-    // Always wait for a FRESH cue — never resolve from stale cueMap entries.
-    // In Sonic Pi, sync(:name) parks the thread until a NEW cue fires.
-    // get(:name) returns existing values; sync waits for the next one.
-    // Without this, loops synced to met1 start at vt=0 instead of waiting
-    // for met1's first beat (met1's auto-cue fires before synced loops run).
-    // Capture the virtual time at which this waiter starts syncing. fireCue
-    // only delivers cues that fire strictly after this instant, reproducing
-    // desktop's "a freshly-started synced loop misses a simultaneous cue and
-    // waits for the next one" wake-phase (SK15; #351 note-0 / #350).
-    const waiterVt = this.tasks.get(taskId)?.virtualTime ?? 0
+    // GAP A2: desktop `sync` (event_history.rb:215) checks history FIRST —
+    // `get_next` returns the next cue strictly after the sync point if one is
+    // already recorded — and only blocks if none. This is the with_fx
+    // registration-race fix: the driver's vt0 cue fired before this inline
+    // waiter (in __run_once = main `[0]`) registered, but it is in cueHistory,
+    // and `getNext('tick', 0, [0])` finds it (the same-`t` higher-idPath cue is
+    // strictly greater) → deliver now, no missed cycle. A forked-sibling waiter
+    // ([0,1]) gets `null` from getNext (the cue is ≤ it) and blocks for the next
+    // cycle — desktop's "a freshly-started synced loop waits a cycle" (#350/#481).
+    // SV11 is preserved: a genuinely-past cue has lower vt, so it is NOT strictly
+    // greater and is not delivered.
+    const task = this.tasks.get(taskId)
+    const waiterVt = task?.virtualTime ?? 0
+    const waiterIdPath = task?.idPath ?? [0]
+
+    // History-first only for exact cue names; glob patterns (`sync "/midi:*"`,
+    // #150) register and wait for a future matching cue (their cross-key history
+    // scan is GAP M / not needed by #350/#481 which use exact names).
+    if (!name.includes('*') && !name.includes('?')) {
+      const hit = this.cueHistory.getNextDelivered(name, waiterVt, waiterIdPath)
+      if (hit) {
+        if (task) task.virtualTime = hit.t // inherit the cue's vt (SV5)
+        const payload = hit.value as { args: unknown[]; bpm: number }
+        return Promise.resolve({ args: payload.args, bpm: payload.bpm })
+      }
+    }
+
     return new Promise<SyncPayload>((resolve) => {
       const waiters = this.syncWaiters.get(name) ?? []
-      waiters.push({ taskId, resolve, waiterVt })
+      waiters.push({ taskId, resolve, waiterVt, waiterIdPath })
       this.syncWaiters.set(name, waiters)
     })
   }
@@ -615,7 +650,7 @@ export class VirtualTimeScheduler {
     this.tasks.clear()
     this.queue.clear()
     this.eventHandlers.length = 0
-    this.cueMap.clear()
+    this.cueHistory.clear()
     this.syncWaiters.clear()
     this.pendingCallbacks.length = 0
   }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -1,5 +1,5 @@
 import { MinHeap } from './MinHeap'
-import { EventHistory, cueDelivers } from './EventHistory'
+import { EventHistory, cueDelivers, compareEvent } from './EventHistory'
 
 // ---------------------------------------------------------------------------
 // Cue glob matching (#150) — supports * and ? wildcards in sync targets
@@ -122,6 +122,18 @@ export interface TaskState {
    * own children independently.
    */
   childSpawnCount: number
+  /**
+   * GAP A / #489 — the cue this task most recently consumed via `sync` (its
+   * `(t, idPath)`). Desktop tracks this as `:sonic_pi_local_last_sync`
+   * (`core.rb:4551-4571`): a RE-sync's matcher is the LAST CONSUMED cue, and
+   * `event_history.rb:139` `ce > matcher.ce` is STRICT, so the same cue is never
+   * re-matched — only the next strictly-greater cue is. Without it an inline/main
+   * waiter (`[0]`) that catches an equal-vt ancestor cue (`[0,0]`) re-catches the
+   * SAME cue every iteration (its vt never advances) → runaway. The FIRST sync
+   * has no `lastSyncedCue`, so the `(t,idPath)` wake-phase (`cueDelivers`, #400)
+   * is unaffected. Cleared on Run (clear()) and at fresh registration.
+   */
+  lastSyncedCue?: { t: number; idPath: number[] }
 }
 
 export interface SchedulerEvent {
@@ -493,11 +505,18 @@ export class VirtualTimeScheduler {
       // ([0]) catches a driver cue ([0,0]) at the same vt (#481 with_fx/bare_loop).
       const kept: typeof waiters = []
       for (const waiter of waiters) {
-        if (cueDelivers(cueVirtualTime, cueIdPath, waiter.waiterVt, waiter.waiterIdPath)) {
-          const waiterTask = this.tasks.get(waiter.taskId)
+        const waiterTask = this.tasks.get(waiter.taskId)
+        // #489: don't re-deliver a cue at or before the one this waiter already
+        // consumed (desktop's last-sync matcher). The wake-phase (cueDelivers) is
+        // unchanged; this only excludes an already-seen cue on a re-sync.
+        const after = waiterTask?.lastSyncedCue
+        const delivers = cueDelivers(cueVirtualTime, cueIdPath, waiter.waiterVt, waiter.waiterIdPath)
+          && (!after || compareEvent({ t: cueVirtualTime, idPath: cueIdPath }, after) > 0)
+        if (delivers) {
           if (waiterTask) {
-            // Inherit cue's virtual time (SV5)
+            // Inherit cue's virtual time (SV5) and advance the re-sync matcher.
             waiterTask.virtualTime = cueVirtualTime
+            waiterTask.lastSyncedCue = { t: cueVirtualTime, idPath: cueIdPath }
           }
           waiter.resolve({ args, bpm: cueBpm })
         } else {
@@ -534,10 +553,17 @@ export class VirtualTimeScheduler {
     // History-first only for exact cue names; glob patterns (`sync "/midi:*"`,
     // #150) register and wait for a future matching cue (their cross-key history
     // scan is GAP M / not needed by #350/#481 which use exact names).
+    // #489: a re-sync excludes the cue this task last consumed (and anything
+    // before it) so an inline/main waiter doesn't re-catch the same equal-vt
+    // ancestor cue forever. First sync ⇒ `after` undefined ⇒ pure cueDelivers.
+    const after = task?.lastSyncedCue
     if (!name.includes('*') && !name.includes('?')) {
-      const hit = this.cueHistory.getNextDelivered(name, waiterVt, waiterIdPath)
+      const hit = this.cueHistory.getNextDelivered(name, waiterVt, waiterIdPath, after)
       if (hit) {
-        if (task) task.virtualTime = hit.t // inherit the cue's vt (SV5)
+        if (task) {
+          task.virtualTime = hit.t // inherit the cue's vt (SV5)
+          task.lastSyncedCue = { t: hit.t, idPath: hit.idPath } // #489: advance matcher
+        }
         const payload = hit.value as { args: unknown[]; bpm: number }
         return Promise.resolve({ args: payload.args, bpm: payload.bpm })
       }

--- a/src/engine/__tests__/EventHistory.test.ts
+++ b/src/engine/__tests__/EventHistory.test.ts
@@ -1,0 +1,142 @@
+/**
+ * EventHistory — the `(t, idPath)`-ordered store (GAP A2 / Spike 2), ported from
+ * desktop `event_history.rb`. These tests are the CONTRACT for the total order
+ * and the two query modes, asserted directly so the scheduler/TimeState wiring
+ * (which adds Promise/blocking glue) can rely on them.
+ *
+ * Grounded refs (sonic-pi-net/sonic-pi @ main):
+ *   - cueevent.rb:64-74   — `<=>`: t → priority(0) → thread_id → delta(0)
+ *   - thread_id.rb:41-55  — lexicographic idPath, longer-prefix-greater
+ *   - event_history.rb:505-511 — find_most_recent_event (inclusive `e <= ge`)
+ *   - event_history.rb:513-545 — find_next_event (strict `e > ge`)
+ */
+import { describe, it, expect } from 'vitest'
+import { EventHistory, compareIdPath, compareEvent } from '../EventHistory'
+
+describe('compareIdPath (thread_id.rb:41-55)', () => {
+  it('equal paths compare 0', () => {
+    expect(compareIdPath([0], [0])).toBe(0)
+    expect(compareIdPath([0, 1, 2], [0, 1, 2])).toBe(0)
+  })
+  it('element-wise on the shared prefix', () => {
+    expect(compareIdPath([0, 0], [0, 1])).toBe(-1)
+    expect(compareIdPath([0, 2], [0, 1])).toBe(1)
+  })
+  it('longer path is GREATER on a shared prefix (child > ancestor)', () => {
+    expect(compareIdPath([0, 0], [0])).toBe(1) // child after ancestor
+    expect(compareIdPath([0], [0, 0])).toBe(-1)
+    expect(compareIdPath([0, 0, 0], [0, 0])).toBe(1)
+  })
+})
+
+describe('compareEvent (cueevent.rb:64-74 — t then idPath)', () => {
+  it('orders by t first', () => {
+    expect(compareEvent({ t: 0, idPath: [9] }, { t: 1, idPath: [0] })).toBe(-1)
+    expect(compareEvent({ t: 2, idPath: [0] }, { t: 1, idPath: [9] })).toBe(1)
+  })
+  it('falls through to idPath at equal t (within epsilon)', () => {
+    expect(compareEvent({ t: 0, idPath: [0, 0] }, { t: 0, idPath: [0, 1] })).toBe(-1)
+    expect(compareEvent({ t: 0, idPath: [0, 0] }, { t: 0, idPath: [0] })).toBe(1)
+  })
+  it('treats float-noise-equal times as equal-t (epsilon)', () => {
+    expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5 + 1e-12, idPath: [0] })).toBe(0)
+  })
+})
+
+describe('EventHistory.insert — descending (t, idPath) order', () => {
+  it('keeps the list greatest-first regardless of insertion order', () => {
+    const h = new EventHistory()
+    h.insert('k', 1, [0], 'a')
+    h.insert('k', 0, [0], 'b') // out of order (smaller t)
+    h.insert('k', 2, [0], 'c')
+    // latest() reads events[0] — must be the greatest (t=2).
+    expect(h.latest('k')).toBe('c')
+    // most recent at or before t=0.5 is the t=0 entry.
+    expect(h.getMostRecent('k', 0.5, [0])!.value).toBe('b')
+  })
+})
+
+describe('EventHistory.getMostRecent — `get :key` (inclusive e <= ge)', () => {
+  it('returns the greatest event at or before the reader (INCLUSIVE)', () => {
+    const h = new EventHistory()
+    h.insert('root', 0, [0], 52)
+    h.insert('root', 1, [0], 55)
+    expect(h.getMostRecent('root', 0, [0])!.value).toBe(52) // inclusive at t=0
+    expect(h.getMostRecent('root', 0.9, [0])!.value).toBe(52)
+    expect(h.getMostRecent('root', 1, [0])!.value).toBe(55)
+  })
+  it('returns null when nothing is at or before the reader', () => {
+    const h = new EventHistory()
+    h.insert('root', 5, [0], 1)
+    expect(h.getMostRecent('root', 1, [0])).toBeNull()
+    expect(h.getMostRecent('missing', 1, [0])).toBeNull()
+  })
+
+  it('#400: at equal t, writer idPath ≤ reader idPath is visible; greater is NOT', () => {
+    // director-first: director [0,0] sets, player [0,1] reads at same t=0.
+    const h = new EventHistory()
+    h.insert('root', 0, [0, 0], 55) // director writes
+    expect(h.getMostRecent('root', 0, [0, 1])!.value).toBe(55) // player [0,1] sees [0,0]
+    // player-first: player [0,0] reads, director [0,1] writes at same t=0.
+    const h2 = new EventHistory()
+    h2.insert('root', 0, [0, 1], 55) // director [0,1] writes
+    // player [0,0] reads at (0,[0,0]) — director's (0,[0,1]) is GREATER → not ≤ →
+    // not visible → reads prior (null here). This is the #400/#350-reversed flip.
+    expect(h2.getMostRecent('root', 0, [0, 0])).toBeNull()
+  })
+})
+
+describe('EventHistory.getNext — `sync`/`get_next` (strict e > ge, find_next)', () => {
+  it('returns the SMALLEST event strictly after the sync point', () => {
+    const h = new EventHistory()
+    h.insert('tick', 0.5, [0, 0], 'a')
+    h.insert('tick', 1.0, [0, 0], 'b')
+    h.insert('tick', 1.5, [0, 0], 'c')
+    // syncer at t=0.7 → next is the t=1.0 event.
+    expect(h.getNext('tick', 0.7, [0])!.value).toBe('b')
+  })
+  it('returns null when no event is strictly after (must block)', () => {
+    const h = new EventHistory()
+    h.insert('tick', 0, [0, 0], 'a')
+    // syncer at t=1 with everything in the past → block.
+    expect(h.getNext('tick', 1, [0])).toBeNull()
+  })
+
+  it('#481 with_fx race: same-t higher-idPath cue IS delivered (the registration-race fix)', () => {
+    // driver [0,0] cued at vt0; inline with_fx waiter is in __run_once = main [0].
+    const h = new EventHistory()
+    h.insert('tick', 0, [0, 0], 'driver')
+    // idx === -1 (cue (0,[0,0]) is NOT <= (0,[0])); last > ge → deliver → onset 0.
+    expect(h.getNext('tick', 0, [0])!.value).toBe('driver')
+  })
+  it('#481 in_thread: same-t cue with LOWER idPath than waiter is NOT delivered (waits a cycle)', () => {
+    // driver [0,0] cued at vt0; forked in_thread waiter is [0,1].
+    const h = new EventHistory()
+    h.insert('tick', 0, [0, 0], 'driver')
+    // (0,[0,0]) <= (0,[0,1]) → idx 0, last ≯ ge → null → block → catches next@0.5.
+    expect(h.getNext('tick', 0, [0, 1])).toBeNull()
+    // ...then the driver's next cue at vt0.5 IS strictly after → delivered.
+    h.insert('tick', 0.5, [0, 0], 'driver-2')
+    expect(h.getNext('tick', 0, [0, 1])!.value).toBe('driver-2')
+  })
+
+  it('real met/#350 scenario: a freshly-started syncer with a HIGHER idPath waits a cycle', () => {
+    // met [0,0] auto-cues at vt0 BEFORE the synced loop [0,1] registers — the
+    // cue is already in history. idPath order (met < syncer) gives the right MISS
+    // WITH the history scan (the old code needed to ignore history only because
+    // it had no idPath to distinguish).
+    const h = new EventHistory()
+    h.insert('met', 0, [0, 0], 'beat0')
+    expect(h.getNext('met', 0, [0, 1])).toBeNull() // misses the simultaneous cue
+  })
+
+  it(':140 contrived (cue ahead of waiter, same idPath): faithful find_next DELIVERS it', () => {
+    // The grounded desktop behavior (event_history.rb:529-543): a cue at t=2.5
+    // recorded before a waiter syncs at t=0 (same idPath [0]) IS the "next" event
+    // → delivered. (idx === -1, last (2.5) > ge (0).) This is the intended change
+    // to SyncCue:140 — the old web rule blanket-ignored history.
+    const h = new EventHistory()
+    h.insert('ready', 2.5, [0], 'r')
+    expect(h.getNext('ready', 0, [0])!.value).toBe('r')
+  })
+})

--- a/src/engine/__tests__/EventHistory.test.ts
+++ b/src/engine/__tests__/EventHistory.test.ts
@@ -38,8 +38,12 @@ describe('compareEvent (cueevent.rb:64-74 — t then idPath)', () => {
     expect(compareEvent({ t: 0, idPath: [0, 0] }, { t: 0, idPath: [0, 1] })).toBe(-1)
     expect(compareEvent({ t: 0, idPath: [0, 0] }, { t: 0, idPath: [0] })).toBe(1)
   })
-  it('treats float-noise-equal times as equal-t (epsilon)', () => {
-    expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5 + 1e-12, idPath: [0] })).toBe(0)
+  it('compares t EXACTLY (no epsilon) — desktop time_r is a Rational', () => {
+    // The old fireCue +1e-9 epsilon broke the exact "last ≤ t" boundary; the
+    // faithful order is exact, so genuinely-equal vts (synced inherit / bit-exact
+    // launch origin) fall to idPath while a 1e-12 difference still orders by t.
+    expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5, idPath: [0] })).toBe(0)
+    expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5 + 1e-12, idPath: [0] })).toBe(-1)
   })
 })
 

--- a/src/engine/__tests__/EventHistory.test.ts
+++ b/src/engine/__tests__/EventHistory.test.ts
@@ -164,4 +164,40 @@ describe('EventHistory.getNextDelivered — `sync` wake-phase (cueDelivers)', ()
     h.insert('ready', 2.5, [0], 'r')
     expect(h.getNextDelivered('ready', 0, [0])!.value).toBe('r')
   })
+
+  // #489: the `after` (last-consumed cue) guard — desktop core.rb:4551-4571
+  // `:sonic_pi_local_last_sync` + event_history.rb:139 strict `ce > matcher.ce`.
+  describe('getNextDelivered `after` — re-sync excludes the consumed cue (#489)', () => {
+    it('an inline/main waiter [0] does NOT re-catch the same equal-vt ancestor cue', () => {
+      // The bare_loop runaway: driver [0,0] cues :tick at vt0; an inline `loop`
+      // waiter [0] catches it (equal-vt ancestor). On the NEXT sync — still vt0,
+      // still [0] — without the guard it re-delivers the SAME (0,[0,0]) cue
+      // forever (1024-voice runaway). With `after` = the consumed cue, it does not.
+      const h = new EventHistory()
+      h.insert('tick', 0, [0, 0], 'tick0')
+      const first = h.getNextDelivered('tick', 0, [0])
+      expect(first!.value).toBe('tick0') // first sync catches the equal-vt cue
+      // re-sync at the same point, excluding the just-consumed (0,[0,0]):
+      expect(h.getNextDelivered('tick', 0, [0], { t: 0, idPath: [0, 0] })).toBeNull()
+    })
+
+    it('after a catch, the NEXT strictly-greater cue is delivered (spread, not pile)', () => {
+      const h = new EventHistory()
+      h.insert('tick', 0, [0, 0], 'tick0')
+      h.insert('tick', 0.5, [0, 0], 'tick1')
+      // consumed (0,[0,0]) → next delivered is (0.5,[0,0]), not a re-catch of vt0.
+      expect(h.getNextDelivered('tick', 0, [0], { t: 0, idPath: [0, 0] })!.value).toBe('tick1')
+      // and after THAT, exclude (0.5,[0,0]) → nothing left → block for the next.
+      expect(h.getNextDelivered('tick', 0.5, [0], { t: 0.5, idPath: [0, 0] })).toBeNull()
+    })
+
+    it('a FIRST sync (after undefined) keeps the pure cueDelivers wake-phase (#400 intact)', () => {
+      const h = new EventHistory()
+      h.insert('tick', 0, [0, 0], 'tick0')
+      // no `after` ⇒ inline [0] still catches the equal-vt ancestor cue,
+      // sibling [0,1] still misses it — unchanged from the #400/#481 contract.
+      expect(h.getNextDelivered('tick', 0, [0])!.value).toBe('tick0')
+      expect(h.getNextDelivered('tick', 0, [0, 1])).toBeNull()
+    })
+  })
 })

--- a/src/engine/__tests__/EventHistory.test.ts
+++ b/src/engine/__tests__/EventHistory.test.ts
@@ -11,7 +11,7 @@
  *   - event_history.rb:513-545 — find_next_event (strict `e > ge`)
  */
 import { describe, it, expect } from 'vitest'
-import { EventHistory, compareIdPath, compareEvent } from '../EventHistory'
+import { EventHistory, compareIdPath, compareEvent, isStrictPrefix, cueDelivers } from '../EventHistory'
 
 describe('compareIdPath (thread_id.rb:41-55)', () => {
   it('equal paths compare 0', () => {
@@ -90,20 +90,41 @@ describe('EventHistory.getMostRecent — `get :key` (inclusive e <= ge)', () => 
   })
 })
 
-describe('EventHistory.getNext — `sync`/`get_next` (strict e > ge, find_next)', () => {
+describe('cueDelivers — the observed wake-phase (strict-later OR equal-vt strict-ancestor)', () => {
+  it('isStrictPrefix: proper ancestor only', () => {
+    expect(isStrictPrefix([0], [0, 0])).toBe(true)
+    expect(isStrictPrefix([0], [0, 5, 2])).toBe(true)
+    expect(isStrictPrefix([0], [0])).toBe(false) // equal, not strict
+    expect(isStrictPrefix([0, 0], [0, 1])).toBe(false) // siblings
+    expect(isStrictPrefix([0, 0], [0])).toBe(false) // descendant→ancestor
+  })
+  it('delivers a strictly-later cue regardless of idPath', () => {
+    expect(cueDelivers(1, [9], 0, [0])).toBe(true)
+    expect(cueDelivers(0, [0], 1, [9])).toBe(false) // earlier → never
+  })
+  it('at EQUAL vt: ancestor waiter catches; sibling/descendant misses', () => {
+    expect(cueDelivers(0, [0, 0], 0, [0])).toBe(true) // #481 with_fx: waiter [0] ⊏ cue [0,0]
+    expect(cueDelivers(0, [0, 0], 0, [0, 1])).toBe(false) // #481 in_thread: siblings
+    expect(cueDelivers(0, [0, 1], 0, [0, 0])).toBe(false) // #400 player: siblings
+    expect(cueDelivers(0, [0], 0, [0, 0])).toBe(false) // descendant cue, ancestor waiter
+    expect(cueDelivers(0, [0], 0, [0])).toBe(false) // equal idPath: not strict
+  })
+})
+
+describe('EventHistory.getNextDelivered — `sync` wake-phase (cueDelivers)', () => {
   it('returns the SMALLEST event strictly after the sync point', () => {
     const h = new EventHistory()
     h.insert('tick', 0.5, [0, 0], 'a')
     h.insert('tick', 1.0, [0, 0], 'b')
     h.insert('tick', 1.5, [0, 0], 'c')
     // syncer at t=0.7 → next is the t=1.0 event.
-    expect(h.getNext('tick', 0.7, [0])!.value).toBe('b')
+    expect(h.getNextDelivered('tick', 0.7, [0])!.value).toBe('b')
   })
   it('returns null when no event is strictly after (must block)', () => {
     const h = new EventHistory()
     h.insert('tick', 0, [0, 0], 'a')
     // syncer at t=1 with everything in the past → block.
-    expect(h.getNext('tick', 1, [0])).toBeNull()
+    expect(h.getNextDelivered('tick', 1, [0])).toBeNull()
   })
 
   it('#481 with_fx race: same-t higher-idPath cue IS delivered (the registration-race fix)', () => {
@@ -111,17 +132,17 @@ describe('EventHistory.getNext — `sync`/`get_next` (strict e > ge, find_next)'
     const h = new EventHistory()
     h.insert('tick', 0, [0, 0], 'driver')
     // idx === -1 (cue (0,[0,0]) is NOT <= (0,[0])); last > ge → deliver → onset 0.
-    expect(h.getNext('tick', 0, [0])!.value).toBe('driver')
+    expect(h.getNextDelivered('tick', 0, [0])!.value).toBe('driver')
   })
   it('#481 in_thread: same-t cue with LOWER idPath than waiter is NOT delivered (waits a cycle)', () => {
     // driver [0,0] cued at vt0; forked in_thread waiter is [0,1].
     const h = new EventHistory()
     h.insert('tick', 0, [0, 0], 'driver')
     // (0,[0,0]) <= (0,[0,1]) → idx 0, last ≯ ge → null → block → catches next@0.5.
-    expect(h.getNext('tick', 0, [0, 1])).toBeNull()
+    expect(h.getNextDelivered('tick', 0, [0, 1])).toBeNull()
     // ...then the driver's next cue at vt0.5 IS strictly after → delivered.
     h.insert('tick', 0.5, [0, 0], 'driver-2')
-    expect(h.getNext('tick', 0, [0, 1])!.value).toBe('driver-2')
+    expect(h.getNextDelivered('tick', 0, [0, 1])!.value).toBe('driver-2')
   })
 
   it('real met/#350 scenario: a freshly-started syncer with a HIGHER idPath waits a cycle', () => {
@@ -131,7 +152,7 @@ describe('EventHistory.getNext — `sync`/`get_next` (strict e > ge, find_next)'
     // it had no idPath to distinguish).
     const h = new EventHistory()
     h.insert('met', 0, [0, 0], 'beat0')
-    expect(h.getNext('met', 0, [0, 1])).toBeNull() // misses the simultaneous cue
+    expect(h.getNextDelivered('met', 0, [0, 1])).toBeNull() // misses the simultaneous cue
   })
 
   it(':140 contrived (cue ahead of waiter, same idPath): faithful find_next DELIVERS it', () => {
@@ -141,6 +162,6 @@ describe('EventHistory.getNext — `sync`/`get_next` (strict e > ge, find_next)'
     // to SyncCue:140 — the old web rule blanket-ignored history.
     const h = new EventHistory()
     h.insert('ready', 2.5, [0], 'r')
-    expect(h.getNext('ready', 0, [0])!.value).toBe('r')
+    expect(h.getNextDelivered('ready', 0, [0])!.value).toBe('r')
   })
 })

--- a/src/engine/__tests__/ReorderInvariance.test.ts
+++ b/src/engine/__tests__/ReorderInvariance.test.ts
@@ -1,31 +1,26 @@
 /**
- * Web self-consistency under loop-declaration reorder (SV47 / #350 slice 2).
+ * Loop-declaration-order parity with desktop (SV47 Slice 3 / #400 — GAP A2).
  *
- * WHAT THIS PROVES: our engine reads the SAME cross-loop set/get value
- * regardless of the source order in which the two live_loops are declared —
- * {55, 59} for both director-first and player-first. The #350 value-phase fix
- * (eager `b.set` at build + inclusive "last ≤ reader-vt" time-index) does NOT
- * leak a source-order / insertionOrder dependence (our scheduler ties same-vt
- * wakes on insertionOrder, VirtualTimeScheduler.ts:194-196 — NOT a desktop-style
- * total order; the `(time, taskId)` docstring at :152 is aspirational).
+ * WHAT THIS PROVES: our engine now matches desktop's declaration-order
+ * DEPENDENCE via the `(t, idPath)` total order (EventHistory, a port of
+ * `event_history.rb`). director-first → {55, 59}; player-first → {52, 57}.
  *
- * WHAT THIS DOES *NOT* CLAIM: desktop parity on the reversed order. Grounded +
- * reproduced ×3 (2026-05-28), DESKTOP IS declaration-order-DEPENDENT here:
- * director-first → {55,59}, player-first → {52,57}. Root: desktop `sync` =
- * get_next "next cue strictly AFTER my time t" (event_history.rb:215,542) over
- * the full CueEvent total order (t, p, i, d…); at equal vt the (p=priority,
- * i=thread_id, d=thread_delta) thread-identity fields (core.rb:114-119, assigned
- * at thread spawn = declaration order) break the tie, so player-first catches the
- * t=0 cue (index 0 = 52). We do NOT implement that (t,p,i,d) total order — our
- * strict-vt-after wake-phase (Slice 1) collapses the equal-vt case, making web
- * self-consistent instead. Matching desktop's order-dependence is a separate
- * wake-phase/event-ordering parity feature (Slice 3, deferred — see GitHub issue
- * + memory sp95_350_reversed_order_total_order_gap). r1 NORMAL order is the #350
- * gate and is a stable Tier-1 PITCH-MATCH ×3.
+ * Root (grounded ×3, 2026-05-28; ported 2026-06-06): desktop `get`/`sync` resolve
+ * over the full CueEvent total order; at equal virtual time the thread-id path
+ * `i` (assigned at thread spawn = declaration order, runtime.rb:1071-1074) breaks
+ * the tie. The first-declared live_loop gets idPath [0,0], the second [0,1].
+ *  - director-first: director [0,0] writes :root; player [0,1] reads at the
+ *    equal cue vt. (vt,[0,0]) ≤ (vt,[0,1]) → the write IS visible → {55,59}.
+ *  - player-first: player [0,0] reads; director [0,1] writes. (vt,[0,1]) is
+ *    GREATER than (vt,[0,0]) → NOT yet visible → player reads the PRIOR ring
+ *    value → {52,57}.
  *
- * Companion Level-3 reproducers: /tmp/s8/r1_director_section.rb (normal — desktop
- * PITCH-MATCH) + /tmp/s8/r1_director_section_reversed.rb (reversed — desktop
- * diverges to {52,57} BY DESIGN, web stays {55,59}).
+ * This REPLACES the prior "web self-consistency" assertion (both {55,59}), which
+ * was the documented Slice-3 divergence — now closed. No ε is relaxed; the flip
+ * is structural (the idPath axis), falsifiable, and ε-insensitive (SP126/SV61).
+ *
+ * Companion Level-3 reproducers: /tmp/s8/r1_director_section.rb (normal {55,59})
+ * + /tmp/s8/r1_director_section_reversed.rb (reversed {52,57} = desktop).
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -85,22 +80,21 @@ async function playerPrefix(src: string, n = 2): Promise<number[]> {
   return notes.slice(0, n)
 }
 
-describe('Web self-consistency under loop reorder (SV47 / #350)', () => {
+describe('Loop reorder parity with desktop (SV47 Slice 3 / #400)', () => {
   beforeEach(() => {
     delete (globalThis as Record<string, unknown>).SuperSonic
   })
 
-  it('director-first and player-first produce the IDENTICAL web prefix {55, 59}', async () => {
+  it('declaration order determines the read: director-first {55,59}, player-first {52,57}', async () => {
     const a = await playerPrefix(DIRECTOR_FIRST, 2)
     const b = await playerPrefix(PLAYER_FIRST, 2)
-    // director-first matches desktop's {55, 59} — the #350 value-phase fix
-    // (Level-3 PITCH-MATCH ×3). player-first is web's self-consistent result;
-    // desktop diverges to {52,57} here BY DESIGN (the (t,p,i,d) total-order gap,
-    // Slice 3) — NOT asserted against desktop. See file header.
+    // director-first: director [0,0] write ≤ player [0,1] read → visible → {55,59}.
     expect(a).toEqual([55, 59])
-    expect(b).toEqual([55, 59])
-    // The two web prefixes match each other — web does NOT leak a source-order /
-    // insertionOrder dependence. If it did, they would diverge here.
-    expect(b).toEqual(a)
+    // player-first: director [0,1] write > player [0,0] read → not yet visible →
+    // reads prior ring value → {52,57}. Desktop parity (was a divergence).
+    expect(b).toEqual([52, 57])
+    // The two prefixes now DIVERGE by source order — the (t, idPath) total order
+    // reproduces desktop's declaration-order dependence (no longer self-consistent).
+    expect(b).not.toEqual(a)
   })
 })

--- a/src/engine/__tests__/SonicPiEngineTimeState.test.ts
+++ b/src/engine/__tests__/SonicPiEngineTimeState.test.ts
@@ -93,9 +93,14 @@ describe('Time State — engine-level cross-loop set/get (SV47 / #350)', () => {
     engine.dispose()
   })
 
-  it('(e) reversed: player declared BEFORE director — STILL reads {55,59} (reorder-invariant)', async () => {
-    // The HARD gate. If this reads {52,57} or anything else, the design has
-    // leaked a source-order dependence — eager-apply by causation is broken.
+  it('(e) reversed: player declared BEFORE director — reads desktop {52,57} (GAP A2 / #400)', async () => {
+    // DESKTOP-PARITY gate (was a documented divergence; SV47 Slice 3 / #400).
+    // Source order now matters via the (t, idPath) total order: player declared
+    // FIRST gets idPath [0,0], director [0,1]. At the equal cue vt, the director's
+    // set ((vt,[0,1])) is GREATER than the player's read point ((vt,[0,0])), so it
+    // is NOT yet visible — the player reads the PRIOR ring value, landing on
+    // {52,57} instead of {55,59}. This mirrors desktop exactly
+    // (event_history.rb get = "greatest event ≤ (t, idPath)").
     const engine = new SonicPiEngine()
     await engine.init()
 
@@ -119,8 +124,8 @@ describe('Time State — engine-level cross-loop set/get (SV47 / #350)', () => {
 
     const played = midiNotes(events, 'player')
     expect(played.length).toBeGreaterThanOrEqual(2)
-    expect(played[0]).toBe(55)
-    expect(played[1]).toBe(59)
+    expect(played[0]).toBe(52)
+    expect(played[1]).toBe(57)
 
     engine.dispose()
   })
@@ -154,17 +159,23 @@ describe('Time State — engine-level cross-loop set/get (SV47 / #350)', () => {
     await drive(engine, 5, 5)
 
     const store = (engine as unknown as {
-      globalStore: { get: (k: string, t?: number) => unknown }
+      globalStore: { get: (k: string, t?: number, readerIdPath?: number[]) => unknown }
     }).globalStore
 
+    // GAP A2: the writes were tagged with `:writer`'s idPath ([0,0] — the first
+    // top-level fork), so a white-box read must use a reader idPath that
+    // dominates the writer's to see them (a main reader at [0] would NOT see a
+    // child loop's equal-t write — correct per the (t, idPath) total order). Read
+    // at the writer's own idPath to isolate the TIME dimension this test checks.
+    const RID = [0, 0]
     // Iteration 1 starts at vt=0 (initial sleep(0) wake), so the per-set
     // timestamps are 0 (set :y, 1) and 2 (set :y, 2 — after sleep 2).
-    expect(store.get('y', -0.5)).toBeNull() // before any write
-    expect(store.get('y', 0)).toBe(1) // at the first set's vt
-    expect(store.get('y', 1)).toBe(1) // between the two sets
-    expect(store.get('y', 1.99)).toBe(1) // just before the second set
-    expect(store.get('y', 2)).toBe(2) // at the second set's vt (inclusive)
-    expect(store.get('y', 10)).toBe(2) // long after — latest stays visible
+    expect(store.get('y', -0.5, RID)).toBeNull() // before any write
+    expect(store.get('y', 0, RID)).toBe(1) // at the first set's vt
+    expect(store.get('y', 1, RID)).toBe(1) // between the two sets
+    expect(store.get('y', 1.99, RID)).toBe(1) // just before the second set
+    expect(store.get('y', 2, RID)).toBe(2) // at the second set's vt (inclusive)
+    expect(store.get('y', 10, RID)).toBe(2) // long after — latest stays visible
 
     engine.dispose()
   })

--- a/src/engine/__tests__/SyncCue.test.ts
+++ b/src/engine/__tests__/SyncCue.test.ts
@@ -137,14 +137,15 @@ describe('sync/cue', () => {
     expect(w2Play!.audioTime).toBe(101)
   })
 
-  it('sync waits for fresh cue, does not resolve from stale cueMap', async () => {
-    // In Sonic Pi, sync always waits for a FRESH cue — never resolves from stale ones.
-    // This prevents synced loops from starting at vt=0 when the sync target's
-    // auto-cue fires before the synced loop calls waitForSync.
-    const scheduler = new VirtualTimeScheduler({
-      getAudioTime: () => 0,
-      schedAheadTime: 100,
-    })
+  it('sync does not resolve from a genuinely-PAST cue (lower vt); waits for a fresh one (SV11)', async () => {
+    // GAP A2: `sync` resolves over the (t, idPath) event history via get_next —
+    // "the next cue strictly AFTER my sync point" (event_history.rb:215). A cue
+    // recorded at a LOWER virtual time than the syncer's point is in its PAST, so
+    // it is NOT "next" and is NOT delivered — the syncer waits for a future cue.
+    // (This is the real SV11 invariant. NB: unlike the pre-A2 web rule, a cue at a
+    // HIGHER vt already in history IS the next cue and DOES deliver — faithful
+    // find_next; see EventHistory.test.ts ":140 contrived".)
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
 
     scheduler.registerLoop('source', async () => {
       await scheduler.scheduleSleep('source', 999999)
@@ -152,12 +153,15 @@ describe('sync/cue', () => {
     scheduler.tick(100)
     await flushMicrotasks()
 
-    scheduler.getTask('source')!.virtualTime = 2.5
+    // A cue fires at vt 0 (in the past relative to the syncer below).
+    scheduler.getTask('source')!.virtualTime = 0
     scheduler.fireCue('ready', 'source')
 
     let syncedTime = -1
     scheduler.registerLoop('late', async () => {
-      const args = await scheduler.waitForSync('ready', 'late')
+      // The syncer is already AHEAD (vt 2.5) when it syncs — the vt-0 cue is past.
+      scheduler.getTask('late')!.virtualTime = 2.5
+      await scheduler.waitForSync('ready', 'late')
       syncedTime = scheduler.getTask('late')!.virtualTime
       await scheduler.scheduleSleep('late', 999999)
     })
@@ -165,10 +169,10 @@ describe('sync/cue', () => {
     scheduler.tick(100)
     await flushMicrotasks()
 
-    // sync should NOT have resolved yet — cue was stale
+    // The vt-0 cue is in the syncer's past → NOT delivered.
     expect(syncedTime).toBe(-1)
 
-    // Now fire a fresh cue — this should wake the synced loop
+    // A fresh cue strictly after the syncer's point (vt 5) — this one wakes it.
     scheduler.getTask('source')!.virtualTime = 5.0
     scheduler.fireCue('ready', 'source')
     await flushMicrotasks()
@@ -371,6 +375,42 @@ describe('sync/cue — SP95(d) build-time payload + wake-phase (#350/#351)', () 
     scheduler.fireCue('beat', 'sender', [{ val: 64 }])
     await flushMicrotasks()
     expect(resolved).toEqual({ args: [{ val: 64 }], bpm: sender.bpm })
+  })
+
+  it('the #481 idPath split: at equal vt0 an inline/main waiter CATCHES the cue; a forked-sibling MISSES', async () => {
+    // GAP A2 — the #481 fix in miniature. Driver `[0,0]` cues at vt0. A waiter
+    // INLINE in main (`[0]`, e.g. with_fx/bare_loop in __run_once) is < the cue's
+    // idPath at equal vt, so the cue is STRICTLY GREATER → delivered now (onset 0).
+    // A forked-sibling waiter (`[0,1]`, e.g. in_thread) is > the cue's idPath, so
+    // the cue is NOT strictly greater → it waits for the next cycle (onset 0.5).
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    scheduler.registerLoop('driver', async () => {}, { idPath: [0, 0] })
+    scheduler.registerLoop('mainWaiter', async () => {}, { idPath: [0] })
+    scheduler.registerLoop('forkWaiter', async () => {}, { idPath: [0, 1] })
+    for (const n of ['driver', 'mainWaiter', 'forkWaiter']) scheduler.getTask(n)!.virtualTime = 0
+
+    // Driver fires its vt0 cue FIRST (it is in history before either waiter syncs)
+    // — reproduces the with_fx registration race.
+    scheduler.fireCue('tick', 'driver', [{ beat: 0 }])
+
+    let mainRes: unknown = 'PENDING'
+    let forkRes: unknown = 'PENDING'
+    scheduler.waitForSync('tick', 'mainWaiter').then((p) => { mainRes = p })
+    scheduler.waitForSync('tick', 'forkWaiter').then((p) => { forkRes = p })
+    await flushMicrotasks()
+
+    // main/inline waiter caught the vt0 cue (history-first getNext finds it).
+    expect(mainRes).toEqual({ args: [{ beat: 0 }], bpm: scheduler.getTask('driver')!.bpm })
+    // forked sibling missed it — still pending.
+    expect(forkRes).toBe('PENDING')
+    expect(scheduler.getTask('mainWaiter')!.virtualTime).toBe(0) // inherited the cue's vt0
+
+    // Driver's NEXT cue at vt0.5 — the forked sibling catches this one.
+    scheduler.getTask('driver')!.virtualTime = 0.5
+    scheduler.fireCue('tick', 'driver', [{ beat: 1 }])
+    await flushMicrotasks()
+    expect(forkRes).toEqual({ args: [{ beat: 1 }], bpm: scheduler.getTask('driver')!.bpm })
+    expect(scheduler.getTask('forkWaiter')!.virtualTime).toBe(0.5)
   })
 
   it('manual builder sync (no scheduler) keeps the legacy runtime-step path + returns this', () => {


### PR DESCRIPTION
Stacked on **#488** (GAP A1 idPath). Base will auto-retarget to \`fix-parity-gap\` when #488 merges. Part of GAP A umbrella **#487**.

## What this delivers
The flagship thread-identity total order — cross-thread coordination (cue/sync/get/set) now resolves over ONE `(t, idPath)`-ordered EventHistory (port of desktop `event_history.rb`), and the cue wake-phase matches OBSERVED desktop behaviour. **All of #400 + the three #481 cells EVENT-MATCH on the real engine.**

## Commits
- **A2.1** `e5ec944` — `EventHistory.ts`, the `(t,idPath)` store (insert / getMostRecent / getNextDelivered, maxPerKey cap).
- **A2.2** `5abc2a3` — set/get resolve by `(t,idPath)` (TimeState = idPath facade). **Closes #400** (real-engine verified).
- **A2.3** `5470fcb` — cue/sync via cueHistory; wake-phase `cueDelivers` = strict-ANCESTOR (happens-before), NOT lexicographic (Level-3-grounded: desktop reversed plays {52,57}, lex predicts {52,55}).
- **A2.4** `55e074c` — top-level `in_thread` sync via the RUNTIME-STEP path (`__oneShotThread` skips `setSyncContext`), so a one-shot's multi-sync body interleaves at interpret time instead of build-await batching every play at the final vt. **SP131 / #481 in_thread.**
- **A2.5** `ac07b38` + `10ff2c9` (test) — `TaskState.lastSyncedCue` + `getNextDelivered(after)` mirroring desktop `:sonic_pi_local_last_sync` (core.rb:4551-4571, strict `ce>matcher.ce`): a re-sync can't re-catch the same equal-vt cue. **SP132 / closes #489, #490 (bare_loop runaway + with_fx pile).** First sync unchanged → #400 preserved.
- `5d163ad` — doc fix (lastSyncedCue lifecycle).

## Verification (Level-3, desktop-vs-web event-parity, real engine)
| case | result |
|---|---|
| #400 director-first | EVENT-MATCH, notes {55,59}, Δ0ms |
| #400 player-first (reversed) | EVENT-MATCH, notes {52,57}, Δ0ms |
| #481 in_thread | EVENT-MATCH, 8 onsets, Δ1ms |
| #481 bare_loop | EVENT-MATCH, 16 onsets, Δ2ms (was 1024 runaway) |
| #481 with_fx | EVENT-MATCH, 8 onsets, Δ4ms (was DIVERGE) |

Suite **1244/1244**, `tsc --noEmit` clean. Gate files green: SyncCue, EventHistory, ReorderInvariance, SonicPiEngineTimeState, ThreadIdPath, NestedInThreadFork. No ε relaxation (SP126/SV61). The shared ProgramBuilder.sync build-await path (#350) is untouched by A2.4/A2.5.

## Non-goals (deferred by design)
GAP M (cue/set path namespace — `set` does not wake `sync`), GAP B (vt0 arming — confirmed fine), EventHistory pruning beyond maxPerKey=256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)