### PR TITLE
🎛️ fix(fx): control on a top-level with_fx node ref now reaches scsynth (closes #511)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -217,6 +217,23 @@ export class SonicPiEngine {
   private loopFxScope = new Map<string, string>()
   /** Maps FX scope ID → FX chain definition. */
   private fxScopeChains = new Map<string, Array<{ name: string; opts: Record<string, number> }>>()
+  /**
+   * Maps FX scope ID → the build-time node refs of each FX in the chain (#511).
+   * Parallel to `fxScopeChains` (same index = same FX). When the persistent FX
+   * nodes are created, these refs are written into `nodeRefMap` so that
+   * `control c, …` inside the loop — where `c` is the `with_fx` block param —
+   * resolves to the real scsynth node and is actually sent. Refs are NEGATIVE
+   * (see `nextTopFxRef`) so they can never collide with the positive lockstep
+   * refs that synth `control` relies on.
+   */
+  private fxScopeRefs = new Map<string, number[]>()
+  /**
+   * Monotonic NEGATIVE counter for top-level `with_fx` node refs (#511). The
+   * synth-`control` path aligns ProgramBuilder's positive `nextRef` with the
+   * interpreter's positive `nextNodeRef` by lockstep; a top-level FX ref must
+   * live in a disjoint space, so we count down from -1.
+   */
+  private nextTopFxRef = -1
   /** Compile-once cache: source code → transpiled JS. Reused on hot-swap with unchanged code (#8). */
   private transpileCache = new Map<string, string>()
   /**
@@ -871,6 +888,7 @@ export class SonicPiEngine {
               }
 
               this.persistentFx.set(scopeId, { buses, groups, nodeIds, outBus: currentOutBus })
+              this.bindFxScopeRefs(scopeId, nodeIds) // #511: make `control c` resolvable
             }
           }
 
@@ -1103,6 +1121,9 @@ export class SonicPiEngine {
       // Stack of top-level FX — nested with_fx accumulates, innermost is last.
       // When a live_loop is registered, ALL stacked FX wrap its builder.
       const topFxStack: Array<{ name: string; opts: Record<string, number> }> = []
+      // #511: build-time node refs parallel to topFxStack — handed to the
+      // `with_fx` block param (`|c|`) so `control c` can target the FX node.
+      const topFxRefStack: number[] = []
       /** Current FX scope ID — set when entering a with_fx block, used by live_loops inside. */
       let currentFxScopeId: string | null = null
       let fxScopeCounter = 0
@@ -1122,15 +1143,22 @@ export class SonicPiEngine {
           fn = maybeFn!
         }
         topFxStack.push({ name: fxName, opts })
+        // #511: mint a negative node ref for THIS with_fx and hand it to the
+        // block as `|c|`. The real scsynth node id is bound to this ref in
+        // nodeRefMap when the persistent FX is created (see the two creation
+        // sites below), so `control c, …` inside the loop resolves and fires.
+        const fxRef = this.nextTopFxRef--
+        topFxRefStack.push(fxRef)
         // Generate scope ID for the outermost with_fx (nested ones reuse it)
         const isOutermost = currentFxScopeId === null
         if (isOutermost) {
           currentFxScopeId = `__fxscope_${fxScopeCounter++}`
         }
         try {
-          fn(null) // execute callback to register live_loops
+          fn(fxRef) // execute callback to register live_loops; `|c|` = fxRef
         } finally {
           topFxStack.pop()
+          topFxRefStack.pop()
           if (isOutermost) {
             currentFxScopeId = null
           }
@@ -1162,6 +1190,10 @@ export class SonicPiEngine {
           this.loopFxScope.set(name, scopeId)
           if (!this.fxScopeChains.has(scopeId)) {
             this.fxScopeChains.set(scopeId, [...topFxStack])
+            // #511: snapshot the block-param refs for this chain alongside it,
+            // so the persistent-FX creation sites can bind each FX node id to
+            // the ref `control c` was given.
+            this.fxScopeRefs.set(scopeId, [...topFxRefStack])
           }
           // Register with ORIGINAL builder (no FX wrapping)
           if (opts) {
@@ -1788,6 +1820,7 @@ export class SonicPiEngine {
         if (isReEvaluate) {
           this.loopFxScope.clear()
           this.fxScopeChains.clear()
+          this.fxScopeRefs.clear() // #511: rebuilt by the new program's with_fx blocks
         }
         await sandbox.execute(...dslValues)
       } finally {
@@ -1971,11 +2004,33 @@ export class SonicPiEngine {
    *
    * Idempotent: scopes already in `persistentFx` are skipped.
    */
+  /**
+   * #511: bind each persistent FX node id to the build-time ref that the
+   * `with_fx` block param (`|c|`) carries, so `control c, …` resolves to the
+   * real scsynth node via `nodeRefMap`. `fxScopeRefs[i]` is parallel to the
+   * `fxScopeChains[i]` / `nodeIds[i]` ordering (all outermost-first). Idempotent
+   * and cheap — called from both persistent-FX creation sites.
+   */
+  private bindFxScopeRefs(scopeId: string, nodeIds: number[]): void {
+    const refs = this.fxScopeRefs.get(scopeId)
+    if (!refs) return
+    for (let i = 0; i < nodeIds.length && i < refs.length; i++) {
+      if (refs[i] !== undefined) this.nodeRefMap.set(refs[i], nodeIds[i])
+    }
+  }
+
   private async preCreatePersistentFx(bpm: number): Promise<void> {
     if (!this.bridge) return
     for (const [scopeId, fxChain] of this.fxScopeChains) {
       if (!fxChain || fxChain.length === 0) continue
-      if (this.persistentFx.has(scopeId)) continue
+      if (this.persistentFx.has(scopeId)) {
+        // #511: scope survived a hot-swap (node reused, not re-created) but
+        // nodeRefMap was cleared in the reconcile step. Re-bind THIS program's
+        // freshly-minted refs to the existing node ids so `control c` still
+        // resolves — otherwise modulation silently dies after an Update.
+        this.bindFxScopeRefs(scopeId, this.persistentFx.get(scopeId)!.nodeIds)
+        continue
+      }
       let currentOutBus = 0  // FX-wrapped loops route to master through chain
       const buses: number[] = []
       const groups: number[] = []
@@ -2001,6 +2056,7 @@ export class SonicPiEngine {
         currentOutBus = bus
       }
       this.persistentFx.set(scopeId, { buses, groups, nodeIds, outBus: currentOutBus })
+      this.bindFxScopeRefs(scopeId, nodeIds) // #511: make `control c` resolvable
     }
   }
 
@@ -2096,6 +2152,7 @@ export class SonicPiEngine {
     this.reusableFx.clear()
     this.loopFxScope.clear()
     this.fxScopeChains.clear()
+    this.fxScopeRefs.clear() // #511
     // Nested live_loop bookkeeping (issue #198). Defensive reset of depth
     // counter — should be 0 already, but stop() may be called mid-build
     // on error paths.

--- a/src/engine/__tests__/ControlPersistentFx.test.ts
+++ b/src/engine/__tests__/ControlPersistentFx.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #511 — `control c` inside a TOP-LEVEL `with_fx` block must reach scsynth and
+ * target the persistent FX node.
+ *
+ * Bug (found via illusionist/filtered_dnb, which rendered near-silent on web —
+ * RMS 0.003 vs desktop 0.17): the top-level `with_fx` handler
+ * (`SonicPiEngine.topLevelWithFx`) executed the block as `fn(null)`, so the
+ * block param `|c|` bound to `null`. `control c, …` became `control(null, …)`,
+ * and at runtime `nodeRefMap.get(null)` is `undefined` → the control step was
+ * silently skipped (guard at `AudioInterpreter` `case 'control'`). The rlpf
+ * opened `cutoff: 10` (~13 Hz) and the `control` meant to sweep it open never
+ * fired → the filter stayed shut → near-silence.
+ *
+ *   with_fx :rlpf, cutoff: 10 do |c|
+ *     live_loop :dnb do
+ *       play 60
+ *       sleep 1
+ *       control c, cutoff: 100   # opens the filter — was DROPPED on web
+ *     end
+ *   end
+ *
+ * The inner `ProgramBuilder.with_fx` path passes `fn(inner, fxRef)` correctly,
+ * but loop-wrapping (top-level) `with_fx` uses a separate lazy-`persistentFx`
+ * path that dropped the ref and never populated `nodeRefMap` for the FX node.
+ *
+ * Fix: `topLevelWithFx` mints a negative `fxRef` per `with_fx` and hands it to
+ * the block; the persistent-FX creation sites bind `nodeRefMap[fxRef] = nodeId`.
+ *
+ * Observation: a spy bridge records every `sendTimedControl(time, nodeId, …)`
+ * and the node id returned by `applyFx` for the rlpf. The fix is proven when a
+ * control fires AND its target nodeId is exactly the rlpf's node — no audio
+ * hardware needed; the divergence is pure routing/ref resolution.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+type SchedulerLike = { tick: (t: number) => void }
+
+async function drive(engine: SonicPiEngine, targetVt = 4, steps = 8) {
+  const scheduler = (engine as unknown as { scheduler: SchedulerLike | null }).scheduler
+  if (!scheduler) return
+  for (let i = 1; i <= steps; i++) {
+    scheduler.tick((targetVt * i) / steps)
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+/**
+ * Spy bridge — records the rlpf node id (from applyFx/applyFxOrdered) and every
+ * sendTimedControl. A Proxy supplies no-op defaults for the rest of the
+ * SuperSonicBridge surface so the engine's create/tick/teardown paths run.
+ */
+function createSpyBridge() {
+  const fxNodes: Array<{ name: string; id: number }> = []
+  const controls: Array<{ nodeId: number; params: (string | number)[] }> = []
+  let nextNode = 9000
+  let nextBus = 16
+  const impl: Record<string, unknown> = {
+    allocateBus: () => nextBus++,
+    createFxGroup: () => nextNode++,
+    async applyFx(name: string, _t: number, _p: Record<string, number>, _in: number, _out: number) {
+      const id = nextNode++; fxNodes.push({ name, id }); return id
+    },
+    async applyFxOrdered(name: string, _p: Record<string, number>, _in: number, _out: number) {
+      const id = nextNode++; fxNodes.push({ name, id }); return id
+    },
+    async triggerSynth() { return nextNode++ },
+    async playSample() { return nextNode++ },
+    async ensureSamplePlaybackDuration() { return 1 },
+    sendTimedControl(_time: number, nodeId: number, params: (string | number)[]) {
+      controls.push({ nodeId, params })
+    },
+    get audioContext() { return null },
+  }
+  const proxy = new Proxy(impl, {
+    get(target, prop: string) {
+      if (prop in target) return (target as Record<string, unknown>)[prop]
+      return () => undefined // permissive no-op for the rest of the surface
+    },
+  })
+  return { bridge: proxy, fxNodes, controls }
+}
+
+/** Read `params` array [k, v, k, v, …] as a record. */
+function paramsToObj(params: (string | number)[]): Record<string, number> {
+  const o: Record<string, number> = {}
+  for (let i = 0; i + 1 < params.length; i += 2) o[String(params[i])] = Number(params[i + 1])
+  return o
+}
+
+describe('control inside a top-level with_fx targets the persistent FX node (#511)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('sends /n_set to the rlpf node when the loop calls control c', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+
+    // JS DSL form = exactly what the transpiler emits for the Ruby:
+    //   with_fx :rlpf, cutoff: 10 do |c|
+    //     live_loop :dnb do; play 60; sleep 1; control c, cutoff: 100; end
+    //   end
+    const r = await engine.evaluate(`
+      with_fx("rlpf", { cutoff: 10 }, (c) => {
+        live_loop("dnb", (b) => {
+          b.play(60)
+          b.sleep(1)
+          b.control(c, { cutoff: 100 })
+        })
+      })
+    `)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 4, 8)
+
+    // The rlpf FX node was created.
+    const rlpf = spy.fxNodes.find((f) => f.name === 'rlpf')
+    expect(rlpf).toBeDefined()
+
+    // At least one control fired (pre-fix: ZERO — control(null) was skipped).
+    expect(spy.controls.length).toBeGreaterThan(0)
+
+    // Every control targets the rlpf node, and carries the opened cutoff.
+    for (const c of spy.controls) {
+      expect(c.nodeId).toBe(rlpf!.id)
+      expect(paramsToObj(c.params).cutoff).toBe(100)
+    }
+    engine.dispose()
+  })
+})


### PR DESCRIPTION
## Problem
`illusionist/filtered_dnb` (Sam Aaron) rendered **near-silent** on web — RMS `0.0027` / peak `0.0099` vs desktop `0.1742` / `1.0` (~65× quieter). The sweep flagged it as a Tier‑1 pitch divergence, but that was a *downstream symptom of silence* (the pitch‑tracker latched the noise floor at a constant 41).

```ruby
use_sample_bpm :loop_amen
with_fx :rlpf, cutoff: 10, cutoff_slide: 4 do |c|
  live_loop :dnb do
    sample :bass_dnb_f, amp: 5
    sample :loop_amen, amp: 5
    sleep 1
    control c, cutoff: rrand(40, 120), cutoff_slide: rrand(1, 4)
  end
end
```

The piece opens `rlpf cutoff: 10` (≈13 Hz — filters out almost everything) and relies on `control c, cutoff: rrand(40,120)` each beat to sweep the filter open. The web event log showed the rlpf created **once** at cutoff 10, samples routed correctly to `out_bus: 18`, and **zero `/n_set` (control) messages** — the filter stayed at ~13 Hz forever → near‑silence.

## Root cause
The **top‑level** `with_fx` handler (`SonicPiEngine.topLevelWithFx`) executed the block as `fn(null)` — it never passed a node reference. So the block param `|c|` bound to `null`, `control c, …` became `control(null, …)`, and at runtime `nodeRefMap.get(null)` was `undefined` → the control step was silently skipped (guard in `AudioInterpreter` `case 'control'`).

The **inner** `ProgramBuilder.with_fx` path passes `fn(inner, fxRef)` correctly (and `case 'fx'` binds `nodeRefMap`), but loop‑wrapping (top‑level) `with_fx` uses a separate lazy‑`persistentFx` path that dropped the ref and never bound the FX node. The FX *persisted* fine (SV13) — it just couldn't be *targeted*.

## Fix (engine‑only, follows the SP72/SV28 parallel‑map pattern)
- `topLevelWithFx` mints a **negative** `fxRef` per `with_fx` (`nextTopFxRef--`, disjoint from the positive `nextRef`/`nextNodeRef` synth‑control lockstep, so no collision) and hands it to the block as `|c|`.
- A parallel `fxScopeRefs: Map<scopeId, number[]>` carries the chain's refs alongside `fxScopeChains` (same outermost‑first index).
- New `bindFxScopeRefs(scopeId, nodeIds)` writes `nodeRefMap[fxRef] = nodeId` at **both** persistent‑FX creation sites.
- The hot‑swap node‑reuse path (`preCreatePersistentFx`'s `persistentFx.has` skip) **re‑binds** the new program's refs to the surviving node — otherwise modulation would silently die after an Update (nodeRefMap is cleared in the reconcile step).
- `fxScopeRefs` cleared wherever `fxScopeChains` is.

## Test plan
- **L1:** full suite **1307/1307**, `tsc --noEmit` clean. New differential test `ControlPersistentFx.test.ts` — **red pre‑fix** (0 control calls), **green post‑fix** (`/n_set` targets the rlpf node with the opened cutoff).
- **L3** (`tools/capture.ts`): **0 → 17 `/n_set`** control messages, cutoff opening **54–96** (MIDI → ~5–12 kHz); web **RMS 0.0027 → 0.15** (vs desktop 0.17), **MFCC dist 534 → 99**, **mel‑L2 15.7 → 10.6 dB**.
- Residual Tier‑1 "divergence" is **PRNG‑variant** (`rrand` cutoff differs per engine, SV49) over a non‑melodic amen drum loop — not a defect.

## Self-review notes
- Nested `with_fx` (`|x|`/`|y|`): parallel `topFxRefStack` ↔ `fxChain` ↔ `nodeIds` all outermost‑first → index‑aligned.
- One `with_fx` wrapping multiple loops: shared `scopeId`, one ref → one shared node (matches desktop).
- Bare top‑level `with_fx` *without* a live_loop uses the inner `ProgramBuilder.with_fx` path (already worked) — not regressed.

Catalogues: hetvabhāsa **SP137**, vyāpti **SV13 corollary** (persistence ≠ targetability).

closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)