### PR TITLE
GAP E — explicit Stop declick via mixer amp fade (closes #493)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -343,6 +343,12 @@ export class SonicPiEngine {
     }
 
     try {
+      // GAP E (#493): if a previous Stop is still inside its declick fade
+      // window, complete its deferred /g_freeAll NOW — before this Run ships
+      // any /s_new — so the old nodes are gone and the mixer amp is restored
+      // to baseline. Idempotent no-op when nothing is pending.
+      this.bridge?.flushPendingStopFade()
+
       // No-op Update short-circuit: if the user clicks Update without
       // changing a single character, hot-swap is pure churn — it would kill
       // every running synth, recreate FX, and restart loop iterations even
@@ -1930,9 +1936,15 @@ export class SonicPiEngine {
       this.recorder = null
     }
 
-    // Free all scsynth nodes for clean silence
+    // Free all scsynth nodes for clean silence — but declick first (GAP E,
+    // #493): ramp the scsynth mixer amp to 0 over a short fade, THEN /g_freeAll,
+    // so the node-kill can never click. The free is deferred behind the fade; a
+    // Run within the fade window flushes it (evaluate() calls
+    // flushPendingStopFade at entry). The JS-side bus-pool frees below run
+    // synchronously — that's safe because the only thing that could reuse a
+    // returned bus is a new Run, which flushes the deferred free first.
     if (this.bridge) {
-      this.bridge.freeAllNodes()
+      this.bridge.fadeOutAndFreeAllNodes()
       // Release mic / line-in tracks so the browser's recording indicator
       // clears and nothing keeps feeding scsynth's input channel (#152).
       this.bridge.stopAllLiveAudio()

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -119,6 +119,14 @@ const COMMON_SYNTHDEFS = [
 /** Max stereo track outputs (beyond master). Channels 0-1 = master, 2-3 = track 0, etc. */
 const NUM_OUTPUT_CHANNELS = 2 + AUDIO_IO.MAX_TRACK_OUTPUTS * 2 // 14 channels total
 
+/** Stop-declick fade (GAP E, #493). Master-gain ramp-to-0 duration before the
+ *  /g_freeAll node-kill, and the extra margin before the deferred free fires.
+ *  30ms is imperceptible as Stop latency yet ample to cover the node-free
+ *  instant (a few ms suffices). Desktop uses ~1s, but that also drains
+ *  sched-ahead events via sleep — we purge() those instead. */
+const STOP_FADE_SEC = 0.03
+const STOP_FADE_MARGIN_MS = 10
+
 // Gain staging, I/O, and safety parameters are centralized in config.ts.
 // See config.ts SECTION 1 (MIXER) for the full A/B calibration history.
 import { MIXER, AUDIO_IO } from './config'
@@ -172,6 +180,10 @@ export class SuperSonicBridge {
   private splitter: ChannelSplitterNode | null = null
   private masterMerger: ChannelMergerNode | null = null
   private masterGainNode: GainNode | null = null
+  /** Stop-declick (GAP E, #493): deferred /g_freeAll timer + the mixer amp to
+   *  restore after the fade completes. See fadeOutAndFreeAllNodes. */
+  private pendingStopFade: ReturnType<typeof setTimeout> | null = null
+  private stopFadeBaseline = 1
   /** Per-loop monitor state: loopBus (internal routing) + monitorNodeId (scsynth node) */
   private loopMonitors = new Map<string, { loopBus: number; monitorNodeId: number }>()
   /** Whether the track-monitor SynthDef has been loaded via /d_recv */
@@ -1388,6 +1400,78 @@ export class SuperSonicBridge {
   }
 
   /**
+   * Declick teardown for Stop (GAP E, #493). Ramp the scsynth mixer amp to 0
+   * over a short fade, THEN hard-free all nodes — so the /g_freeAll node-kill
+   * lands while bus 0 is already silent and can never produce a click.
+   *
+   * Direct port of desktop's `shutdown_job_mixer` (`sound.rb:3965-3971`):
+   * `ctl amp_slide: t; ctl amp: 0; sleep t; kill`. We fade the MIXER (not the
+   * Web Audio masterGainNode) deliberately: the mixer sits on bus 0 upstream of
+   * the splitter → analyser → masterGain fan-out, so fading it declicks EVERY
+   * downstream tap — the speakers AND the analyser-tapped in-app Rec
+   * (App.ts records `audio.analyser`, which is BEFORE masterGain; a masterGain
+   * fade would miss it). amp_slide is verified to ramp in WASM scsynth.
+   *
+   * The fade is ~30ms, not desktop's ~1s: desktop's long fade also drains
+   * sched-ahead events via `Kernel.sleep`; we purge() future bundles instead,
+   * so we only need to cover the node-free instant (~-40dB residual by the
+   * deferred free — inaudible).
+   *
+   * Today the WASM output path already smooths the /g_freeAll cut (observed:
+   * no click on Stop pre-fix). This makes that guarantee EXPLICIT rather than
+   * reliant on an incidental property — a future change to the free path
+   * cannot reintroduce a click.
+   *
+   * The free is DEFERRED until after the fade. A Run within the fade window
+   * MUST flush it first — flushPendingStopFade() is called at evaluate() entry
+   * so old nodes are torn down before new /s_new bundles ship (verified: a
+   * fast Stop→Run does not silence the new run).
+   */
+  fadeOutAndFreeAllNodes(fadeSec: number = STOP_FADE_SEC): void {
+    // Fade the scsynth MIXER amp (not the Web Audio masterGainNode): the mixer
+    // sits on bus 0 upstream of the splitter → analyser → masterGain fan-out,
+    // so fading it declicks EVERY downstream tap — the speakers AND the
+    // analyser-tapped Rec (App.ts records audio.analyser, which is pre-gain).
+    // This is the direct port of desktop's shutdown_job_mixer (sound.rb:3965).
+    if (!this.sonic || !this.mixerNodeId) { this.freeAllNodes(); return }
+    this.flushPendingStopFade()  // collapse any prior pending fade (no stacking)
+    this.stopFadeBaseline = this.currentMixerAmp
+    // amp_slide is the Lag time on the mixer synthdef's amp param; set it then
+    // drive amp to 0 so scsynth ramps bus 0 to silence over fadeSec.
+    this.sonic.send('/n_set', this.mixerNodeId, 'amp_slide', fadeSec)
+    this.sonic.send('/n_set', this.mixerNodeId, 'amp', 0)
+    this.pendingStopFade = setTimeout(() => {
+      this.pendingStopFade = null
+      this.completeStopFade()
+    }, fadeSec * 1000 + STOP_FADE_MARGIN_MS)
+  }
+
+  /**
+   * Run any pending Stop-fade teardown immediately (cancel timer, free now,
+   * restore gain). Idempotent no-op when nothing is pending. Called at
+   * evaluate() entry so a Run during the fade window tears the old nodes down
+   * before new bundles ship, and on dispose so the deferred callback never
+   * fires against a torn-down context.
+   */
+  flushPendingStopFade(): void {
+    if (this.pendingStopFade === null) return
+    clearTimeout(this.pendingStopFade)
+    this.pendingStopFade = null
+    this.completeStopFade()
+  }
+
+  /** Free all nodes then restore the mixer amp to its pre-fade value (bus 0 is
+   *  silent now, so the restore is inaudible — it readies the mixer for the
+   *  next Run). amp_slide is reset to 0 so the restore is instant. */
+  private completeStopFade(): void {
+    this.freeAllNodes()
+    if (this.sonic && this.mixerNodeId) {
+      this.sonic.send('/n_set', this.mixerNodeId, 'amp_slide', 0)
+      this.sonic.send('/n_set', this.mixerNodeId, 'amp', this.stopFadeBaseline)
+    }
+  }
+
+  /**
    * Drain future-scheduled bundles from the WASM scheduler queue WITHOUT
    * killing currently-rendering synths.
    *
@@ -1439,6 +1523,9 @@ export class SuperSonicBridge {
   }
 
   dispose(): void {
+    // Run any deferred Stop-fade free NOW so its timer can't fire against the
+    // torn-down context/nodes below (GAP E, #493).
+    this.flushPendingStopFade()
     // Stop all live audio streams
     this.stopAllLiveAudio()
     if (this.masterGainNode) {

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -28,6 +28,7 @@ function createMockSuperSonic() {
     loadSynthDefs: vi.fn().mockResolvedValue(undefined),
     loadSample: vi.fn().mockResolvedValue(undefined),
     sync: vi.fn().mockResolvedValue(undefined),
+    purge: vi.fn().mockResolvedValue(undefined),
     nextNodeId: vi.fn(() => nodeIdCounter++),
     destroy: vi.fn(),
     node: { connect: vi.fn() },
@@ -369,5 +370,63 @@ describe('SuperSonicBridge', () => {
     bridge.dispose()
 
     expect(mockSonic.destroy).toHaveBeenCalled()
+  })
+
+  // GAP E (#493): Stop declick — fade the mixer amp, defer /g_freeAll until the
+  // fade completes, and let a Run within the fade window flush it first.
+  describe('fadeOutAndFreeAllNodes — Stop declick (GAP E, #493)', () => {
+    it('fades the mixer amp to 0 and DEFERS the /g_freeAll until after the fade', async () => {
+      vi.useFakeTimers()
+      try {
+        const { mockSonic, sent } = createMockSuperSonic()
+        ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+        const bridge = new SuperSonicBridge()
+        await bridge.init()
+        sent.length = 0
+
+        bridge.fadeOutAndFreeAllNodes()
+
+        // Mixer amp ramped to 0 immediately (amp_slide set, then amp 0).
+        const sets = sent.filter(m => m.address === '/n_set')
+        expect(sets.some(m => m.args[1] === 'amp_slide')).toBe(true)
+        const ampSet = sets.find(m => m.args[1] === 'amp')
+        expect(ampSet?.args[2]).toBe(0)
+        // The hard node-free is NOT sent yet — it's deferred behind the fade.
+        expect(sent.some(m => m.address === '/g_freeAll')).toBe(false)
+
+        // After the fade window, /g_freeAll fires and the amp is restored.
+        vi.runAllTimers()
+        const frees = sent.filter(m => m.address === '/g_freeAll').map(m => m.args[0])
+        expect(frees).toEqual([100, 101, 102])
+        const restore = sent.filter(m => m.address === '/n_set' && m.args[1] === 'amp').pop()
+        expect(restore?.args[2]).not.toBe(0)  // restored to the pre-fade baseline
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('flushPendingStopFade completes the deferred free immediately (Run during fade)', async () => {
+      vi.useFakeTimers()
+      try {
+        const { mockSonic, sent } = createMockSuperSonic()
+        ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+        const bridge = new SuperSonicBridge()
+        await bridge.init()
+        sent.length = 0
+
+        bridge.fadeOutAndFreeAllNodes()
+        expect(sent.some(m => m.address === '/g_freeAll')).toBe(false)  // still deferred
+
+        bridge.flushPendingStopFade()  // simulate a Run inside the fade window
+        expect(sent.filter(m => m.address === '/g_freeAll').map(m => m.args[0])).toEqual([100, 101, 102])
+
+        // The deferred timer must not double-fire after the flush.
+        sent.length = 0
+        vi.runAllTimers()
+        expect(sent.some(m => m.address === '/g_freeAll')).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 })


### PR DESCRIPTION
## GAP E — explicit Stop declick (closes #493)

Part of the desktop-parity stack (umbrella #487). Branches off `fix-parity-gap`.

### TL;DR
Observation overturned GAP E's premise, so this ships the *minimal* fix rather than the register's prescribed 4-phase `LifecycleHooks` refactor.

### What the observation found
A lossless capture (raw float32 PCM, two amplitudes incl. a loud dry saw at 0.40 FS) across a Stop showed **no audible click today** — the WASM output path already smooths the `/g_freeAll` cut (~20ms fall, max sample jump ≤2/32768). The bus-leak half (SP85) is already fixed on both paths. So GAP E's headline ("structural root of the click-on-stop / bus-leak") was *empirically already satisfied*.

That makes the full 4-phase `LifecycleHooks` refactor a zero-behavior-change rewrite of a working, load-bearing teardown path with a **flat cost curve** (last teardown bug SP88 was 2026-05-14). Per "When NOT to Consolidate", it was **not** done. (Source read also corrected #364-2: the `Kernel.sleep` at `runtime.rb:992` is between `exit`→`all_completed`, not `completed`→`exit`; and the real desktop anti-click is the mixer amp fade in `shutdown_job_mixer`, not the sched-ahead sleep.)

### What this PR does — declick insurance (SV64)
Make the no-click guarantee **explicit** instead of an incidental WASM property a future change could break:
- `stop()` ramps the **scsynth mixer amp → 0** over 30ms (`/n_set amp_slide` + `amp 0`) and **defers `/g_freeAll`** until bus 0 is silent. Direct port of desktop's `shutdown_job_mixer` (`sound.rb:3965-3971`).
- Fades the **mixer** (bus 0, upstream of `splitter → analyser → masterGain`) not the Web Audio masterGain, so it declicks **every** downstream tap — the speakers *and* the analyser-tapped in-app Rec (`App.ts:1011` records `audio.analyser`, which is pre-gain; a masterGain fade would miss it).
- `flushPendingStopFade()` re-entrancy guard at `evaluate()` entry + `bridge.dispose()`: a Run inside the fade window completes the deferred free first, so the new run isn't killed and the mixer amp is restored.
- Fade is 30ms not desktop's ~1s: we `purge()` future bundles instead of draining via sleep, so we only cover the node-free instant (~-40dB residual by the deferred free — inaudible).
- `stop()` stays `void` (the `@motif/editor` contract); fade+free run async like desktop's GC thread.

### Test plan
- **L1:** `tsc` clean; `1213/1213` (+2 bridge unit tests: fade ramps amp + defers free; flush completes immediately and doesn't double-fire).
- **L3 (real engine):** `amp_slide` confirmed to ramp in WASM (refines blind-spot #6); sustained saw fades smoothly to silence with no sample discontinuity; **fast Stop→Run keeps the new run alive** (deferred free flushed, amp restored).

### Notes
- The full 4-phase `LifecycleHooks` abstraction remains a future option *only if* a teardown bug appears that the current per-site fixes don't cover.
- Catalogues (anvideck): SV64, PARITY-GAPS GAP E → resolved, dharana §40.
