### PR TITLE
🐛 fix(capture): nested in_thread false-positive made bare-sequential pieces ignore --duration (bach timeout + ungradeable)

### DIFF
--- a/tools/__tests__/capture-async-heuristic.test.ts
+++ b/tools/__tests__/capture-async-heuristic.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { isAsyncByConstruction } from '../capture'
+
+/**
+ * Guards the capture `--wrap-recording` classification (#501).
+ *
+ * `isAsyncByConstruction(code)` decides whether user code returns immediately
+ * (top-level live_loop / loop → run bare, preserve with_fx FX routing) or
+ * BLOCKS the main thread (→ wrap in in_thread so the recording window stays
+ * bounded to --duration). The original heuristic also matched `in_thread`,
+ * which false-positive-classified bare-sequential pieces with a NESTED
+ * in_thread (bach.rb) as async → unbounded render (sweep timeout #429) +
+ * window-misaligned, ungradeable capture (#406). These cases lock the contract.
+ */
+describe('isAsyncByConstruction (capture --wrap-recording classifier)', () => {
+  it('treats top-level live_loop as async (skip wrap)', () => {
+    expect(isAsyncByConstruction('live_loop :a do\n  play 60\n  sleep 1\nend')).toBe(true)
+  })
+
+  it('treats a top-level bare `loop do` as async (skip wrap — SP111)', () => {
+    expect(isAsyncByConstruction('loop do\n  play 60\n  sleep 1\nend')).toBe(true)
+  })
+
+  it('treats a `loop` indented inside with_fx as async — crushed.rb stays FX-routed', () => {
+    // The loop is indented; the regex must allow leading whitespace or crushed
+    // would be wrapped and lose its FX bus (SV30, #426).
+    const crushed = 'with_fx :bitcrusher do\n  loop do\n    play 50\n    sleep 0.5\n  end\nend'
+    expect(isAsyncByConstruction(crushed)).toBe(true)
+  })
+
+  it('#501: a NESTED in_thread inside bare-sequential code is NOT async (must wrap)', () => {
+    // bach.rb shape: top level is `2.times { ... }` (blocks) with in_thread
+    // nested inside. The program does NOT return immediately, so it must be
+    // wrapped to bound the recording window.
+    const bachShape =
+      'use_bpm 60\n' +
+      '2.times do\n' +
+      '  in_thread do\n' +
+      '    play 40\n' +
+      '    sleep 8\n' +
+      '  end\n' +
+      '  play_pattern_timed [:c4, :e4], [0.5, 0.5]\n' +
+      'end'
+    expect(isAsyncByConstruction(bachShape)).toBe(false)
+  })
+
+  it('a top-level in_thread alone is NOT treated as async (#501 — wrapping it is harmless and bounds the window)', () => {
+    expect(isAsyncByConstruction('in_thread do\n  play 60\n  sleep 1\nend')).toBe(false)
+  })
+
+  it('a top-level with_fx over blocking N.times (no loop) is NOT async — orchard_improv.rb stays wrapped', () => {
+    const orchardShape = 'with_fx :reverb do\n  100.times do\n    play 60\n    sleep 0.28\n  end\nend'
+    expect(isAsyncByConstruction(orchardShape)).toBe(false)
+  })
+
+  it('plain bare-sequential code is NOT async (must wrap)', () => {
+    expect(isAsyncByConstruction('play 60\nsleep 1\nplay 64')).toBe(false)
+  })
+
+  it('does not match identifiers that merely contain the keywords', () => {
+    // `looper`, `my_loop` etc. must not trip the \b-anchored match.
+    expect(isAsyncByConstruction('looper = 5\nplay looper')).toBe(false)
+    expect(isAsyncByConstruction('my_live_loop = 1')).toBe(false)
+  })
+})

