### PR TITLE
🐛 fix: rand(range)→NaN silenced cloud_beat; + NaN-param mix-poison guard (closes #508, #509)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -18,6 +18,26 @@ import { chord, scale, chord_invert, note, note_range, chord_degree, degree, cho
 /** Default maximum iterations before a loop is considered infinite. */
 export const DEFAULT_LOOP_BUDGET = 100_000
 
+/**
+ * A range materialized by the transpiler (`case 'range'`, #508) is a plain array
+ * annotated with its TRUE numeric endpoints. `rangeSpan` recovers `{from, to}`
+ * from such a value so `rand`/`rand_i` can treat `a..b` as a continuous interval
+ * (desktop semantics) rather than reading the array (which corrupts float ranges
+ * and produced NaN). A non-range arg returns null → numeric fast-path. A bare
+ * array (no annotation) falls back to [first, last] so it degrades to a sane
+ * interval instead of NaN.
+ */
+interface RangeAnnotated extends Array<number> { __rangeFrom?: number; __rangeTo?: number }
+function rangeSpan(arg: number | number[] | undefined): { from: number; to: number } | null {
+  if (!Array.isArray(arg)) return null
+  const a = arg as RangeAnnotated
+  if (typeof a.__rangeFrom === 'number' && typeof a.__rangeTo === 'number') {
+    return { from: a.__rangeFrom, to: a.__rangeTo }
+  }
+  if (a.length > 0) return { from: a[0], to: a[a.length - 1] }
+  return null
+}
+
 export class InfiniteLoopError extends Error {
   constructor(message = 'Infinite loop detected — did you forget a sleep?') {
     super(message)
@@ -981,25 +1001,33 @@ export class ProgramBuilder {
     return this.rng.rrand_i(min, max)
   }
 
-  rand(...args: number[]): number {
+  rand(...args: (number | number[])[]): number {
     if (args.length > 1) {
       throw new Error(
         `wrong number of arguments to rand (given ${args.length}, expected 0..1). ` +
         `For a [min, max] range, use rrand(min, max) instead.`
       )
     }
-    const max = args[0] ?? 1
+    // rand(a..b) — desktop returns a random float WITHIN the range. The
+    // transpiler materializes a Ruby range to an array annotated with its true
+    // endpoints (#508); read them so float ranges (0.01..2) keep their real max.
+    const span = rangeSpan(args[0])
+    if (span) return this.rng.rrand(span.from, span.to)
+    const max = (args[0] as number) ?? 1
     return this.rng.rrand(0, max)
   }
 
-  rand_i(...args: number[]): number {
+  rand_i(...args: (number | number[])[]): number {
     if (args.length > 1) {
       throw new Error(
         `wrong number of arguments to rand_i (given ${args.length}, expected 0..1). ` +
         `For a [min, max] integer range, use rrand_i(min, max) instead.`
       )
     }
-    const max = args[0] ?? 2
+    // rand_i(a..b) — desktop returns a random INTEGER within the range (inclusive).
+    const span = rangeSpan(args[0])
+    if (span) return this.rng.rrand_i(span.from, span.to)
+    const max = (args[0] as number) ?? 2
     return this.rng.rrand_i(0, max - 1)
   }
 

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -772,9 +772,7 @@ export class SuperSonicBridge {
   ): number {
     const nodeId = this.sonic!.nextNodeId()
     const paramList: (string | number)[] = []
-    for (const key in params) {
-      paramList.push(key, params[key])
-    }
+    this.pushFiniteParams(paramList, params, `synth ${fullName.replace('sonic-pi-', ':')}`)
     this.queueMessage(audioTime, '/s_new', [fullName, nodeId, 0, 100, ...paramList])
 
     // Schedule node free after expected duration (#73).
@@ -786,6 +784,39 @@ export class SuperSonicBridge {
     }
 
     return nodeId
+  }
+
+  /**
+   * Push key/value pairs onto an /s_new param list, DROPPING any non-finite
+   * numeric value (NaN / ±Infinity) so scsynth falls back to the synthdef's
+   * compiled default. Extends the SV51 note/freq finiteness guard to ALL numeric
+   * params (#509): a single non-finite value (e.g. `cutoff: NaN` from a bad
+   * `rand`) on a synth that USES it (filter/LFO) poisons the persistent FX/mixer
+   * node it routes through and permanently silences the WHOLE mix — once a
+   * UGen integrator goes NaN it stays NaN every control block. Dropping the bad
+   * param contains the blast radius to (at worst) one off-timbre voice. Loud,
+   * not silent: warns once per dispatch listing the dropped params (SV50).
+   */
+  private pushFiniteParams(
+    paramList: (string | number)[],
+    params: Record<string, number>,
+    label: string,
+  ): void {
+    let dropped: string[] | undefined
+    for (const key in params) {
+      const v = params[key]
+      if (typeof v !== 'number' || !Number.isFinite(v)) {
+        ;(dropped ??= []).push(key)
+        continue
+      }
+      paramList.push(key, v)
+    }
+    if (dropped) {
+      this.warnHandler?.(
+        `[Warning] ${label} — dropped non-finite param(s) ${dropped.join(', ')} ` +
+        `(NaN/Infinity); using synthdef default. Check for rand/division producing NaN.`,
+      )
+    }
   }
 
   /**
@@ -864,9 +895,7 @@ export class SuperSonicBridge {
     const params = normalizeSampleParams(translated, bpm ?? 60, sampleWarn)
 
     const paramList: (string | number)[] = ['buf', bufNum]
-    for (const key in params) {
-      paramList.push(key, params[key])
-    }
+    this.pushFiniteParams(paramList, params, `sample :${sampleName}`)
 
     this.queueMessage(audioTime, '/s_new', [playerName, nodeId, 0, 100, ...paramList])
 
@@ -994,9 +1023,7 @@ export class SuperSonicBridge {
       }
       paramList.push('rand_buf', this.randBufId)
     }
-    for (const key in params) {
-      paramList.push(key, params[key])
-    }
+    this.pushFiniteParams(paramList, params, `with_fx ${fullName.replace('sonic-pi-fx_', ':')}`)
     return { nodeId, args: [fullName, nodeId, 0, 101, ...paramList] }
   }
 

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -710,10 +710,19 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       const from = transpileNode(node.namedChildren[0], ctx)
       const to = transpileNode(node.namedChildren[1], ctx)
       const exclusive = node.text.includes('...')
-      if (exclusive) {
-        return `Array.from({length: ${to} - ${from}}, (_, _i) => ${from} + _i)`
-      }
-      return `Array.from({length: ${to} - ${from} + 1}, (_, _i) => ${from} + _i)`
+      // Materialize to an integer array (back-compat: .tick/.each/[i]/.length/.map
+      // all keep working) BUT annotate the TRUE numeric endpoints so rand()/
+      // rand_i() can treat a range as a continuous interval — desktop's
+      // `rand(6..8)` is a random float in [6,8), and integer materialization
+      // loses float endpoints (0.01..2 → [0.01,1.01]) and produced NaN when the
+      // array was fed to rand. The IIFE binds from/to once (no double-eval of a
+      // possibly side-effecting expression). #508 / SP136.
+      const len = exclusive ? '__t - __f' : '__t - __f + 1'
+      // Math.max(0, …) guards reversed ranges (5..1) — Array.from throws
+      // RangeError on a negative length (latent in the prior emit too).
+      return `((__f, __t) => Object.assign(`
+        + `Array.from({length: Math.max(0, ${len})}, (_, __i) => __f + __i), `
+        + `{__rangeFrom: __f, __rangeTo: __t, __rangeExcl: ${exclusive}}))(${from}, ${to})`
     }
 
     // ---- Method calls — the heart of the DSL ----

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -921,4 +921,70 @@ describe('ProgramBuilder', () => {
       expect(warped).toEqual([0, 4])
     })
   })
+
+  describe('rand / rand_i with a range (#508 — SP136)', () => {
+    // The transpiler materializes a Ruby range to an array annotated with its
+    // TRUE endpoints (TreeSitterTranspiler.ts `case 'range'`). rand/rand_i must
+    // read those endpoints and return a value WITHIN the range — desktop's
+    // `rand(6..8)` is a random float in [6,8). Before the fix, rand([6,7,8])
+    // did rrand(0, [array]) → NaN, which poisoned synth params (cloud_beat).
+    const mkRange = (from: number, to: number, excl = false) =>
+      Object.assign(
+        Array.from({ length: Math.max(0, excl ? to - from : to - from + 1) }, (_, i) => from + i),
+        { __rangeFrom: from, __rangeTo: to, __rangeExcl: excl },
+      ) as unknown as number[]
+
+    it('rand(int range) returns a finite float within [from, to)', () => {
+      const b = new ProgramBuilder()
+      for (let i = 0; i < 100; i++) {
+        const v = b.rand(mkRange(6, 8))
+        expect(Number.isFinite(v)).toBe(true)
+        expect(v).toBeGreaterThanOrEqual(6)
+        expect(v).toBeLessThan(8)
+      }
+    })
+
+    it('rand(float range) preserves the true max — NOT the materialized [0.01,1.01]', () => {
+      const b = new ProgramBuilder()
+      let max = -Infinity
+      for (let i = 0; i < 200; i++) {
+        const v = b.rand(mkRange(0.01, 2))
+        expect(Number.isFinite(v)).toBe(true)
+        expect(v).toBeGreaterThanOrEqual(0.01)
+        expect(v).toBeLessThan(2)
+        max = Math.max(max, v)
+      }
+      // If the array endpoints were used (bug), max would cap near 1.01.
+      // Reading __rangeTo=2 lets draws exceed it.
+      expect(max).toBeGreaterThan(1.5)
+    })
+
+    it('rand_i(range) returns an integer within [from, to] inclusive', () => {
+      const b = new ProgramBuilder()
+      for (let i = 0; i < 100; i++) {
+        const v = b.rand_i(mkRange(2, 5))
+        expect(Number.isInteger(v)).toBe(true)
+        expect(v).toBeGreaterThanOrEqual(2)
+        expect(v).toBeLessThanOrEqual(5)
+      }
+    })
+
+    it('plain numeric rand(max) / rand() still work (no regression)', () => {
+      const b = new ProgramBuilder()
+      const v1 = b.rand(4)
+      expect(v1).toBeGreaterThanOrEqual(0)
+      expect(v1).toBeLessThan(4)
+      const v2 = b.rand()
+      expect(v2).toBeGreaterThanOrEqual(0)
+      expect(v2).toBeLessThan(1)
+    })
+
+    it('a bare (un-annotated) array degrades to [first,last], never NaN', () => {
+      const b = new ProgramBuilder()
+      const v = b.rand([3, 4, 5, 6] as number[])
+      expect(Number.isFinite(v)).toBe(true)
+      expect(v).toBeGreaterThanOrEqual(3)
+      expect(v).toBeLessThan(6)
+    })
+  })
 })

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -109,6 +109,29 @@ describe('SuperSonicBridge', () => {
     expect(bundleStr).toContain('sonic-pi-beep')
   })
 
+  it('drops non-finite numeric params before /s_new (#509 — NaN must not reach scsynth)', async () => {
+    const { mockSonic, bundles } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+    const warnings: string[] = []
+    bridge.warnHandler = (m) => warnings.push(m)
+
+    // cutoff NaN (e.g. from rand(50..85) before #508), vibrato_rate Inf; amp finite.
+    await bridge.triggerSynth('blade', 1.0, { note: 60, amp: 0.55, cutoff: NaN, vibrato_rate: Infinity })
+    bridge.flushMessages()
+
+    const bundleStr = new TextDecoder().decode(bundles[0])
+    expect(bundleStr).toContain('sonic-pi-blade')
+    // Finite params survive; the non-finite ones are dropped (scsynth uses defaults).
+    expect(bundleStr).toContain('amp')
+    expect(bundleStr).not.toContain('cutoff')
+    expect(bundleStr).not.toContain('vibrato_rate')
+    // Loud, not silent (SV50).
+    expect(warnings.some((w) => /non-finite/.test(w) && /cutoff/.test(w) && /vibrato_rate/.test(w))).toBe(true)
+  })
+
   it('multiple events between flushes share one bundle', async () => {
     const { mockSonic, bundles } = createMockSuperSonic()
     ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)


### PR DESCRIPTION
## Diagnosis
`algomancer__cloud_beat` plays ~5s then **stops abruptly** — total permanent silence while the scheduler keeps running. Root cause is a two-bug chain:

1. **`rand(<range>)` → `NaN` (#508).** The transpiler materialized every Ruby range into an integer array, so `rand(6..8)` became `rand([6,7,8])` → `rrand(0, [array])` → NaN. Float ranges were doubly broken (`0.01..2` → `[0.01,1.01]`). cloud_beat's `chord_player` (`release: rand(6..8), cutoff: rand(50..85), vibrato_rate: rand(0.01..2)`) thus dispatched `:blade` with all-NaN params.
2. **One NaN param silences the whole mix (#509).** `:blade` *uses* cutoff/vibrato_rate, so NaN entered its DSP → into the always-on `with_fx :reverb` → poisoned the shared mix/mixer → all layers dead, permanently. `SV51` only guarded note/freq.

### Decisive A/B (isolate-the-variable)
Same blade chord + reverb + beat; only `rand(range)` vs fixed numbers differs:

| variant | active 200ms-RMS bins (9s) |
|---|---|
| `rand(6..8)` etc. | **1/45** — dies after first kick |
| fixed values | **45/45** — full run |

## Fixes (two atomic commits)

**#508 — `rand(range)` correctness.** The transpiler annotates the materialized range array with its true endpoints (`__rangeFrom`/`__rangeTo`/`__rangeExcl`); `rand`/`rand_i` read them and route to `rrand`/`rrand_i` over the real interval. Back-compat: still a plain array for `.tick`/`.each`/`[i]`/`.length`/`.map`. Float endpoints preserved. Reversed-range `Array.from` RangeError guarded.

**#509 — finiteness resilience.** `pushFiniteParams` drops any non-finite numeric value before `/s_new` (synth + sample + FX paths) so scsynth uses the synthdef default, and warns once per dispatch (loud, not silent). Extends SV51 to all params — a bad value can no longer take down the whole mix.

## Verification
- **Level 1:** suite **1305/1305** (+6 tests: rand-range contract, float-endpoint, rand_i, plain-numeric no-regression, bare-array degrade; bridge NaN-drop + warning), `tsc` clean.
- **Level 3 (cloud_beat re-capture on fixed engine):** envelope **57/60 active, last-active 11.8s** (was 25/60 dying ~7s); **zero `NaN` on the wire** (blade now `release:3.82 cutoff:57.4 vibrato_rate:1.53`); zero guard-warnings (Fix #1 removed the NaN at source, so Fix #2 never had to fire — as intended).

Closes #508, closes #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)