### PR TITLE
GAP M — Time State richness: hierarchical paths + arg_matcher + current_bpm_mode (#496)

### DIFF
--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -29,6 +29,7 @@ export const DSL_NAMES = [
   'hz_to_midi', 'midi_to_hz',
   'quantise', 'quantize', 'octs',
   'current_bpm',
+  'current_bpm_mode',
   'puts', 'print', 'stop', 'stop_loop',
   // Volume & introspection
   'set_volume', 'current_synth', 'current_volume',

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -34,7 +34,7 @@
  * history pruning (`@history_depth`, event_history.rb:163) are likewise deferred.
  */
 
-import { pathMatch } from './PathMatcher'
+import { pathMatch, toWritePath, toReadPath } from './PathMatcher'
 
 /** Glob tokens that force a read to scan-and-merge across keys (GAP M1b). */
 const GLOB_TOKENS = /[*?{[]/
@@ -292,5 +292,46 @@ export class EventHistory {
   /** Clear all events. Dispose-only (SK14) — never on stop/run. */
   clear(): void {
     this.store.clear()
+  }
+}
+
+/**
+ * TimeStateView — GAP M1c. Exposes the prior `TimeState` `{set, get}` interface
+ * but backed by a SHARED EventHistory with path namespacing, so `set`/`get` use
+ * the ONE coordination store that `cue`/`sync` use (desktop's single
+ * `@event_history`). The consequence — desktop-faithful — is that a `get :foo`
+ * now sees a `cue :foo` / `live_loop :foo` (the `/{cue,set,live_loop}/foo` read
+ * union), which the separate-store world could not do.
+ *
+ * Writes go to the `/set/` root (`toWritePath(key, 'set')`); reads use the union
+ * glob (`toReadPath`). The leading-`/` heuristic (PathMatcher) routes an explicit
+ * absolute key (`set "/a/b"`) to a verbatim path. Returns value-or-`null`,
+ * matching the prior TimeState vt-aware contract (SonicPiEngine `?? null`).
+ */
+export class TimeStateView {
+  constructor(private readonly eh: EventHistory) {}
+
+  set(key: string | symbol, value: unknown, t: number, writerIdPath: number[] = [0]): void {
+    this.eh.insert(toWritePath(String(key), 'set'), t, writerIdPath, value)
+  }
+
+  get(key: string | symbol, t?: number, readerIdPath: number[] = [0]): unknown {
+    const readPath = toReadPath(String(key))
+    // No-vt facade (the engine's `get(key)` fallback): the absolute latest across
+    // the union — a reader at +∞ with a maximal idPath sees every stored event.
+    const at = t === undefined ? Number.POSITIVE_INFINITY : t
+    const rid = t === undefined ? [Number.MAX_SAFE_INTEGER] : readerIdPath
+    const e = this.eh.getMostRecent(readPath, at, rid)
+    return e ? e.value : null
+  }
+
+  /** Distinct-key count facade (parity with the prior TimeState). */
+  get size(): number {
+    return this.eh.size
+  }
+
+  /** Dispose-only clear (SK14) — delegates to the shared store. */
+  clear(): void {
+    this.eh.clear()
   }
 }

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -34,6 +34,11 @@
  * history pruning (`@history_depth`, event_history.rb:163) are likewise deferred.
  */
 
+import { pathMatch } from './PathMatcher'
+
+/** Glob tokens that force a read to scan-and-merge across keys (GAP M1b). */
+const GLOB_TOKENS = /[*?{[]/
+
 /** A coordination event: a value recorded at virtual time `t` by thread `idPath`. */
 export interface CueEvent {
   /** Virtual time (seconds) the event was recorded at. */
@@ -181,9 +186,27 @@ export class EventHistory {
    * `null` when nothing is at or before the reader's point.
    */
   getMostRecent(key: string | symbol, t: number, idPath: number[]): CueEvent | null {
+    const ge = { t, idPath }
+    // GAP M1b: a glob read scans every key whose stored path the pattern matches
+    // and returns the GREATEST `e <= ge` across all of them — desktop's `__get`
+    // min/max merge over matching tree nodes (event_history.rb:299-380), here
+    // over a flat key set. A glob-free key keeps the O(1) exact Map lookup.
+    if (typeof key === 'string' && GLOB_TOKENS.test(key)) {
+      let best: CueEvent | null = null
+      for (const [storedKey, events] of this.store) {
+        if (typeof storedKey !== 'string' || !pathMatch(key, storedKey)) continue
+        const cand = this.firstAtOrBefore(events, ge)
+        if (cand && (!best || compareEvent(cand, best) > 0)) best = cand
+      }
+      return best
+    }
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
-    const ge = { t, idPath }
+    return this.firstAtOrBefore(events, ge)
+  }
+
+  /** First (greatest) event `<= ge` in a descending list, or null. */
+  private firstAtOrBefore(events: CueEvent[], ge: { t: number; idPath: number[] }): CueEvent | null {
     for (let i = 0; i < events.length; i++) {
       if (compareEvent(events[i], ge) <= 0) return events[i]
     }
@@ -210,8 +233,33 @@ export class EventHistory {
    * pure `(t,idPath)` `cueDelivers` rule (#400 unaffected).
    */
   getNextDelivered(key: string | symbol, t: number, idPath: number[], after?: { t: number; idPath: number[] }): CueEvent | null {
+    // GAP M1b: a glob sync (`sync :foo` → `/{cue,set,live_loop}/foo`) wakes on the
+    // SMALLEST deliverable cue across EVERY matching key — desktop's `get_next`
+    // min merge (event_history.rb:303-360). A glob-free key keeps the fast scan.
+    if (typeof key === 'string' && GLOB_TOKENS.test(key)) {
+      let best: CueEvent | null = null
+      for (const [storedKey, events] of this.store) {
+        if (typeof storedKey !== 'string' || !pathMatch(key, storedKey)) continue
+        const cand = this.firstDeliverable(events, t, idPath, after)
+        if (cand && (!best || compareEvent(cand, best) < 0)) best = cand
+      }
+      return best
+    }
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
+    return this.firstDeliverable(events, t, idPath, after)
+  }
+
+  /**
+   * Smallest deliverable cue in a descending list — scan from the tail
+   * (ascending t) and return the first that clears `after` and {@link cueDelivers}.
+   */
+  private firstDeliverable(
+    events: CueEvent[],
+    t: number,
+    idPath: number[],
+    after?: { t: number; idPath: number[] },
+  ): CueEvent | null {
     for (let i = events.length - 1; i >= 0; i--) {
       const e = events[i]
       if (after && compareEvent(e, after) <= 0) continue

--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -39,6 +39,19 @@ import { pathMatch, toWritePath, toReadPath } from './PathMatcher'
 /** Glob tokens that force a read to scan-and-merge across keys (GAP M1b). */
 const GLOB_TOKENS = /[*?{[]/
 
+/**
+ * Apply a value matcher safely — a port of `safe_matcher_call`
+ * (event_history.rb:19-26): a matcher that throws is treated as NON-matching
+ * (`false`), never propagating the error out of the lookup. GAP M2.
+ */
+function safeMatch(matcher: (value: unknown) => boolean, value: unknown): boolean {
+  try {
+    return matcher(value) === true
+  } catch {
+    return false
+  }
+}
+
 /** A coordination event: a value recorded at virtual time `t` by thread `idPath`. */
 export interface CueEvent {
   /** Virtual time (seconds) the event was recorded at. */
@@ -232,37 +245,44 @@ export class EventHistory {
    * set on a RE-sync; a first sync passes `undefined` so the wake-phase is the
    * pure `(t,idPath)` `cueDelivers` rule (#400 unaffected).
    */
-  getNextDelivered(key: string | symbol, t: number, idPath: number[], after?: { t: number; idPath: number[] }): CueEvent | null {
+  getNextDelivered(key: string | symbol, t: number, idPath: number[], after?: { t: number; idPath: number[] }, valMatcher?: (value: unknown) => boolean): CueEvent | null {
     // GAP M1b: a glob sync (`sync :foo` → `/{cue,set,live_loop}/foo`) wakes on the
     // SMALLEST deliverable cue across EVERY matching key — desktop's `get_next`
     // min merge (event_history.rb:303-360). A glob-free key keeps the fast scan.
+    // GAP M2: `valMatcher` (desktop's `arg_matcher`) further constrains a
+    // candidate by its value — the scan must keep looking past a value-rejected
+    // cue to the next deliverable one (event_history.rb:529-534).
     if (typeof key === 'string' && GLOB_TOKENS.test(key)) {
       let best: CueEvent | null = null
       for (const [storedKey, events] of this.store) {
         if (typeof storedKey !== 'string' || !pathMatch(key, storedKey)) continue
-        const cand = this.firstDeliverable(events, t, idPath, after)
+        const cand = this.firstDeliverable(events, t, idPath, after, valMatcher)
         if (cand && (!best || compareEvent(cand, best) < 0)) best = cand
       }
       return best
     }
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
-    return this.firstDeliverable(events, t, idPath, after)
+    return this.firstDeliverable(events, t, idPath, after, valMatcher)
   }
 
   /**
    * Smallest deliverable cue in a descending list — scan from the tail
-   * (ascending t) and return the first that clears `after` and {@link cueDelivers}.
+   * (ascending t) and return the first that clears `after`, {@link cueDelivers},
+   * and (GAP M2) the optional `valMatcher` value predicate. A matcher that throws
+   * is treated as non-matching (desktop `safe_matcher_call`, event_history.rb:19-26).
    */
   private firstDeliverable(
     events: CueEvent[],
     t: number,
     idPath: number[],
     after?: { t: number; idPath: number[] },
+    valMatcher?: (value: unknown) => boolean,
   ): CueEvent | null {
     for (let i = events.length - 1; i >= 0; i--) {
       const e = events[i]
       if (after && compareEvent(e, after) <= 0) continue
+      if (valMatcher && !safeMatch(valMatcher, e.value)) continue
       if (cueDelivers(e.t, e.idPath, t, idPath)) return e
     }
     return null

--- a/src/engine/PathMatcher.ts
+++ b/src/engine/PathMatcher.ts
@@ -179,6 +179,28 @@ export function pathMatch(pattern: string, path: string): boolean {
   return re.test(path)
 }
 
+/**
+ * Symbol-erasure adaptation (the GAP M faithfulness boundary). Our transpiler
+ * lowers BOTH `:foo` and `"foo"` to the same JS string `"foo"`
+ * (TreeSitterTranspiler.ts:509) — Ruby symbol-ness does not survive to the
+ * engine. Desktop's namespacing split keys on symbol-vs-string, which we cannot
+ * observe. We use the distinction that DOES survive: a leading `/` marks an
+ * explicit absolute path (string semantics); everything else is treated as a
+ * symbol key (op-namespaced write + `/{cue,set,live_loop}/` union read).
+ *
+ * This is exact for the two cases users actually write — a bare `:foo` and an
+ * absolute `"/a/b"` — and collapses only the rare relative-string `set "foo"`
+ * into symbol behaviour (a documented, more-permissive divergence).
+ */
+export function toWritePath(key: string, op: string): string {
+  return normalizeWritePath(key, op, !key.startsWith('/'))
+}
+
+/** Read-side companion of {@link toWritePath} (same leading-`/` heuristic). */
+export function toReadPath(key: string): string {
+  return normalizeReadPath(key, !key.startsWith('/'))
+}
+
 function stripSlashes(s: string): string {
   let a = 0
   let b = s.length

--- a/src/engine/PathMatcher.ts
+++ b/src/engine/PathMatcher.ts
@@ -1,0 +1,188 @@
+/**
+ * PathMatcher — desktop Sonic Pi's OSC-style Time State path glob, ported from
+ * `EventMatcher` (`event_history.rb:52-120`) + the `__cue_path` / `__sync_path`
+ * / `__cue_path_segment` normalisation (`core.rb:64-99`). GAP M, the `path`
+ * field of the `CueEvent` 8-tuple (`cueevent.rb`).
+ *
+ * Desktop routes `set` / `cue` / `live_loop` / `get` / `sync` through ONE
+ * coordination store keyed by hierarchical OSC paths, with an asymmetry that is
+ * the whole point of the design (verified source-first, `core.rb:64-105`):
+ *
+ *  - WRITES namespace by operation. A SYMBOL key is rooted under the op:
+ *      `set :foo`       → `/set/foo`
+ *      `cue :foo`       → `/cue/foo`
+ *      `live_loop :foo` → `/live_loop/foo`   (the per-iteration heartbeat)
+ *    A STRING key always uses the `cue` root unless it is already absolute:
+ *      `set "foo"`      → `/cue/foo`          (default prefix, core.rb:104 else-branch)
+ *      `set "/a/b"`     → `/a/b`              (leading `/` ⇒ taken verbatim)
+ *
+ *  - READS glob across all three op roots. A SYMBOL key reads the union:
+ *      `get :foo` / `sync :foo` → `/{cue,set,live_loop}/foo`
+ *    so a `get :foo` sees a `set :foo` AND a `cue :foo`, and a `sync :foo` wakes
+ *    on a `cue :foo` OR a `live_loop :foo` tick. A STRING key reads its own root:
+ *      `get "foo"`  → `/cue/foo`
+ *      `get "/a/b"` → `/a/b`                  (exact, no glob)
+ *
+ * The matcher itself (the reader path) supports the full OSC glob vocabulary,
+ * matched against the concrete stored (writer) path (examples avoid the literal
+ * `star-slash` sequence so this block comment does not self-terminate, SP101):
+ *   double-star  across segments   `a · ** · d` matches `/a/b/c/d`
+ *   single-star  within a segment  `/a/*` matches `/a/foo` but not `/a/b/c`
+ *   `?`          one char          `/a/?oo` matches `/a/foo`
+ *   `{a,b}`      alternation       `/{set,cue}/x`
+ *   `[a-g]`      char range        `/[a-g]oo`
+ *   `[!a-g]`     negated range
+ *
+ * NOTE on faithfulness: rather than literally replaying Ruby's
+ * `Regexp.escape`-then-`gsub!` chain (whose escape set differs from JS), this
+ * builds the regex directly to the SAME match SEMANTICS, token by token, and is
+ * pinned by unit tests covering every glob form. Leading/trailing `/` are
+ * optional on both sides exactly as desktop's `\A/?…/?\Z` anchor (`:94`).
+ */
+
+/** The three op-roots a symbol read globs across (`__sync_path`, core.rb:87). */
+export const SYNC_PATH_ROOTS = ['cue', 'set', 'live_loop'] as const
+
+/**
+ * Sanitise one path segment — port of `__cue_path_segment` (core.rb:64-68):
+ * whitespace and OSC-glob metacharacters become `_` so a user key can never
+ * inject glob structure into a WRITE path. Note `/` is also replaced (a symbol
+ * key is a single segment), unlike the string-key path which keeps `/`.
+ */
+export function cuePathSegment(s: string): string {
+  return s.replace(/[\s#*,?/[\]{}]/g, '_')
+}
+
+/**
+ * Normalise a WRITE key to its stored path — port of `__cue_path` (core.rb:70-83)
+ * combined with the symbol branch of `__cueset` (core.rb:105-111).
+ *
+ * @param key    the user key (already a string; the caller converts symbols)
+ * @param prefix the op root for a relative key (`'set'`, `'cue'`, `'live_loop'`)
+ * @param isSymbol whether the original key was a Ruby symbol (rooted under the
+ *   op) vs a string (only the `cue` root, and absolute strings verbatim)
+ */
+export function normalizeWritePath(key: string, prefix: string, isSymbol: boolean): string {
+  if (isSymbol) {
+    // Symbol: always `/{prefix}/{sanitised-segment}` (core.rb:106 → __cue_path(k, prefix)).
+    return `/${prefix}/${cuePathSegment(key)}`
+  }
+  // String: absolute stays verbatim; relative uses the default `cue` root.
+  // core.rb:73-79 sanitises everything except `/`, so segment structure is kept.
+  const sanitised = key.replace(/[\s#*,?[\]{}]/g, '_')
+  if (sanitised.startsWith('/')) return sanitised
+  return `/cue/${sanitised}`
+}
+
+/**
+ * Normalise a READ key to its matcher (glob) path — port of `__sync_path`
+ * (core.rb:85-99).
+ *
+ *  - symbol → `/{cue,set,live_loop}/{sanitised}` (the union read glob)
+ *  - string starting `/` → verbatim (exact path, may itself contain user globs)
+ *  - string otherwise → `/cue/{string}`
+ */
+export function normalizeReadPath(key: string, isSymbol: boolean): string {
+  if (isSymbol) {
+    return `/{${SYNC_PATH_ROOTS.join(',')}}/${cuePathSegment(key)}`
+  }
+  const s = String(key)
+  if (s.startsWith('/')) return s
+  return `/cue/${s}`
+}
+
+/**
+ * Compile a reader glob path into a RegExp with desktop's match semantics
+ * (`EventMatcher#initialize`, event_history.rb:57-96). Leading/trailing `/` are
+ * optional on the target via the `^/?…/?$` anchor.
+ */
+function compileGlob(pattern: string): RegExp {
+  // Strip the single optional leading `/`; the anchor restores its optionality.
+  let p = pattern.trim()
+  if (p.startsWith('/')) p = p.slice(1)
+
+  let out = ''
+  for (let i = 0; i < p.length; i++) {
+    const c = p[i]
+    if (c === '*') {
+      if (p[i + 1] === '*') {
+        // `**` — cross-segment. Desktop maps `/**/` → `/.*/` and a trailing
+        // `/**` → `/.*`; in both cases the `.*` may span `/`. A bare `**`
+        // (no surrounding slashes) likewise becomes `.*`.
+        out += '.*'
+        i++ // consume the second '*'
+      } else {
+        // `*` — within a segment only.
+        out += '[^/]*'
+      }
+    } else if (c === '?') {
+      out += '.' // one char (event_history.rb:91)
+    } else if (c === '{') {
+      // `{a,b,c}` → `(a|b|c)` (event_history.rb:78). Literal chars inside are
+      // escaped; `,` becomes `|`.
+      const end = p.indexOf('}', i)
+      if (end === -1) {
+        out += '\\{' // unterminated — literal
+      } else {
+        const inner = p
+          .slice(i + 1, end)
+          .split(',')
+          .map((alt) => escapeLiteral(alt))
+          .join('|')
+        out += `(${inner})`
+        i = end
+      }
+    } else if (c === '[') {
+      // `[a-g]` / `[!a-g]` char class (event_history.rb:81-84). `-` is kept as a
+      // range operator; `!` at the front becomes `^`.
+      const end = p.indexOf(']', i)
+      if (end === -1) {
+        out += '\\[' // unterminated — literal
+      } else {
+        let inner = p.slice(i + 1, end)
+        if (inner.startsWith('!')) inner = '^' + inner.slice(1)
+        out += `[${inner}]`
+        i = end
+      }
+    } else {
+      out += escapeLiteral(c)
+    }
+  }
+  return new RegExp(`^/?${out}/?$`)
+}
+
+/** Escape a run of literal characters for use in a RegExp body. */
+function escapeLiteral(s: string): string {
+  return s.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+}
+
+const globCache = new Map<string, RegExp>()
+
+/**
+ * True iff the reader `pattern` (a normalised glob path) matches the concrete
+ * stored `path`. Port of `EventMatcher#path_match` (event_history.rb:113-120),
+ * value side excluded (that is the `val_matcher`, handled by EventHistory).
+ *
+ * Fast path: an exact, glob-free pattern is a string compare.
+ */
+export function pathMatch(pattern: string, path: string): boolean {
+  if (pattern === path) return true
+  if (!/[*?{[]/.test(pattern)) {
+    // No glob tokens — only the optional leading/trailing `/` can differ.
+    return stripSlashes(pattern) === stripSlashes(path)
+  }
+  let re = globCache.get(pattern)
+  if (!re) {
+    re = compileGlob(pattern)
+    globCache.set(pattern, re)
+  }
+  return re.test(path)
+}
+
+function stripSlashes(s: string): string {
+  let a = 0
+  let b = s.length
+  if (s[a] === '/') a++
+  if (b > a && s[b - 1] === '/') b--
+  return s.slice(a, b)
+}

--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -22,7 +22,7 @@ export type Step =
   // bpmSync is `?: true` (not `?: boolean`): ProgramBuilder.sync_bpm pushes
   // the flag only when set, so the field is either absent or `true` — the
   // tighter type makes the discriminator unambiguous.
-  | { tag: 'sync'; name: string; bpmSync?: true }
+  | { tag: 'sync'; name: string; bpmSync?: true; argMatcher?: (args: unknown) => boolean }
   | { tag: 'fx'; name: string; opts: Record<string, number>; body: Program; nodeRef?: number }
   | { tag: 'thread'; body: Program }
   | { tag: 'print'; message: string }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -58,7 +58,7 @@ export class ProgramBuilder {
   // legacy runtime-step path (the QueryInterpreter never wires it, so an
   // S3 sync loop can't register a phantom waiter through the capture pass).
   private _syncScheduler: {
-    waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }>
+    waitForSync(name: string, taskId: string, argMatcher?: (args: unknown) => boolean): Promise<{ args: unknown[]; bpm: number }>
     getTask?(taskId: string): { virtualTime: number } | undefined
   } | null = null
   private _syncTaskId: string | null = null
@@ -272,7 +272,7 @@ export class ProgramBuilder {
    */
   setSyncContext(
     scheduler: {
-      waitForSync(name: string, taskId: string): Promise<{ args: unknown[]; bpm: number }>
+      waitForSync(name: string, taskId: string, argMatcher?: (args: unknown) => boolean): Promise<{ args: unknown[]; bpm: number }>
       getTask?(taskId: string): { virtualTime: number } | undefined
     },
     taskId: string,
@@ -332,8 +332,9 @@ export class ProgramBuilder {
     return this
   }
 
-  sync(name: string, opts?: { bpm_sync?: boolean }): this | Promise<unknown> {
+  sync(name: string, opts?: { bpm_sync?: boolean; arg_matcher?: (args: unknown) => boolean }): this | Promise<unknown> {
     const bpmSync = opts?.bpm_sync === true
+    const argMatcher = typeof opts?.arg_matcher === 'function' ? opts.arg_matcher : undefined
     // SP95(d) #393: build-time await path. The scheduler resolves the cue
     // payload through the SAME channel as sleep (a Promise only tick() can
     // resolve), so the build "blocks" in virtual time exactly like desktop's
@@ -357,7 +358,7 @@ export class ProgramBuilder {
       // current_time() advances across await b.sync ... before wiring" — this
       // closes that gap. (#350 / SV47 slice 2.)
       const taskBefore = scheduler.getTask?.(taskId)?.virtualTime
-      return scheduler.waitForSync(name, taskId).then(
+      return scheduler.waitForSync(name, taskId, argMatcher).then(
         (payload) => {
           const taskAfter = scheduler.getTask?.(taskId)?.virtualTime
           if (typeof taskBefore === 'number' && typeof taskAfter === 'number') {
@@ -372,7 +373,11 @@ export class ProgramBuilder {
         },
       )
     }
-    this.steps.push(bpmSync ? { tag: 'sync', name, bpmSync: true } : { tag: 'sync', name })
+    this.steps.push(
+      bpmSync
+        ? { tag: 'sync', name, bpmSync: true, argMatcher }
+        : { tag: 'sync', name, argMatcher },
+    )
     return this
   }
 

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1,6 +1,6 @@
 import { VirtualTimeScheduler, DEFAULT_SCHED_AHEAD_TIME, type TaskState } from './VirtualTimeScheduler'
 import { ProgramBuilder } from './ProgramBuilder'
-import { TimeState } from './TimeState'
+import { EventHistory, TimeStateView } from './EventHistory'
 import { runProgram, type AudioContext as AudioCtx } from './interpreters/AudioInterpreter'
 import { queryLoopProgram, type QueryEvent } from './interpreters/QueryInterpreter'
 import { SuperSonicBridge, type SuperSonicBridgeOptions } from './SuperSonicBridge'
@@ -227,12 +227,18 @@ export class SonicPiEngine {
    * scheduler-aware and time-stamped correctly.
    */
   readonly midiBridge = new MidiBridge()
-  /** Global key-value store — shared across all loops via get/set.
-   *  SP95(d) #350 slice 2: virtual-time-indexed TimeState (was a plain Map).
-   *  Writes carry the writer's current_time(); reads resolve "last set ≤ reader
-   *  vt". A back-compat facade (.get(key)/.size/.clear) keeps Map-shaped tests
-   *  green. Cleared only on dispose (SK14). */
-  private globalStore = new TimeState()
+  /**
+   * GAP M1c — the single coordination store (desktop's `@event_history`). ONE
+   * `(t, idPath)`-ordered EventHistory backs BOTH cue/sync (the scheduler is
+   * injected with it below) AND set/get (via the `globalStore` TimeStateView
+   * adapter). Because they share it, a `get :foo` sees a `cue :foo` and a
+   * `sync :foo` wakes on a `set :foo` — the `/{cue,set,live_loop}/foo` read union.
+   */
+  private readonly eventHistory = new EventHistory({ maxPerKey: 256 })
+  /** set/get facade over {@link eventHistory} with `/set/` write namespacing.
+   *  Keeps the prior TimeState `{set,get,size,clear}` shape so the builder,
+   *  closures and tests are unchanged. Cleared only on dispose (SK14). */
+  private globalStore = new TimeStateView(this.eventHistory)
   /** User-defined functions — `define`/`ndefine` register here. Seeded back into the
    *  next eval's scopeBase so removing a `define` line from the buffer does not
    *  break a still-running live_loop that calls it. (#215) */
@@ -474,6 +480,8 @@ export class SonicPiEngine {
         this.scheduler = new VirtualTimeScheduler({
           getAudioTime: () => audioCtx?.currentTime ?? 0,
           schedAheadTime: this.schedAheadTime,
+          // GAP M1c: cue/sync and set/get share this ONE store.
+          eventHistory: this.eventHistory,
         })
 
         this.scheduler.onLoopError((loopName, err) => {
@@ -992,7 +1000,9 @@ export class SonicPiEngine {
           // Auto-cue the loop name after each iteration.
           // In Sonic Pi, `live_loop :foo` auto-cues `:foo` on each iteration
           // so that `live_loop :bar, sync: :foo` can synchronize to it.
-          scheduler.fireCue(name, name)
+          // GAP M1c: heartbeat writes the `/live_loop/foo` root; a `sync :foo`
+          // reads the `/{cue,set,live_loop}/foo` union and still matches.
+          scheduler.fireCue(name, name, [], 'live_loop')
         }
 
         // SP72: when this registration fires from inside a parent builderFn

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1379,6 +1379,12 @@ export class SonicPiEngine {
 
       // Top-level current_bpm — returns the current default BPM
       const current_bpm = (): number => defaultBpm
+      // GAP M3 (#496): current_bpm_mode — desktop returns the tempo MODE, either a
+      // bpm number or `:link` (core.rb:4106). We have no Ableton Link, so the mode
+      // is always the current bpm (never `:link`). This is the `m` field of the
+      // CueEvent tuple surfaced to the DSL; the value channel already carries bpm
+      // for sync_bpm (#236), so no separate per-event `m` field is stored.
+      const current_bpm_mode = (): number => defaultBpm
 
       // Pure math helpers (no engine state needed)
       const quantise = (val: number, step: number): number => Math.round(val / step) * step
@@ -1429,6 +1435,7 @@ export class SonicPiEngine {
         hzToMidi, midiToFreq,
         quantise, quantize, octs,
         current_bpm,
+        current_bpm_mode,
         topLevelPuts, topLevelPrint, topLevelStop, stop_loop,
         // Volume & introspection
         set_volume, current_synth_fn, current_volume_fn,

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -877,10 +877,21 @@ function transpileNode(node: any, ctx: TranspileContext): string {
 
     // ---- Lambda ----
     case 'lambda': {
-      // ->(x) { x * 2 } → (x) => { return x * 2 }
+      // ->(x) { x * 2 } → (x) => (x * 2)   (Ruby's last expression is the return)
       const params = node.namedChildren.find((c: any) => c.type === 'lambda_parameters' || c.type === 'block_parameters')
       const body = node.namedChildren.find((c: any) => c.type === 'block' || c.type === 'do_block') ?? node.namedChildren[node.namedChildCount - 1]
       const paramStr = params ? params.namedChildren.map((c: any) => transpileNode(c, ctx)).join(', ') : ''
+      // A SINGLE-statement body becomes an expression-bodied arrow so the value
+      // is implicitly returned (Ruby semantics) — this is what makes a value
+      // predicate like `arg_matcher: ->(a){ a[0] == 9 }` (GAP M2) actually return
+      // its boolean instead of `undefined`. Multi-statement bodies keep the block
+      // form (no implicit return — a pre-existing limitation, rare for lambdas).
+      if (body && (body.type === 'block' || body.type === 'do_block')) {
+        const stmts = body.namedChildren.filter((c: any) => c.type !== 'block_parameters' && c.type !== 'comment')
+        if (stmts.length === 1) {
+          return `(${paramStr}) => (${transpileNode(stmts[0], ctx)})`
+        }
+      }
       const bodyStr = body ? transpileNode(body, ctx) : ''
       return `(${paramStr}) => { ${bodyStr} }`
     }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -888,7 +888,11 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       // form (no implicit return — a pre-existing limitation, rare for lambdas).
       if (body && (body.type === 'block' || body.type === 'do_block')) {
         const stmts = body.namedChildren.filter((c: any) => c.type !== 'block_parameters' && c.type !== 'comment')
-        if (stmts.length === 1) {
+        // Only a single EXPRESSION statement can become an expression-bodied
+        // arrow. A statement node (return/break/next/control flow) would produce
+        // invalid JS like `() => (return 5)`, so keep the block form for those.
+        const STMT_NODES = new Set(['return', 'break', 'next', 'redo', 'retry', 'if', 'unless', 'while', 'until', 'case', 'for', 'begin'])
+        if (stmts.length === 1 && !STMT_NODES.has(stmts[0].type)) {
           return `(${paramStr}) => (${transpileNode(stmts[0], ctx)})`
         }
       }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -230,6 +230,8 @@ export class VirtualTimeScheduler {
      */
     waiterVt: number
     waiterIdPath: number[]
+    /** GAP M2: desktop's `arg_matcher` — wakes only on a cue whose value passes. */
+    valMatcher?: (value: unknown) => boolean
   }>>()
   /** One-shot audio-time-bound callbacks (SV41 — backs scheduleAtVirtualTime). */
   private pendingCallbacks: PendingCallback[] = []
@@ -526,6 +528,9 @@ export class VirtualTimeScheduler {
         const after = waiterTask?.lastSyncedCue
         const delivers = cueDelivers(cueVirtualTime, cueIdPath, waiter.waiterVt, waiter.waiterIdPath)
           && (!after || compareEvent({ t: cueVirtualTime, idPath: cueIdPath }, after) > 0)
+          // GAP M2: arg_matcher — the waiter only wakes if the cue's value passes.
+          // The stored-value shape is `{ args, bpm }`, the same as history-first.
+          && (!waiter.valMatcher || waiter.valMatcher({ args, bpm: cueBpm }))
         if (delivers) {
           if (waiterTask) {
             // Inherit cue's virtual time (SV5) and advance the re-sync matcher.
@@ -548,7 +553,7 @@ export class VirtualTimeScheduler {
    * payload also carries the cuer's BPM so callers using `bpm_sync: true`
    * (sync_bpm, #236) can mutate the waiter's task.bpm.
    */
-  waitForSync(name: string, taskId: string): Promise<SyncPayload> {
+  waitForSync(name: string, taskId: string, argMatcher?: (args: unknown) => boolean): Promise<SyncPayload> {
     // GAP A2: desktop `sync` (event_history.rb:215) checks history FIRST —
     // `get_next` returns the next cue strictly after the sync point if one is
     // already recorded — and only blocks if none. This is the with_fx
@@ -570,13 +575,27 @@ export class VirtualTimeScheduler {
     // @event_history (the cross-namespace wake).
     const readPath = toReadPath(name)
 
+    // GAP M2: `arg_matcher` filters by the cue's VALUE. A cue's stored value is
+    // `{ args, bpm }`; desktop's matcher receives the cue's `val` (= the args),
+    // so unwrap to `.args`. A `set`-sourced event (cross-namespace) stores a raw
+    // value — pass it through. Both EventHistory's history-first scan and the live
+    // wake loop use this same predicate over the stored value.
+    const valMatcher = argMatcher
+      ? (stored: unknown): boolean => {
+          const v = stored && typeof stored === 'object' && 'args' in (stored as object)
+            ? (stored as { args: unknown }).args
+            : stored
+          return argMatcher(v)
+        }
+      : undefined
+
     // History-first (event_history.rb:215): if a deliverable cue is already
     // recorded, resolve now — this is the with_fx registration-race fix
     // (#350/#481), and via the union glob it also catches a set/cue that fired
     // before this sync registered. getNextDelivered (GAP M1b) scans every key the
     // glob matches. #489: a re-sync excludes the cue this task last consumed.
     const after = task?.lastSyncedCue
-    const hit = this.cueHistory.getNextDelivered(readPath, waiterVt, waiterIdPath, after)
+    const hit = this.cueHistory.getNextDelivered(readPath, waiterVt, waiterIdPath, after, valMatcher)
     if (hit) {
       if (task) {
         task.virtualTime = hit.t // inherit the cue's vt (SV5)
@@ -588,7 +607,7 @@ export class VirtualTimeScheduler {
 
     return new Promise<SyncPayload>((resolve) => {
       const waiters = this.syncWaiters.get(readPath) ?? []
-      waiters.push({ taskId, resolve, waiterVt, waiterIdPath })
+      waiters.push({ taskId, resolve, waiterVt, waiterIdPath, valMatcher })
       this.syncWaiters.set(readPath, waiters)
     })
   }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -1,28 +1,11 @@
 import { MinHeap } from './MinHeap'
 import { EventHistory, cueDelivers, compareEvent } from './EventHistory'
+import { pathMatch, toWritePath, toReadPath } from './PathMatcher'
 
-// ---------------------------------------------------------------------------
-// Cue glob matching (#150) — supports * and ? wildcards in sync targets
-// ---------------------------------------------------------------------------
-
-/**
- * Match a sync pattern against a fired cue name.
- * Exact match is the fast path; glob matching activates only when the
- * pattern contains `*` or `?`.
- *
- * `*` matches any sequence of characters (including empty).
- * `?` matches exactly one character.
- *
- * Used by fireCue to wake sync waiters whose patterns glob-match the cue.
- */
-function cueGlobMatch(pattern: string, name: string): boolean {
-  if (pattern === name) return true
-  if (!pattern.includes('*') && !pattern.includes('?')) return false
-  // Convert glob to regex: escape special regex chars, then replace glob tokens
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-  const re = new RegExp('^' + escaped.replace(/\*/g, '.*').replace(/\?/g, '.') + '$')
-  return re.test(name)
-}
+// Cue/sync matching (#150 glob, GAP M1c path semantics) is now the shared
+// `pathMatch` from PathMatcher — the registered read glob is matched against the
+// concrete fired path. The old `cueGlobMatch` (`*`/`?`-only on the raw name) was
+// subsumed by it. `pathMatch` keeps the exact-string fast path for glob-free keys.
 
 // ---------------------------------------------------------------------------
 // Scheduling constants
@@ -171,6 +154,14 @@ export interface SchedulerOptions {
   schedAheadTime?: number
   /** Tick interval in ms (default: 25) */
   tickInterval?: number
+  /**
+   * GAP M1c — the shared coordination store. When the engine injects its
+   * EventHistory, `set`/`get` (engine side) and `cue`/`sync` (scheduler side)
+   * use the SAME store, so a `get :foo` sees a `cue :foo` (desktop's single
+   * `@event_history`). Omitted ⇒ the scheduler owns a private store (raw
+   * scheduler usage / unit tests, behaviour unchanged).
+   */
+  eventHistory?: EventHistory
 }
 
 // ---------------------------------------------------------------------------
@@ -216,7 +207,16 @@ export class VirtualTimeScheduler {
    * forward-looking `sync`) so it does not grow unbounded the way cueMap never
    * did. Value = `{ args, bpm }` (the cuer's BPM at fire time, for sync_bpm).
    */
-  private cueHistory = new EventHistory({ maxPerKey: 256 })
+  private cueHistory: EventHistory
+  /**
+   * GAP M1c: true only when this scheduler created its OWN cueHistory. When the
+   * engine injects the shared store, the scheduler must NOT clear it on dispose —
+   * the engine owns its lifecycle (cleared only on engine dispose, SK14). Without
+   * this guard, re-evaluating (which disposes the prior scheduler) would wipe
+   * set/get state, breaking #336 (set persists across Stop; desktop's
+   * @event_history persists until quit).
+   */
+  private readonly ownsCueHistory: boolean
   /** Tasks waiting for a cue */
   private syncWaiters = new Map<string, Array<{
     taskId: string
@@ -238,6 +238,9 @@ export class VirtualTimeScheduler {
     this.getAudioTime = options.getAudioTime ?? (() => 0)
     this.schedAheadTime = options.schedAheadTime ?? DEFAULT_SCHED_AHEAD_TIME
     this.tickInterval = options.tickInterval ?? DEFAULT_TICK_INTERVAL_MS
+    // GAP M1c: share the engine's coordination store if injected, else own one.
+    this.ownsCueHistory = !options.eventHistory
+    this.cueHistory = options.eventHistory ?? new EventHistory({ maxPerKey: 256 })
 
     // Priority: by time, then by insertion order for determinism (SP1)
     // Uses entry.order directly — no Map lookup or string allocation (#75)
@@ -469,7 +472,7 @@ export class VirtualTimeScheduler {
    * not exist, fall back to the current audio time so external sources still
    * wake sync waiters instead of silently returning.
    */
-  fireCue(name: string, taskId: string, args: unknown[] = []): void {
+  fireCue(name: string, taskId: string, args: unknown[] = [], op: 'cue' | 'live_loop' = 'cue'): void {
     const task = this.tasks.get(taskId)
     const cueVirtualTime = task?.virtualTime ?? this.getAudioTime()
     // Synthetic external sources ('__midi__', '__osc__', #151) have no real
@@ -480,10 +483,16 @@ export class VirtualTimeScheduler {
     // external sources (no task) cue as main `[0]`.
     const cueIdPath = task?.idPath ?? [0]
 
+    // GAP M1c: namespace the write by op — `cue :foo`→/cue/foo, a live_loop
+    // heartbeat→/live_loop/foo. An absolute key (external `/midi:*`) is kept
+    // verbatim (toWritePath's leading-`/` rule). A `sync :foo` reads the union
+    // `/{cue,set,live_loop}/foo`, so it matches whichever root the writer used.
+    const firedPath = toWritePath(name, op)
+
     // Record the cue in the (t, idPath)-ordered history so a late or
     // forked-sibling syncer resolves it correctly (replaces the single-entry
     // cueMap). Value carries the cuer's BPM for sync_bpm waiters (#236).
-    this.cueHistory.insert(name, cueVirtualTime, cueIdPath, { args, bpm: cueBpm })
+    this.cueHistory.insert(firedPath, cueVirtualTime, cueIdPath, { args, bpm: cueBpm })
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({
@@ -499,7 +508,9 @@ export class VirtualTimeScheduler {
     // Example: `sync "/midi:*:*/note_on"` matches a cue named `/midi:*:1/note_on`.
     for (const [pattern, waiters] of this.syncWaiters) {
       if (waiters.length === 0) continue
-      if (!cueGlobMatch(pattern, name)) continue
+      // GAP M1c: a waiter is registered under its READ path (a glob like
+      // `/{cue,set,live_loop}/foo`); match it against the concrete fired path.
+      if (!pathMatch(pattern, firedPath)) continue
       // Wake-phase (cueDelivers, observed desktop #481/#400): deliver iff the cue
       // is strictly LATER, or — at EQUAL vt — the waiter is a strict ANCESTOR of
       // the cuer (its thread spawned the cuer, then synced → happens-after). A
@@ -553,29 +564,32 @@ export class VirtualTimeScheduler {
     const waiterVt = task?.virtualTime ?? 0
     const waiterIdPath = task?.idPath ?? [0]
 
-    // History-first only for exact cue names; glob patterns (`sync "/midi:*"`,
-    // #150) register and wait for a future matching cue (their cross-key history
-    // scan is GAP M / not needed by #350/#481 which use exact names).
-    // #489: a re-sync excludes the cue this task last consumed (and anything
-    // before it) so an inline/main waiter doesn't re-catch the same equal-vt
-    // ancestor cue forever. First sync ⇒ `after` undefined ⇒ pure cueDelivers.
+    // GAP M1c: read via the union path (`sync :foo` → `/{cue,set,live_loop}/foo`,
+    // an explicit/external `/midi:*` kept verbatim). The store is shared with
+    // set/get, so this glob also sees a `set :foo` — desktop's single
+    // @event_history (the cross-namespace wake).
+    const readPath = toReadPath(name)
+
+    // History-first (event_history.rb:215): if a deliverable cue is already
+    // recorded, resolve now — this is the with_fx registration-race fix
+    // (#350/#481), and via the union glob it also catches a set/cue that fired
+    // before this sync registered. getNextDelivered (GAP M1b) scans every key the
+    // glob matches. #489: a re-sync excludes the cue this task last consumed.
     const after = task?.lastSyncedCue
-    if (!name.includes('*') && !name.includes('?')) {
-      const hit = this.cueHistory.getNextDelivered(name, waiterVt, waiterIdPath, after)
-      if (hit) {
-        if (task) {
-          task.virtualTime = hit.t // inherit the cue's vt (SV5)
-          task.lastSyncedCue = { t: hit.t, idPath: hit.idPath } // #489: advance matcher
-        }
-        const payload = hit.value as { args: unknown[]; bpm: number }
-        return Promise.resolve({ args: payload.args, bpm: payload.bpm })
+    const hit = this.cueHistory.getNextDelivered(readPath, waiterVt, waiterIdPath, after)
+    if (hit) {
+      if (task) {
+        task.virtualTime = hit.t // inherit the cue's vt (SV5)
+        task.lastSyncedCue = { t: hit.t, idPath: hit.idPath } // #489: advance matcher
       }
+      const payload = hit.value as { args: unknown[]; bpm: number }
+      return Promise.resolve({ args: payload.args, bpm: payload.bpm })
     }
 
     return new Promise<SyncPayload>((resolve) => {
-      const waiters = this.syncWaiters.get(name) ?? []
+      const waiters = this.syncWaiters.get(readPath) ?? []
       waiters.push({ taskId, resolve, waiterVt, waiterIdPath })
-      this.syncWaiters.set(name, waiters)
+      this.syncWaiters.set(readPath, waiters)
     })
   }
 
@@ -679,7 +693,10 @@ export class VirtualTimeScheduler {
     this.tasks.clear()
     this.queue.clear()
     this.eventHandlers.length = 0
-    this.cueHistory.clear()
+    // GAP M1c: only clear a store we OWN. An injected (shared) store is the
+    // engine's — clearing it here would wipe set/get + cue state on every
+    // re-evaluate (which disposes the prior scheduler). #336 / SK14.
+    if (this.ownsCueHistory) this.cueHistory.clear()
     this.syncWaiters.clear()
     this.pendingCallbacks.length = 0
   }
@@ -704,7 +721,7 @@ export class VirtualTimeScheduler {
       // This is how sync: :name works on other live_loops.
       // Note: SonicPiEngine also fires a cue after each iteration (line ~290).
       // Having it here ensures it works for raw scheduler usage too.
-      this.fireCue(task.id, task.id)
+      this.fireCue(task.id, task.id, [], 'live_loop')
       const vtBefore = task.virtualTime
       try {
         await task.asyncFn()

--- a/src/engine/__tests__/DslBuilderContract.test.ts
+++ b/src/engine/__tests__/DslBuilderContract.test.ts
@@ -149,6 +149,7 @@ const PURE_OR_INTENTIONAL_BUILD_TIME = new Map<string, string>([
   // resolution) and is out of scope for the deferred-step contract.
   ['get',              'Global store read. Stale-read P2 — tracked separately.'],
   ['current_bpm',      'Stale-read P2 — returns build-time bpm snapshot.'],
+  ['current_bpm_mode', 'Pure query (GAP M3) — returns current bpm; no :link without Link.'],
   ['current_synth',    'Stale-read P2 — returns build-time synth snapshot.'],
   ['current_volume',   'Stale-read P2 — returns build-time volume snapshot.'],
   ['get_cc',           'Stale-read P2 — returns MIDI-CC value at build time.'],

--- a/src/engine/__tests__/EventHistoryGlob.test.ts
+++ b/src/engine/__tests__/EventHistoryGlob.test.ts
@@ -58,3 +58,31 @@ describe('EventHistory — glob getNextDelivered (sync across the union)', () =>
     expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])).toBeNull()
   })
 })
+
+describe('EventHistory — getNextDelivered valMatcher (GAP M2 arg_matcher)', () => {
+  it('skips value-rejected cues and returns the next matching deliverable', () => {
+    const eh = new EventHistory()
+    eh.insert('/cue/foo', 1, [0, 0], { args: [3], bpm: 60 })
+    eh.insert('/cue/foo', 2, [0, 0], { args: [9], bpm: 60 })
+    const m = (v: unknown) => (v as { args: number[] }).args[0] > 5
+    // Without the matcher the smallest deliverable is t=1 (args 3); with it,
+    // t=1 is value-rejected so the next deliverable t=2 (args 9) is returned.
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0], undefined, m)?.t).toBe(2)
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])?.t).toBe(1)
+  })
+
+  it('returns null when no deliverable cue passes the matcher', () => {
+    const eh = new EventHistory()
+    eh.insert('/cue/foo', 1, [0, 0], { args: [3], bpm: 60 })
+    const m = (v: unknown) => (v as { args: number[] }).args[0] > 5
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0], undefined, m)).toBeNull()
+  })
+
+  it('a throwing matcher is treated as non-matching, never propagates', () => {
+    const eh = new EventHistory()
+    eh.insert('/cue/foo', 1, [0, 0], { args: [3], bpm: 60 })
+    const boom = () => { throw new Error('bad matcher') }
+    expect(() => eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0], undefined, boom)).not.toThrow()
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0], undefined, boom)).toBeNull()
+  })
+})

--- a/src/engine/__tests__/EventHistoryGlob.test.ts
+++ b/src/engine/__tests__/EventHistoryGlob.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { EventHistory } from '../EventHistory'
+
+/**
+ * GAP M1b — path-aware (glob) reads over EventHistory. These exercise the
+ * scan-and-merge across matching keys; the (t, idPath) ordering itself is
+ * covered by the GAP A2 EventHistory tests.
+ */
+describe('EventHistory — glob getMostRecent (set/cue/live_loop union)', () => {
+  it('a glob read returns the GREATEST e<=ge across all matching keys', () => {
+    const eh = new EventHistory()
+    eh.insert('/set/foo', 1, [0], 'set@1')
+    eh.insert('/cue/foo', 2, [0], 'cue@2')
+    eh.insert('/live_loop/foo', 0.5, [0], 'll@0.5')
+    // reader at t=5 sees all three; greatest is cue@2.
+    expect(eh.getMostRecent('/{cue,set,live_loop}/foo', 5, [0])?.value).toBe('cue@2')
+    // reader at t=1.5 excludes cue@2 (t=2 > 1.5); greatest <= is set@1.
+    expect(eh.getMostRecent('/{cue,set,live_loop}/foo', 1.5, [0])?.value).toBe('set@1')
+  })
+
+  it('a glob read ignores non-matching keys', () => {
+    const eh = new EventHistory()
+    eh.insert('/set/foo', 1, [0], 'foo')
+    eh.insert('/set/bar', 2, [0], 'bar')
+    expect(eh.getMostRecent('/{cue,set,live_loop}/foo', 5, [0])?.value).toBe('foo')
+  })
+
+  it('glob-free read keeps exact behaviour (no cross-key bleed)', () => {
+    const eh = new EventHistory()
+    eh.insert('/set/foo', 1, [0], 'set')
+    eh.insert('/cue/foo', 2, [0], 'cue')
+    // exact /set/foo must NOT see /cue/foo.
+    expect(eh.getMostRecent('/set/foo', 5, [0])?.value).toBe('set')
+    expect(eh.getMostRecent('/cue/foo', 5, [0])?.value).toBe('cue')
+  })
+})
+
+describe('EventHistory — glob getNextDelivered (sync across the union)', () => {
+  it('wakes on the SMALLEST deliverable cue across matching keys', () => {
+    const eh = new EventHistory()
+    // waiter at t=0, idPath [0] (root). Strictly-later cues are deliverable.
+    eh.insert('/cue/foo', 3, [0, 0], 'cue@3')
+    eh.insert('/live_loop/foo', 1, [0, 0], 'll@1')
+    // smallest deliverable (earliest t) across the union is ll@1.
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])?.value).toBe('ll@1')
+  })
+
+  it('a set DOES wake a glob sync (the GAP M cross-namespace behaviour)', () => {
+    const eh = new EventHistory()
+    eh.insert('/set/foo', 2, [0, 0], 'set@2')
+    // Under the old separate-store world this could not happen; the union allows it.
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])?.value).toBe('set@2')
+  })
+
+  it('returns null when nothing matching is deliverable', () => {
+    const eh = new EventHistory()
+    eh.insert('/cue/bar', 3, [0, 0], 'bar')
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])).toBeNull()
+  })
+})

--- a/src/engine/__tests__/GapMTimeStateRichness.test.ts
+++ b/src/engine/__tests__/GapMTimeStateRichness.test.ts
@@ -79,3 +79,34 @@ describe('GAP M — hierarchical path Time State (set/get)', () => {
     engine.dispose()
   })
 })
+
+describe('GAP M2 — sync arg_matcher (value predicate)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('a sync with arg_matcher wakes only on a cue whose value passes', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    // driver cues :beat with value 9; listener only wakes when arg[0] == 9.
+    await engine.evaluate(`
+      live_loop :driver do
+        cue :beat, 9
+        sleep 1
+      end
+      live_loop :listener do
+        sync :beat, arg_matcher: ->(a){ a[0] == 9 }
+        play 72
+        sleep 1
+      end
+    `)
+    engine.play()
+    await drive(engine, 4, 4)
+
+    expect(notes(events)).toContain(72)
+    engine.dispose()
+  })
+})

--- a/src/engine/__tests__/GapMTimeStateRichness.test.ts
+++ b/src/engine/__tests__/GapMTimeStateRichness.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+import type { SoundEvent } from '../SoundEventStream'
+
+/**
+ * GAP M (#496) — engine-level proof of the path/glob Time State surface that the
+ * unified EventHistory now provides. Unit-level matcher + store behaviour is in
+ * PathMatcher.test.ts / EventHistoryGlob.test.ts; these drive the real
+ * DSL → transpile → builder → EventHistory path.
+ */
+type SchedulerLike = { tick: (t: number) => void }
+
+async function drive(engine: SonicPiEngine, targetVt = 5, steps = 5) {
+  const scheduler = (engine as unknown as { scheduler: SchedulerLike | null }).scheduler
+  if (!scheduler) return
+  for (let i = 1; i <= steps; i++) {
+    scheduler.tick((targetVt * i) / steps)
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+const notes = (events: SoundEvent[]) =>
+  events.filter((e) => typeof e.midiNote === 'number').map((e) => e.midiNote as number)
+
+describe('GAP M — hierarchical path Time State (set/get)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('an absolute path key round-trips through set/get', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    await engine.evaluate(`
+      set "/synth/lead", 60
+      play get("/synth/lead")
+    `)
+    engine.play()
+    await drive(engine, 2, 2)
+
+    expect(notes(events)).toContain(60)
+    engine.dispose()
+  })
+
+  it('a path glob read resolves a matching absolute set', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    await engine.evaluate(`
+      set "/synth/lead", 64
+      play get("/synth/*")
+    `)
+    engine.play()
+    await drive(engine, 2, 2)
+
+    expect(notes(events)).toContain(64)
+    engine.dispose()
+  })
+
+  it('a symbol get sees a symbol set (the /{cue,set,live_loop} read union)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+
+    // set :foo writes /set/foo; get :foo reads /{cue,set,live_loop}/foo and finds it.
+    await engine.evaluate(`
+      set :foo, 67
+      play get(:foo)
+    `)
+    engine.play()
+    await drive(engine, 2, 2)
+
+    expect(notes(events)).toContain(67)
+    engine.dispose()
+  })
+})

--- a/src/engine/__tests__/PathMatcher.test.ts
+++ b/src/engine/__tests__/PathMatcher.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  pathMatch,
+  normalizeWritePath,
+  normalizeReadPath,
+  cuePathSegment,
+  SYNC_PATH_ROOTS,
+} from '../PathMatcher'
+
+describe('PathMatcher — write/read normalisation (core.rb:64-99)', () => {
+  it('symbol write namespaces by op root', () => {
+    expect(normalizeWritePath('foo', 'set', true)).toBe('/set/foo')
+    expect(normalizeWritePath('foo', 'cue', true)).toBe('/cue/foo')
+    expect(normalizeWritePath('foo', 'live_loop', true)).toBe('/live_loop/foo')
+  })
+
+  it('string write uses cue root when relative, verbatim when absolute', () => {
+    // core.rb:104 — non-symbol keys always take __cue_path with the default prefix.
+    expect(normalizeWritePath('foo', 'set', false)).toBe('/cue/foo')
+    expect(normalizeWritePath('/a/b', 'set', false)).toBe('/a/b')
+  })
+
+  it('symbol read globs across all three op roots', () => {
+    expect(normalizeReadPath('foo', true)).toBe('/{cue,set,live_loop}/foo')
+  })
+
+  it('string read: absolute verbatim, relative under cue root', () => {
+    expect(normalizeReadPath('/a/b', false)).toBe('/a/b')
+    expect(normalizeReadPath('foo', false)).toBe('/cue/foo')
+  })
+
+  it('cuePathSegment sanitises glob metacharacters to underscore', () => {
+    expect(cuePathSegment('a b')).toBe('a_b')
+    expect(cuePathSegment('a*b?c')).toBe('a_b_c')
+    expect(cuePathSegment('a/b')).toBe('a_b') // symbol is a single segment
+  })
+
+  it('SYNC_PATH_ROOTS is the canonical desktop order', () => {
+    expect([...SYNC_PATH_ROOTS]).toEqual(['cue', 'set', 'live_loop'])
+  })
+})
+
+describe('PathMatcher — the read-glob unifies set/cue/live_loop (GAP M headline)', () => {
+  it('a symbol read matches a set, a cue, AND a live_loop write', () => {
+    const reader = normalizeReadPath('foo', true) // /{cue,set,live_loop}/foo
+    expect(pathMatch(reader, normalizeWritePath('foo', 'set', true))).toBe(true)
+    expect(pathMatch(reader, normalizeWritePath('foo', 'cue', true))).toBe(true)
+    expect(pathMatch(reader, normalizeWritePath('foo', 'live_loop', true))).toBe(true)
+  })
+
+  it('a symbol read does NOT match a different key', () => {
+    const reader = normalizeReadPath('foo', true)
+    expect(pathMatch(reader, normalizeWritePath('bar', 'set', true))).toBe(false)
+  })
+
+  it('a string read on /cue does NOT see a /set write (desktop is stricter)', () => {
+    // get "foo" → /cue/foo, which must NOT match a set :foo → /set/foo.
+    expect(pathMatch(normalizeReadPath('foo', false), normalizeWritePath('foo', 'set', true))).toBe(false)
+  })
+})
+
+describe('PathMatcher — exact + leading/trailing slash optionality (event_history.rb:94)', () => {
+  it('exact match', () => {
+    expect(pathMatch('/a/b', '/a/b')).toBe(true)
+    expect(pathMatch('/a/b', '/a/c')).toBe(false)
+  })
+  it('leading/trailing slash is optional on both sides', () => {
+    expect(pathMatch('a/b', '/a/b')).toBe(true)
+    expect(pathMatch('/a/b/', '/a/b')).toBe(true)
+    expect(pathMatch('/a/b', 'a/b/')).toBe(true)
+  })
+})
+
+describe('PathMatcher — glob vocabulary (event_history.rb:69-91)', () => {
+  it('* matches within a single segment only', () => {
+    expect(pathMatch('/a/*', '/a/foo')).toBe(true)
+    expect(pathMatch('/a/*', '/a/')).toBe(true) // empty segment
+    expect(pathMatch('/a/*', '/a/b/c')).toBe(false) // does not cross /
+  })
+
+  it('** matches across segments', () => {
+    expect(pathMatch('/a/**/d', '/a/b/c/d')).toBe(true)
+    expect(pathMatch('/a/**/d', '/a/x/d')).toBe(true)
+    // Desktop's /**/ → /.*/ keeps the surrounding slashes, so the middle ** needs
+    // at least one intermediate segment: /a/d (zero segments) does NOT match.
+    expect(pathMatch('/a/**/d', '/a/d')).toBe(false)
+    expect(pathMatch('/a/**', '/a/b/c')).toBe(true)
+    expect(pathMatch('/**', '/anything/at/all')).toBe(true)
+  })
+
+  it('? matches exactly one character', () => {
+    expect(pathMatch('/a/?oo', '/a/foo')).toBe(true)
+    expect(pathMatch('/a/?oo', '/a/oo')).toBe(false)
+  })
+
+  it('{a,b} alternation', () => {
+    expect(pathMatch('/{set,cue}/x', '/set/x')).toBe(true)
+    expect(pathMatch('/{set,cue}/x', '/cue/x')).toBe(true)
+    expect(pathMatch('/{set,cue}/x', '/live_loop/x')).toBe(false)
+  })
+
+  it('[a-g] char range and [!a-g] negation', () => {
+    expect(pathMatch('/[a-g]oo', '/foo')).toBe(true)
+    expect(pathMatch('/[a-g]oo', '/zoo')).toBe(false)
+    expect(pathMatch('/[!a-g]oo', '/zoo')).toBe(true)
+    expect(pathMatch('/[!a-g]oo', '/foo')).toBe(false)
+  })
+
+  it('regex metacharacters in literal segments are escaped, not interpreted', () => {
+    expect(pathMatch('/a.b', '/a.b')).toBe(true)
+    expect(pathMatch('/a.b', '/axb')).toBe(false) // '.' is literal, not "any char"
+  })
+})

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -345,7 +345,7 @@ export async function runProgram(
 
       case 'sync': {
         ctx.bridge?.flushMessages()
-        const payload = await ctx.scheduler.waitForSync(step.name, ctx.taskId)
+        const payload = await ctx.scheduler.waitForSync(step.name, ctx.taskId, step.argMatcher)
         if (step.bpmSync) {
           // Inherit cuer's BPM (sync_bpm, #236). Mutate both runtime locals
           // so subsequent sleep/play/FX steps in this iteration use the

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -8,6 +8,7 @@
 
 import type { Program } from '../Program'
 import { TimeState } from '../TimeState'
+import { TimeStateView } from '../EventHistory'
 import { normalizePlayParams, normalizeControlParams, normalizeFxParams, resolveSynthName } from '../SoundLayer'
 import { noteToMidi } from '../NoteToFreq'
 
@@ -89,7 +90,7 @@ export interface AudioContext {
    * Still typed to permit a plain Map for any non-engine caller; only the
    * TimeState path is no-op'd.
    */
-  globalStore?: TimeState | Map<string | symbol, unknown>
+  globalStore?: TimeState | TimeStateView | Map<string | symbol, unknown>
   /** Host-provided OSC send handler. If not set, osc_send is a silent no-op. */
   oscHandler?: (host: string, port: number, path: string, ...args: unknown[]) => void
   /** MIDI bridge for deferred midi-out steps (issue #195). */
@@ -334,7 +335,10 @@ export async function runProgram(
         // option a) — so the deferred apply is a no-op for TimeState. The step
         // is retained only for SV20/SP41 contract + event-stream/capture. A
         // plain Map (any non-engine caller) keeps the legacy blind-overwrite.
-        if (ctx.globalStore && !(ctx.globalStore instanceof TimeState)) {
+        // GAP M1c: the engine path is now a TimeStateView over the shared
+        // EventHistory — also eager, also a no-op here (and its `.set` needs a
+        // vt/idPath the deferred step doesn't carry). Only a plain Map writes.
+        if (ctx.globalStore instanceof Map) {
           ctx.globalStore.set(step.key, step.value)
         }
         break


### PR DESCRIPTION
Closes #496. Stacked on #491 (GAP A2 EventHistory) → merge after #488→#491.

Completes the desktop `CueEvent` 8-tuple `(t,p,i,d,b,m,path,val)` on the unified EventHistory. GAP A delivered `i` (thread idPath); this adds the remaining three fields: **`path`**, **`val`**, **`m`**.

## What changed

**M1 — `path` (hierarchical paths + glob, the headline):**
- New `PathMatcher.ts` — desktop's OSC glob (`**` `*` `?` `{a,b}` `[a-g]` `[!a-g]`) + write/read namespacing, ported from `EventMatcher` + `__cue_path`/`__sync_path` (`event_history.rb`, `core.rb:64-99`).
- `EventHistory` reads are now path-aware (glob scan-and-merge across keys).
- **Unified store:** the engine owns ONE `EventHistory`, injected into the scheduler, so `set`/`get` and `cue`/`sync` share it (`set→/set/`, `cue→/cue/`, heartbeat→`/live_loop/`; reads use the `/{cue,set,live_loop}/…` union). Consequence (desktop-faithful): **`get :foo` sees a `cue :foo`; `sync :foo` wakes on a `set :foo`.** `TimeState` retired behind a `TimeStateView` adapter.

**M2 — `val` (`arg_matcher`):** `sync :foo, arg_matcher: ->(a){ a[0] == 9 }` wakes only on a cue whose value passes. Threaded through `getNextDelivered` → `waitForSync` (history-first + live wake loop + waiter). Includes a lambda implicit-return fix (single-expression lambdas now return their value — without it every predicate silently returned `undefined`).

**M3 — `m` (`current_bpm_mode`):** returns the current bpm (no `:link` — Ableton Link is out of v1 scope).

## Faithfulness notes / scope
- **Symbol erasure:** our transpiler lowers `:foo` and `"foo"` to the same JS string, so the symbol/string namespacing split keys on a leading `/` (absolute = explicit path, else symbol semantics) — exact for `:foo` and `"/a/b"`, a documented divergence for the rare relative-string `set "foo"`.
- **Flat store kept** (GAP A2's choice): glob-scan over a flat Map is semantically identical to desktop's `EventHistoryNode` tree at v1 key counts; the tree is a perf structure, deferred.
- Ableton Link (`:link`) and desktop's `@history_depth` time-pruning remain out of scope.

## Verification
- **Full suite 1274/1274**, `tsc` clean. The sync/cue fatality boundary (`SyncCue` + #481/#400 cells) stays green — the store unification is additive and the scheduler only clears a store it OWNS (fixes a #336 regression: re-evaluate's scheduler-dispose was wiping the now-shared set/get state).
- New tests: `PathMatcher` (every glob form + namespacing), `EventHistoryGlob` (union reads + valMatcher skip/null/throw), `GapMTimeStateRichness` (absolute-path get, glob get, symbol read union, arg_matcher DSL).

## Commits
1. M1a — PathMatcher (glob + namespacing)
2. M1b — path-aware EventHistory reads
3. M1c — unify set/get + cue/sync onto one path-namespaced store
4. M2 + M3 — arg_matcher + current_bpm_mode (+ lambda implicit-return)

🤖 Generated with [Claude Code](https://claude.com/claude-code)