--- a/tools/capture.ts
+++ b/tools/capture.ts
@@ -19,12 +19,43 @@
 import { chromium, firefox, type Browser } from '@playwright/test'
 import { writeFileSync, readFileSync, mkdirSync, statSync, readdirSync } from 'fs'
 import { resolve, dirname, basename, extname, relative } from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const CAPTURES_DIR = resolve(__dirname, '../.captures')
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
 const DEFAULT_DURATION = 8000
+
+/**
+ * Is `code` async-by-construction at the PROGRAM level — i.e. does it register
+ * its sound sources and RETURN IMMEDIATELY, leaving the main thread free?
+ *
+ * Used by the `--wrap-recording` path to decide whether to push user code into
+ * `in_thread` (which bounds the recording window to `--duration`). Async code
+ * must NOT be wrapped — the nested `__b.with_fx` builder path doesn't wire the
+ * FX bus the way top-level `topLevelWithFx` does, so wrapping a top-level
+ * `with_fx { live_loop }` (e.g. `crushed.rb`) silences its FX (SV30, #426).
+ *
+ * Only `live_loop` / `loop` qualify: after the #426/SP111 transpiler fix a
+ * top-level `loop do` (bare OR inside `with_fx`) registers an auto-named
+ * live_loop and returns immediately, exactly like an explicit `live_loop`.
+ *
+ * `in_thread` is DELIBERATELY EXCLUDED (#501). It detaches ONE thread but does
+ * NOT make the program return immediately — code after/around it on the main
+ * thread still blocks. `sorcerer/bach.rb` is bare-sequential at top level
+ * (`2.times do … play_pattern_timed … end`) with `in_thread` nested INSIDE it;
+ * treating that nested `in_thread` as async made bach skip the wrap, block the
+ * main thread for the whole ~95s piece, and fire `recording_save` far past
+ * `--duration` → unbounded render (sweep timeout #429) + window-misaligned,
+ * ungradeable capture (#406). Measured blast radius across all 34 official
+ * fixtures: only bach flips (skip→wrap). `crushed.rb` stays async (via `loop`);
+ * `orchard_improv.rb` stays wrapped (top-level `with_fx` over a blocking
+ * `100.times`, no loop). Leading whitespace is allowed so an indented `loop`
+ * inside `with_fx` (crushed) still matches.
+ */
+export function isAsyncByConstruction(code: string): boolean {
+  return /^[ \t]*(?:live_loop|loop)\b/m.test(code)
+}
 
 // ---------------------------------------------------------------------------
 // Capture everything the browser produces
