### PR TITLE
🎏 GAP M residuals (#498): live set wakes parked sync + union read fast path

### DIFF
--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -34,7 +34,7 @@
  * history pruning (`@history_depth`, event_history.rb:163) are likewise deferred.
  */
 
-import { pathMatch, toWritePath, toReadPath } from './PathMatcher'
+import { pathMatch, toWritePath, toReadPath, unionReadKeys } from './PathMatcher'
 
 /** Glob tokens that force a read to scan-and-merge across keys (GAP M1b). */
 const GLOB_TOKENS = /[*?{[]/
@@ -206,8 +206,7 @@ export class EventHistory {
     // over a flat key set. A glob-free key keeps the O(1) exact Map lookup.
     if (typeof key === 'string' && GLOB_TOKENS.test(key)) {
       let best: CueEvent | null = null
-      for (const [storedKey, events] of this.store) {
-        if (typeof storedKey !== 'string' || !pathMatch(key, storedKey)) continue
+      for (const events of this.globCandidateLists(key)) {
         const cand = this.firstAtOrBefore(events, ge)
         if (cand && (!best || compareEvent(cand, best) > 0)) best = cand
       }
@@ -216,6 +215,32 @@ export class EventHistory {
     const events = this.store.get(key)
     if (!events || events.length === 0) return null
     return this.firstAtOrBefore(events, ge)
+  }
+
+  /**
+   * The event lists a glob read must merge over. The canonical symbol union
+   * (`/{cue,set,live_loop}/SEG`, what `get`/`sync :foo` emit) resolves to its
+   * three exact keys by direct lookup ({@link unionReadKeys}, #498 task 2); any
+   * general glob (`/a/*`) scans the store. Both yield the SAME lists — the union
+   * brace is segment-anchored so its only matches ARE those three keys — so this
+   * is a fast path on the read hot path, not a semantic change.
+   */
+  private globCandidateLists(globKey: string): CueEvent[][] {
+    const lists: CueEvent[][] = []
+    const union = unionReadKeys(globKey)
+    if (union) {
+      for (const k of union) {
+        const events = this.store.get(k)
+        if (events && events.length > 0) lists.push(events)
+      }
+      return lists
+    }
+    for (const [storedKey, events] of this.store) {
+      if (typeof storedKey === 'string' && pathMatch(globKey, storedKey) && events.length > 0) {
+        lists.push(events)
+      }
+    }
+    return lists
   }
 
   /** First (greatest) event `<= ge` in a descending list, or null. */
@@ -254,8 +279,7 @@ export class EventHistory {
     // cue to the next deliverable one (event_history.rb:529-534).
     if (typeof key === 'string' && GLOB_TOKENS.test(key)) {
       let best: CueEvent | null = null
-      for (const [storedKey, events] of this.store) {
-        if (typeof storedKey !== 'string' || !pathMatch(key, storedKey)) continue
+      for (const events of this.globCandidateLists(key)) {
         const cand = this.firstDeliverable(events, t, idPath, after, valMatcher)
         if (cand && (!best || compareEvent(cand, best) < 0)) best = cand
       }

--- a/src/engine/PathMatcher.ts
+++ b/src/engine/PathMatcher.ts
@@ -201,6 +201,31 @@ export function toReadPath(key: string): string {
   return normalizeReadPath(key, !key.startsWith('/'))
 }
 
+/** The literal prefix of the canonical symbol union read (`/{cue,set,live_loop}/`). */
+const UNION_READ_PREFIX = `/{${SYNC_PATH_ROOTS.join(',')}}/`
+
+/**
+ * If `pattern` is the canonical symbol union read ({@link toReadPath} of a
+ * symbol: `/{cue,set,live_loop}/SEG` with SEG one glob-free segment), return the
+ * three exact keys it matches — `/cue/SEG`, `/set/SEG`, `/live_loop/SEG` — so a
+ * caller can resolve them by direct lookup instead of scanning the whole store
+ * (#498 task 2). Returns `null` for any general glob (`/a/*`), which keeps the
+ * full scan.
+ *
+ * Safe because the brace glob compiles to `^/?(cue|set|live_loop)/SEG/?$`
+ * ({@link compileGlob}) — segment-anchored, so those three literals are EXACTLY
+ * its match set. The direct lookup is therefore identical to filtering the store
+ * by {@link pathMatch}, just O(3) instead of O(keys).
+ */
+export function unionReadKeys(pattern: string): string[] | null {
+  if (!pattern.startsWith(UNION_READ_PREFIX)) return null
+  const seg = pattern.slice(UNION_READ_PREFIX.length)
+  // SEG must be a single literal segment: no nested path, no residual glob token
+  // (a genuine union SEG is cuePathSegment output, which strips all of these).
+  if (seg.length === 0 || /[*?{}[\]/]/.test(seg)) return null
+  return SYNC_PATH_ROOTS.map((root) => `/${root}/${seg}`)
+}
+
 function stripSlashes(s: string): string {
   let a = 0
   let b = s.length

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -60,6 +60,9 @@ export class ProgramBuilder {
   private _syncScheduler: {
     waitForSync(name: string, taskId: string, argMatcher?: (args: unknown) => boolean): Promise<{ args: unknown[]; bpm: number }>
     getTask?(taskId: string): { virtualTime: number } | undefined
+    // #498: a live `set` wakes an already-parked `sync` (desktop EventHistory.set
+    // → @event_matchers.match). Optional — only the audio scheduler provides it.
+    notifySet?(name: string, vt: number, idPath: number[], value: unknown): void
   } | null = null
   private _syncTaskId: string | null = null
   // SP95(d) #350 slice 2: the virtual-time-indexed Time State the engine wires
@@ -274,6 +277,7 @@ export class ProgramBuilder {
     scheduler: {
       waitForSync(name: string, taskId: string, argMatcher?: (args: unknown) => boolean): Promise<{ args: unknown[]; bpm: number }>
       getTask?(taskId: string): { virtualTime: number } | undefined
+      notifySet?(name: string, vt: number, idPath: number[], value: unknown): void
     },
     taskId: string,
   ): void {
@@ -881,6 +885,13 @@ export class ProgramBuilder {
     // GAP A2: tag the write with the owning task's idPath so a same-vt reader
     // resolves it by the (t, idPath) total order (#400).
     this._timeState?.set(key, value, this.current_time(), this._ownerIdPath)
+    // #498: desktop's EventHistory.set runs @event_matchers.match after the
+    // insert (event_history.rb:204), so a `set` wakes an already-parked `sync`,
+    // not just the set-before-sync case the history-first scan covers. The eager
+    // write above already landed `value` in the shared store; notifySet only runs
+    // the match. Audio path only (the scheduler is the sole waiter holder); the
+    // capture / query builders never wire it, so an S3 sync there can't be woken.
+    this._syncScheduler?.notifySet?.(String(key), this.current_time(), this._ownerIdPath, value)
     this.steps.push({ tag: 'set', key, value })
     return this
   }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -494,7 +494,8 @@ export class VirtualTimeScheduler {
     // Record the cue in the (t, idPath)-ordered history so a late or
     // forked-sibling syncer resolves it correctly (replaces the single-entry
     // cueMap). Value carries the cuer's BPM for sync_bpm waiters (#236).
-    this.cueHistory.insert(firedPath, cueVirtualTime, cueIdPath, { args, bpm: cueBpm })
+    const value = { args, bpm: cueBpm }
+    this.cueHistory.insert(firedPath, cueVirtualTime, cueIdPath, value)
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({
@@ -505,39 +506,64 @@ export class VirtualTimeScheduler {
       params: { name, args },
     })
 
-    // Wake any tasks waiting for this cue.
-    // Supports exact match AND glob patterns (*, ?) in sync targets (#150).
-    // Example: `sync "/midi:*:*/note_on"` matches a cue named `/midi:*:1/note_on`.
+    // Wake any parked sync waiters. Desktop runs `@event_matchers.match(ce)` from
+    // the SAME EventHistory.set both `cue` and `set` flow through (event_history.rb
+    // :204) — so the wake loop is shared via notifyWaiters and also reachable from
+    // the `set` path (#498, notifySet below).
+    this.notifyWaiters(firedPath, cueVirtualTime, cueIdPath, value)
+  }
+
+  /**
+   * Wake the parked sync waiters a just-recorded event satisfies. Desktop's
+   * `EventHistory.set` calls `@event_matchers.match(ce)` after every insert
+   * (event_history.rb:204) — for cues (via {@link fireCue}) AND for `set`s (via
+   * {@link notifySet}, #498). The store insert is the CALLER's responsibility;
+   * this runs only the match, so it never double-records.
+   *
+   * `storedValue` is the value exactly as it sits in the history: `{ args, bpm }`
+   * for a cue, a raw value for a `set`. Both the live wake (here) and the
+   * history-first scan ({@link waitForSync}) pass that same stored value to the
+   * waiter's `valMatcher` and resolve from it, so a set-before-park and a
+   * park-before-set deliver identically.
+   *
+   * Supports exact match AND glob patterns (asterisk, ?) in sync targets (#150):
+   * a `sync` glob like `/midi:_:_/note_on` matches a concrete fired midi path.
+   */
+  notifyWaiters(firedPath: string, vt: number, idPath: number[], storedValue: unknown): void {
     for (const [pattern, waiters] of this.syncWaiters) {
       if (waiters.length === 0) continue
       // GAP M1c: a waiter is registered under its READ path (a glob like
       // `/{cue,set,live_loop}/foo`); match it against the concrete fired path.
       if (!pathMatch(pattern, firedPath)) continue
-      // Wake-phase (cueDelivers, observed desktop #481/#400): deliver iff the cue
+      // Wake-phase (cueDelivers, observed desktop #481/#400): deliver iff the event
       // is strictly LATER, or — at EQUAL vt — the waiter is a strict ANCESTOR of
-      // the cuer (its thread spawned the cuer, then synced → happens-after). A
+      // the firer (its thread spawned the firer, then synced → happens-after). A
       // forked-SIBLING waiter ([0,1]) misses a driver cue ([0,0]) and waits a
       // cycle (#481 in_thread / #350 met / #400 player); an inline/main waiter
       // ([0]) catches a driver cue ([0,0]) at the same vt (#481 with_fx/bare_loop).
       const kept: typeof waiters = []
       for (const waiter of waiters) {
         const waiterTask = this.tasks.get(waiter.taskId)
-        // #489: don't re-deliver a cue at or before the one this waiter already
+        // #489: don't re-deliver an event at or before the one this waiter already
         // consumed (desktop's last-sync matcher). The wake-phase (cueDelivers) is
-        // unchanged; this only excludes an already-seen cue on a re-sync.
+        // unchanged; this only excludes an already-seen event on a re-sync.
         const after = waiterTask?.lastSyncedCue
-        const delivers = cueDelivers(cueVirtualTime, cueIdPath, waiter.waiterVt, waiter.waiterIdPath)
-          && (!after || compareEvent({ t: cueVirtualTime, idPath: cueIdPath }, after) > 0)
-          // GAP M2: arg_matcher — the waiter only wakes if the cue's value passes.
-          // The stored-value shape is `{ args, bpm }`, the same as history-first.
-          && (!waiter.valMatcher || waiter.valMatcher({ args, bpm: cueBpm }))
+        const delivers = cueDelivers(vt, idPath, waiter.waiterVt, waiter.waiterIdPath)
+          && (!after || compareEvent({ t: vt, idPath }, after) > 0)
+          // GAP M2: arg_matcher — the waiter only wakes if the event's value passes.
+          && (!waiter.valMatcher || waiter.valMatcher(storedValue))
         if (delivers) {
           if (waiterTask) {
-            // Inherit cue's virtual time (SV5) and advance the re-sync matcher.
-            waiterTask.virtualTime = cueVirtualTime
-            waiterTask.lastSyncedCue = { t: cueVirtualTime, idPath: cueIdPath }
+            // Inherit the event's virtual time (SV5) and advance the re-sync matcher.
+            waiterTask.virtualTime = vt
+            waiterTask.lastSyncedCue = { t: vt, idPath }
           }
-          waiter.resolve({ args, bpm: cueBpm })
+          // Resolve from the stored value the same way history-first does
+          // (waitForSync): a cue's `{ args, bpm }` round-trips; a raw set value
+          // yields `{ args: undefined, bpm: undefined }` (set→sync value retrieval
+          // is a separate, pre-existing limitation, not this fix's concern).
+          const payload = storedValue as { args: unknown[]; bpm: number }
+          waiter.resolve({ args: payload.args, bpm: payload.bpm })
         } else {
           kept.push(waiter)
         }
@@ -545,6 +571,19 @@ export class VirtualTimeScheduler {
       if (kept.length > 0) this.syncWaiters.set(pattern, kept)
       else this.syncWaiters.delete(pattern)
     }
+  }
+
+  /**
+   * Wake parked syncs for a live `set` (#498). The eager build-time write already
+   * landed `value` in the shared store ({@link ProgramBuilder.set} → TimeStateView);
+   * this runs the match desktop's `EventHistory.set` does afterwards
+   * (event_history.rb:204), so a `set` that fires while a `sync` is already parked
+   * wakes it — not just the set-before-sync case the history-first scan covers.
+   * The `set` write namespaces the key under `/set/` (toWritePath), matching the
+   * union read `sync :foo` registers (`/{cue,set,live_loop}/foo`).
+   */
+  notifySet(name: string, vt: number, idPath: number[], value: unknown): void {
+    this.notifyWaiters(toWritePath(name, 'set'), vt, idPath, value)
   }
 
   /**

--- a/src/engine/__tests__/EventHistoryGlob.test.ts
+++ b/src/engine/__tests__/EventHistoryGlob.test.ts
@@ -86,3 +86,26 @@ describe('EventHistory — getNextDelivered valMatcher (GAP M2 arg_matcher)', ()
     expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0], undefined, boom)).toBeNull()
   })
 })
+
+describe('EventHistory — #498 task 2 union read fast path is semantically identical', () => {
+  it('the canonical union resolves ONLY the 3 exact keys (no prefix / multi-segment bleed)', () => {
+    const eh = new EventHistory()
+    eh.insert('/cue/foo', 1, [0], 'exact')
+    eh.insert('/cue/foobar', 2, [0], 'prefix-only') // same root, longer segment
+    eh.insert('/cue/foo/bar', 3, [0], 'sub-path') // same root, extra segment
+    // The brace glob is segment-anchored (^(cue|set|live_loop)/foo$), so the
+    // direct-3-key fast path must see ONLY /cue/foo, never the t=2/t=3 imposters.
+    expect(eh.getMostRecent('/{cue,set,live_loop}/foo', 5, [0])?.value).toBe('exact')
+    expect(eh.getNextDelivered('/{cue,set,live_loop}/foo', 0, [0])?.value).toBe('exact')
+  })
+
+  it('a general (non-union) glob still scans the whole store', () => {
+    const eh = new EventHistory()
+    eh.insert('/x/a', 1, [0], 'a@1')
+    eh.insert('/x/b', 2, [0], 'b@2')
+    eh.insert('/y/c', 3, [0], 'c@3') // does not match /x/*
+    // unionReadKeys('/x/*') is null → the scan branch merges across /x/a,/x/b.
+    expect(eh.getMostRecent('/x/*', 5, [0])?.value).toBe('b@2')
+    expect(eh.getNextDelivered('/x/*', 0, [0])?.value).toBe('a@1') // smallest deliverable
+  })
+})

--- a/src/engine/__tests__/PathMatcher.test.ts
+++ b/src/engine/__tests__/PathMatcher.test.ts
@@ -4,6 +4,8 @@ import {
   normalizeWritePath,
   normalizeReadPath,
   cuePathSegment,
+  toReadPath,
+  unionReadKeys,
   SYNC_PATH_ROOTS,
 } from '../PathMatcher'
 
@@ -109,5 +111,35 @@ describe('PathMatcher — glob vocabulary (event_history.rb:69-91)', () => {
   it('regex metacharacters in literal segments are escaped, not interpreted', () => {
     expect(pathMatch('/a.b', '/a.b')).toBe(true)
     expect(pathMatch('/a.b', '/axb')).toBe(false) // '.' is literal, not "any char"
+  })
+})
+
+describe('PathMatcher — unionReadKeys fast-path detection (#498 task 2)', () => {
+  it('recognises the canonical symbol union and returns the 3 exact keys', () => {
+    expect(unionReadKeys('/{cue,set,live_loop}/foo')).toEqual([
+      '/cue/foo',
+      '/set/foo',
+      '/live_loop/foo',
+    ])
+  })
+
+  it('the 3 keys it returns are EXACTLY what the glob matches', () => {
+    const pattern = toReadPath('foo') // what `sync :foo` / `get :foo` emit
+    const keys = unionReadKeys(pattern)!
+    expect(keys).not.toBeNull()
+    // Every returned key matches the glob ...
+    for (const k of keys) expect(pathMatch(pattern, k)).toBe(true)
+    // ... and the glob matches nothing the 3-key set would miss (segment-anchored).
+    expect(pathMatch(pattern, '/cue/foobar')).toBe(false)
+    expect(pathMatch(pattern, '/cue/foo/bar')).toBe(false)
+    expect(pathMatch(pattern, '/midi/foo')).toBe(false)
+  })
+
+  it('returns null for a general glob (keeps the full store scan)', () => {
+    expect(unionReadKeys('/x/*')).toBeNull()
+    expect(unionReadKeys('/cue/foo')).toBeNull() // an exact key never hits the glob branch
+    expect(unionReadKeys('/{cue,set,live_loop}/foo/*')).toBeNull() // residual glob in SEG
+    expect(unionReadKeys('/{cue,set,live_loop}/a/b')).toBeNull() // multi-segment SEG
+    expect(unionReadKeys('/{cue,set}/foo')).toBeNull() // a different brace set
   })
 })

--- a/src/engine/__tests__/SetWakesParkedSync.test.ts
+++ b/src/engine/__tests__/SetWakesParkedSync.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { VirtualTimeScheduler } from '../VirtualTimeScheduler'
+import { EventHistory, TimeStateView } from '../EventHistory'
+import { ProgramBuilder } from '../ProgramBuilder'
+import { toWritePath } from '../PathMatcher'
+
+/**
+ * #498 task 1 — a LIVE `set` must wake an already-parked `sync`.
+ *
+ * Desktop's `EventHistory.set` runs `@event_matchers.match(ce)` after every
+ * insert (event_history.rb:204), so a `set` that fires while a `sync` is already
+ * parked wakes it — not only the set-before-sync case the history-first scan
+ * covers. Pre-#498 our `set` eager-wrote to the shared store but never ran the
+ * match, so a parked syncer stayed parked forever (only `cue`/`live_loop`
+ * heartbeats via fireCue ran the wake loop).
+ */
+async function flush(rounds = 10) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+describe('#498 — a live set wakes an already-parked sync', () => {
+  it('notifySet wakes a syncer that parked before the set fired (insert alone does not)', async () => {
+    const eventHistory = new EventHistory({ maxPerKey: 256 })
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+      eventHistory,
+    })
+
+    let woke = false
+    let payload: { args: unknown[]; bpm: number } | null = null
+    scheduler.registerLoop('waiter', async () => {
+      payload = await scheduler.waitForSync('foo', 'waiter')
+      woke = true
+    })
+
+    // Release the loop's initial sleep(0) so the waiter runs, finds nothing in
+    // history for /{cue,set,live_loop}/foo, and parks.
+    scheduler.tick(100)
+    await flush()
+    expect(woke).toBe(false)
+
+    // Reproduce what ProgramBuilder.set does on the audio path: eager-write the
+    // value into the shared store, THEN run the match. The write alone must NOT
+    // wake the parked syncer (that is the residual) ...
+    eventHistory.insert(toWritePath('foo', 'set'), 1, [0, 1], 99)
+    await flush()
+    expect(woke).toBe(false)
+
+    // ... and notifySet (the fix) does.
+    scheduler.notifySet('foo', 1, [0, 1], 99)
+    await flush()
+    expect(woke).toBe(true)
+    // set→sync resolves with the history-first shape: a raw set value yields
+    // {args: undefined} (set-value retrieval is a separate, pre-existing gap).
+    expect(payload).not.toBeNull()
+  })
+
+  it('ProgramBuilder.set wires notifySet end-to-end (a wired setter builder wakes a parked sync)', async () => {
+    const eventHistory = new EventHistory({ maxPerKey: 256 })
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+      eventHistory,
+    })
+
+    let woke = false
+    scheduler.registerLoop('waiter', async () => {
+      await scheduler.waitForSync('foo', 'waiter')
+      woke = true
+    })
+    scheduler.tick(100)
+    await flush()
+    expect(woke).toBe(false)
+
+    // A setter builder wired exactly as SonicPiEngine wires loop builders:
+    // shared TimeStateView for the eager write + the scheduler for notifySet.
+    const setter = new ProgramBuilder(0)
+    setter.setSyncContext(scheduler, 'setter')
+    setter.setTimeStateContext(new TimeStateView(eventHistory), [0, 1])
+    setter.sleep(1) // advance build vt so the set is strictly after the waiter's vt 0
+    setter.set('foo', 42)
+
+    await flush()
+    expect(woke).toBe(true)
+  })
+
+  it('set-before-sync still resolves via the history-first scan (no regression)', async () => {
+    const eventHistory = new EventHistory({ maxPerKey: 256 })
+    const scheduler = new VirtualTimeScheduler({
+      getAudioTime: () => 0,
+      schedAheadTime: 100,
+      eventHistory,
+    })
+
+    // Write the set BEFORE any syncer registers.
+    eventHistory.insert(toWritePath('foo', 'set'), 1, [0], 7)
+
+    let woke = false
+    scheduler.registerLoop('waiter', async () => {
+      await scheduler.waitForSync('foo', 'waiter')
+      woke = true
+    })
+    scheduler.tick(100)
+    await flush()
+    expect(woke).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #498. Both GAP M self-review residuals from #497. **Stacked on `feat/gapM-timestate-richness` (#497 → #491 → …)** — GitHub auto-retargets to `main` as the stack merges.

## Task 1 — a live `set` wakes an already-parked `sync` (correctness)
After GAP M (#497) unified set/get and cue/sync onto one `EventHistory`, a `set` written **before** a `sync` parks is found by the sync's history-first union read — but a `set` that fired while a `sync` was **already parked** never woke it. Only `fireCue` (cue / live_loop heartbeat) ran the wake loop; `set` eager-wrote the value and returned.

Desktop's `EventHistory.set` always runs `@event_matchers.match(ce)` after the insert (`event_history.rb:197-206`) — both `cue` and `set` flow through that one method — so desktop wakes the parked syncer.

**Fix:** extract the fireCue wake loop into `notifyWaiters(firedPath, vt, idPath, storedValue)` + a `notifySet(name, vt, idPath, value)` convenience; `ProgramBuilder.set` calls it (via the already-wired `_syncScheduler`) right after the eager write, mirroring desktop's single `EventHistory.set` = insert + match. The extraction passes the value exactly as stored (`{args,bpm}` for a cue, raw for a set) to both `valMatcher` and `resolve`, so live-wake and history-first deliver identically — **cue behaviour is byte-unchanged**. Audio path only (the scheduler holds the waiters).

Set→sync **value** retrieval stays lossy (`{args: undefined}` for a raw set value, same as the pre-existing history-first path) — a separate limitation, out of scope here.

## Task 2 — union read resolves 3 keys, not a full store scan (perf)
`sync :foo` / `get :foo` read the union glob `/{cue,set,live_loop}/foo`, so `getNextDelivered`/`getMostRecent` took the glob branch and scanned **every** store key per call — O(keys) on the read hot path. The symbol union is exactly 3 candidate keys.

**Fix:** `unionReadKeys(pattern)` recognises the canonical union and returns its 3 exact keys (`/cue/SEG`, `/set/SEG`, `/live_loop/SEG`); `EventHistory` resolves them by direct `Map.get` via a shared `globCandidateLists` helper. General globs (`/a/*`) return `null` → keep the full scan. This is a **fast path, not a semantic change**: the union brace compiles to a segment-anchored `^(cue|set|live_loop)/SEG$` (`compileGlob`), so those 3 literals are *exactly* its match set. The helper also dedups the two previously-duplicated glob scan loops.

## Test plan
- `SetWakesParkedSync.test.ts` — park-then-set wakes (insert alone does **not**), `ProgramBuilder.set` end-to-end wiring, set-before-sync history-first no-regression.
- `EventHistoryGlob.test.ts` — fast path resolves ONLY the 3 exact keys (no prefix / sub-path bleed); a general glob still scans the whole store.
- `PathMatcher.test.ts` — `unionReadKeys` detection (canonical → 3 keys; general glob / multi-seg / residual-glob / different-brace → null), and the returned keys are exactly what the glob matches.
- **Full suite 1282/1282, `tsc --noEmit` clean.** #336 persistence + `SyncCue` fatality cells green.

> Level-3 6-tier audio: deferred to the post-merge corpus re-sweep (this is a scheduler wake-mechanism + read-path change with no audio-output delta; verified by deterministic boundary tests). Catalogue: vyapti **SV65** updated (#498 residuals → RESOLVED).