@@ -91,29 +122,12 @@ async function captureRun(
     // recording_stop/save INSIDE in_thread broke: recording state isn't
     // visible across thread boundaries — issue #266.)
     const dur = opts.wrapRecordingSec
-    // Only wrap in `in_thread` when user code might block the main thread
-    // long enough that recording_stop never fires. Code containing top-level
-    // `live_loop` or `in_thread` is already async-by-construction (registration
-    // returns immediately, scheduler runs the body), so wrapping it adds no
-    // benefit AND breaks `with_fx` semantics: when the transpiler sees
-    // `with_fx ... do live_loop ... end end` inside `in_thread`, it emits
-    // `__b.with_fx` and `__b.live_loop` (builder-method path), which doesn't
-    // wire the FX bus to the loop's outBus the way the top-level
-    // `topLevelWithFx` / `fxAwareWrappedLiveLoop` path does. Result: dry
-    // signal in the capture even though desktop hears the FX.
-    //
-    // Heuristic: regex-detect `live_loop`, `in_thread`, or a bare `loop do`
-    // as standalone identifiers at column-zero-ish positions. After the
-    // #426/SP111 transpiler fix, a top-level `loop do` (bare OR wrapped in
-    // `with_fx`) is async-by-construction — it registers an auto-named
-    // live_loop and returns immediately, exactly like an explicit live_loop.
-    // Pushing it into `in_thread` would (a) be unnecessary and (b) break the
-    // with_fx FX-routing parity (the nested `__b.with_fx` builder path doesn't
-    // wire the FX bus the way top-level `topLevelWithFx` does — `crushed.rb`).
-    // So treat a top-level `loop do` like live_loop/in_thread and skip the wrap.
-    // Strings/comments containing these words are rare in test snippets; a false
-    // positive just degrades to "skipped wrap", safe for short snippets too.
-    const alreadyAsync = /^[ \t]*(?:live_loop|in_thread|loop)\b/m.test(code)
+    // Only wrap in `in_thread` when user code would BLOCK the main thread long
+    // enough that the trailing `recording_stop`/`recording_save` never fires
+    // within `--duration`. Async-by-construction code (top-level live_loop /
+    // loop) returns immediately and must run at top level so its with_fx FX bus
+    // wires correctly — see isAsyncByConstruction's contract (SV30, #426, #501).
+    const alreadyAsync = isAsyncByConstruction(code)
     // with_bpm 60 around the sleep so a user's `use_bpm 120` (or any other
     // tempo set inside <code>) doesn't shrink/expand the recording window.
     // At 60 BPM, sleep N == N real seconds.
@@ -959,7 +973,15 @@ end`
   await browser.close()
 }
 
-main().catch((err) => {
-  console.error('Capture failed:', err)
-  process.exit(1)
-})
+// Only run the CLI when executed directly (`tsx tools/capture.ts …`), NOT when
+// imported (e.g. by tools/__tests__/capture-async-heuristic.test.ts) — importing
+// must not launch Playwright.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('Capture failed:', err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Problem

The capture-hang cluster (#429 bach timeout · #406 bach ignores window · bach half of #426) had **one** root cause.

`tools/capture.ts`'s `--wrap-recording` path decides whether to wrap user code in `in_thread` (which bounds the recording window to `--duration`, matching `capture-desktop.ts`'s unconditional wrap) via:

```js
/^[ \t]*(?:live_loop|in_thread|loop)\b/m.test(code)
```

The leading-whitespace allowance let a **nested** `in_thread` match. `sorcerer/bach.rb` is bare-sequential at top level (`2.times do … play_pattern_timed … end`) with `in_thread` nested inside (the bass) → it false-positive-matched → skipped the wrap → the main thread blocked for the whole ~95s piece → `recording_stop`/`recording_save` fired far past `--duration`. Web rendered **103.68s** for an 8s window (desktop 9.37s). That one behavior caused both the ~120s sweep timeout (#429) and the desktop↔web extent mismatch that left bach ungradeable / INCONCLUSIVE (#406).

The conceptual error: `in_thread` detaches **one** thread but does NOT make the *program* return immediately — only `live_loop`/`loop` (register-and-return) do.

## Fix

- Extract the classifier into an exported `isAsyncByConstruction(code)` and **drop `in_thread`** from it.
- **Measured blast radius across all 34 official fixtures: exactly bach flips (skip→wrap).** `crushed.rb` stays async (matches via `loop`, FX routing preserved — no #426 regression); `orchard_improv.rb` stays wrapped (top-level `with_fx` over a blocking `100.times`, no loop).
- Guard `main()` so importing the module for tests doesn't launch Playwright.
- Add a deterministic regression test for the classifier — the boundary had **zero** test coverage, which is why the misclassification shipped.

## Test plan

- **Level 1:** `npx vitest run` → 1299/1299 (8 new). `npx tsc --noEmit` clean. CLI still runs when invoked directly.
- **Level 3 (observation):**
  - bach web capture: **103.68s → 7.68s** (bounded to the 8s window); wall-clock ~110s+ (timeout) → ~16s.
  - bach full `compare-desktop-vs-web` completes without timeout; verdict **EVENT-MATCH** (was INCONCLUSIVE) — desktop 36 voice `/s_new` vs web 34, onset sequence MATCH (34 `beep` onsets within ε, max Δ 0ms, notes match). Tier-0 residual is now a SOFT 1.69s (desktop reverb tail), not the catastrophic 94s.
  - crushed stays bounded (7.68s) + FX-present (peak 0.20) + zero errors.

Closes #501, closes #429, closes #406.