### PR TITLE
🎛️ fix(tempo): use_sample_bpm survives __run_once deferral + #513/#515 experiments page (closes #515)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1058,7 +1058,15 @@ function subtreeHasBareDslCall(node: any): boolean {
 // set once and not interleaved with plays. `use_synth` is deliberately NOT here:
 // it is flow-sensitive (users change it between plays), so hoisting it would
 // collapse all plays to the last use_synth value (#164).
-const TOP_LEVEL_SETTINGS = new Set(['use_bpm', 'use_random_seed', 'use_debug', 'use_arg_bpm_scaling'])
+// use_sample_bpm is a bpm setting (use_bpm derived from a sample's length) — it
+// must be emitted eagerly at top level so it sets the engine defaultBpm BEFORE
+// any loop-registering block reads it. Without this it falls into bareCode and,
+// when trailing bare top-level code defers that into `__run_once`, runs as
+// `__b.use_sample_bpm` (builder-local bpm only) → the separately-registered
+// live_loop reads the unchanged defaultBpm and the tempo is a no-op. Same
+// flow-sensitive class as use_bpm (SV55/#420; surfaced by the --wrap-recording
+// capture path reintroducing the #513 no-op).
+const TOP_LEVEL_SETTINGS = new Set(['use_bpm', 'use_sample_bpm', 'use_random_seed', 'use_debug', 'use_arg_bpm_scaling'])
 
 // #419/SV55: extract a literal synth name from a `use_synth :X` / `use_synth "X"`
 // call. Returns the bare name for a literal symbol/string arg, or null for a

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -150,6 +150,61 @@ end`)
     // source position in sequential order (runtime.rb:1067). The transpiler
     // restores this by emitting an EAGER top-level use_synth("X") (routes to
     // topLevelUseSynth → defaultSynth) immediately before the loop registers.
+    describe('#513: top-level use_sample_bpm survives trailing bare code (must NOT defer into __run_once)', () => {
+      // use_sample_bpm sets the engine defaultBpm from a sample's length. Like
+      // use_bpm it MUST be emitted as an eager top-level call so a following
+      // live_loop registers at the derived tempo. When it falls into bareCode
+      // and trailing bare top-level code defers that into `__run_once`, it runs
+      // as `__b.use_sample_bpm` (builder-local bpm only) and the separately-
+      // registered live_loop reads the unchanged defaultBpm — the #513 no-op.
+      // Surfaced by the --wrap-recording capture path (recording_start +
+      // trailing `with_bpm 60 { sleep N }`) reintroducing the no-op.
+      it('emits a TOP-LEVEL use_sample_bpm (not __b.) when bare code trails the loop', () => {
+        const result = treeSitterTranspile(`use_sample_bpm :loop_amen
+live_loop :dnb do
+  sample :loop_amen
+  sleep 1
+end
+with_bpm 60 do
+  sleep 5
+end`)
+        expect(result.ok).toBe(true)
+        // Top-level call (no `__b.`/`b.` prefix) must be present...
+        expect(result.code).toMatch(/(^|[^.\w])use_sample_bpm\("loop_amen"\)/m)
+        // ...and the builder-deferred form must NOT be how the top-level call is emitted.
+        expect(result.code).not.toContain('__b.use_sample_bpm("loop_amen")')
+        // The eager top-level use_sample_bpm must precede the loop registration.
+        const topIdx = result.code.search(/(^|[^.\w])use_sample_bpm\("loop_amen"\)/m)
+        const loopIdx = result.code.indexOf('live_loop("dnb"')
+        expect(topIdx).toBeGreaterThanOrEqual(0)
+        expect(loopIdx).toBeGreaterThanOrEqual(0)
+        expect(topIdx).toBeLessThan(loopIdx)
+      })
+
+      it('honors num_beats in the eager top-level emission', () => {
+        const result = treeSitterTranspile(`use_sample_bpm :loop_amen, num_beats: 4
+live_loop :x do
+  sample :loop_amen
+  sleep 4
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        expect(result.code).toContain('num_beats')
+        expect(result.code).not.toContain('__b.use_sample_bpm')
+      })
+
+      it('use_sample_bpm INSIDE a live_loop body stays on the builder path', () => {
+        const result = treeSitterTranspile(`live_loop :x do
+  use_sample_bpm :loop_amen
+  sample :loop_amen
+  sleep 1
+end`)
+        expect(result.ok).toBe(true)
+        // Inside a loop body it must remain builder-scoped, not hoisted to top level.
+        expect(result.code).toContain('__b.use_sample_bpm("loop_amen")')
+      })
+    })
+
     describe('#419 / SV55: top-level use_synth honored by live_loop with trailing bare code', () => {
       // Helper: index of an eager (no `__b.`/`b.` prefix) top-level call.
       const eagerIdx = (code: string, call: string) => {

--- a/test_results/experiments.html
+++ b/test_results/experiments.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>SonicPi.js — Experiments</title>
+<style>
+  :root {
+    --bg:#1a1b26; --bg-elev:#1f2335; --bg-card:#16161e; --border:#2a2e46;
+    --text:#c0caf5; --text-dim:#7a85b3; --text-mute:#565f89;
+    --accent:#7aa2f7; --accent2:#ff1493;
+    --pass:#9ece6a; --flag:#e0af68; --fail:#f7768e; --incon:#565f89;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);font-size:13px;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+  a{color:var(--accent);text-decoration:none}
+  a:hover{text-decoration:underline}
+  .wrap{max-width:1100px;margin:0 auto;padding:28px 24px 60px}
+  h1{font-size:22px;margin:0 0 4px;letter-spacing:-.01em}
+  h2{font-size:17px;margin:34px 0 4px}
+  .sub{color:var(--text-dim);font-size:12.5px;margin:0 0 22px;font-family:var(--mono)}
+  .sub b{color:var(--text)}
+  .card{background:var(--bg-card);border:1px solid var(--border);border-radius:12px;
+    padding:18px 20px;margin:14px 0 26px}
+  .verdict{display:inline-block;padding:3px 12px;border-radius:7px;font-family:var(--mono);
+    font-weight:700;font-size:13px;margin-bottom:10px}
+  .verdict.pass{background:#243218;color:var(--pass)}
+  .verdict.fail{background:#321820;color:var(--fail)}
+  .verdict.warn{background:#322a18;color:var(--flag)}
+  .verdict.accent{background:#16213a;color:var(--accent)}
+  pre{background:var(--bg-elev);border:1px solid var(--border);border-radius:8px;
+    padding:12px 14px;overflow-x:auto;font-family:var(--mono);font-size:12px;color:var(--text);line-height:1.5}
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:760px){.grid2{grid-template-columns:1fr}}
+  .ab{background:var(--bg-elev);border:1px solid var(--border);border-radius:8px;padding:12px 14px}
+  .ab h4{margin:0 0 8px;font-family:var(--mono);font-size:12px;color:var(--text-dim);
+    text-transform:uppercase;letter-spacing:.06em}
+  .ab h4.d{color:var(--accent)} .ab h4.w{color:var(--accent2)}
+  audio{width:100%;height:34px;margin-top:4px;filter:invert(.9) hue-rotate(180deg)}
+  table{border-collapse:collapse;width:100%;font-family:var(--mono);font-size:12px;margin:6px 0}
+  th,td{text-align:left;padding:5px 10px;border-bottom:1px solid var(--border)}
+  th{color:var(--text-dim);font-weight:600;text-transform:uppercase;font-size:10.5px;letter-spacing:.05em}
+  td code{color:var(--text)}
+  .ok{color:var(--pass)} .bad{color:var(--fail)} .warnc{color:var(--flag)} .dim{color:var(--text-mute)}
+  img.spec{width:100%;border:1px solid var(--border);border-radius:8px;margin-top:8px;background:#000}
+  .files{font-family:var(--mono);font-size:11.5px;color:var(--text-dim);margin-top:10px;
+    display:flex;flex-wrap:wrap;gap:14px}
+  .metricrow{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0}
+  .metric{font-family:var(--mono);font-size:11px;padding:2px 9px;border-radius:20px;
+    background:var(--bg-elev);color:var(--text-dim)}
+  .metric b{color:var(--text)}
+  .caveat{background:#1d1a13;border:1px solid #3a3017;border-radius:10px;padding:14px 16px;
+    margin:18px 0 0;font-size:12px;color:var(--text-dim);line-height:1.55}
+  .caveat b{color:var(--flag)}
+  .note{font-size:12px;color:var(--text-dim);line-height:1.6}
+  .note code{color:var(--text);font-family:var(--mono)}
+  footer{margin-top:40px;color:var(--text-mute);font-family:var(--mono);font-size:11px;
+    border-top:1px solid var(--border);padding-top:14px}
+</style>
+</head>
+<body>
+<nav class="tab-bar" id="topnav" data-meta="experiments · ad-hoc investigations"></nav>
+<script src="nav.js"></script>
+<div class="wrap">
+  <h1>Experiments</h1>
+  <p class="sub">Ad-hoc desktop ↔ web investigations with full evidence — code, event diffs, A/B audio, spectrogram diffs. Captured against running desktop Sonic Pi. Latest: <b>#513 — use_sample_bpm tempo</b> (2026-06-09).</p>
+
+  <!-- ===================================================================== -->
+  <h2>#513 — <code style="font-family:var(--mono)">use_sample_bpm</code> derives tempo from the real sample buffer</h2>
+  <p class="note">
+    <b>Bug:</b> <code>ProgramBuilder.sample_duration()</code> was a stub <code>return 1</code>, so
+    <code>use_sample_bpm :loop_amen</code> = <code>use_bpm(60/1)</code> = the default 60 — a no-op. Every
+    sample-tempo piece played too fast. <b>Fix (PR #514):</b> pre-decode the referenced sample in
+    <code>evaluate()</code>, derive BPM from the real buffer length (<code>num_beats·60/raw_seconds</code>,
+    mirroring desktop <code>sound.rb:542/2236</code>). The bug hid behind the piece's <code>rrand</code>
+    (SV49 PRNG masked it in audio/MFCC) — only the <b>event-onset layer</b> exposed it, so these
+    experiments lead with the <code>/s_new</code> event diff.
+  </p>
+
+  <!-- Experiment 1 — tempo isolation -->
+  <div class="card">
+    <div class="verdict pass">EVENT-MATCH ✓ — tempo fixed</div>
+    <h3 style="margin:2px 0 2px">Experiment 1 — tempo isolation (constant <code>cutoff: 80</code>)</h3>
+    <p class="note" style="margin:0 0 10px">
+      <code>rrand</code> removed and the filter pinned to a constant so the only variable is tempo.
+      This was run on the fix branch (before #512 control fix merged), so a constant cutoff sidesteps the
+      filter-sweep path entirely.
+    </p>
+<pre># deterministic filtered_dnb (rrand removed) — tempo isolation
+use_sample_bpm :loop_amen
+
+with_fx :rlpf, cutoff: 80 do |c|
+  live_loop :dnb do
+    sample :bass_dnb_f, amp: 5
+    sample :loop_amen, amp: 5
+    sleep 1
+    control c, cutoff: 80
+  end
+end</pre>
+
+    <h4 style="font-family:var(--mono);font-size:11px;color:var(--text-dim);margin:16px 0 4px;text-transform:uppercase;letter-spacing:.06em">Event diff — sample <code>/s_new</code> onset times (desktop ↔ web)</h4>
+    <table>
+      <tr><th></th><th>player /s_new</th><th>per-beat step</th><th>onset seq</th></tr>
+      <tr><td class="dim">desktop SP</td><td><code>16</code></td><td><code class="ok">1.753 s</code> (BPM 34.2)</td><td><code>0, 0, 1.753, 1.753, 3.507, …</code></td></tr>
+      <tr><td class="dim">web — <b style="color:var(--fail)">before</b></td><td><code class="bad">26</code> (1.63×)</td><td><code class="bad">1.000 s</code> (BPM 60, no-op)</td><td><code class="bad">DIVERGE @#2, max Δ 5273 ms</code></td></tr>
+      <tr><td class="dim">web — <b style="color:var(--pass)">after</b></td><td><code class="ok">16</code> (1.00×)</td><td><code class="ok">1.753 s</code> (BPM 34.2)</td><td><code class="ok">MATCH, max Δ 1 ms</code></td></tr>
+    </table>
+
+    <div class="metricrow">
+      <span class="metric">Tier-1 tempo <b class="ok" style="color:var(--pass)">✓ MATCH</b> 0.98 vs 1.00 s/note</span>
+      <span class="metric">peak freq <b>87.3 / 87.0 Hz</b> (same rate)</span>
+      <span class="metric">RMS ratio <b>0.63×</b></span>
+      <span class="metric">peak ratio <b>0.55×</b></span>
+      <span class="metric">MFCC <b>110.6</b> <span class="dim">(gain/reverb confound)</span></span>
+    </div>
+
+    <div class="grid2" style="margin-top:10px">
+      <div class="ab"><h4 class="d">desktop SP</h4><audio controls preload="none" src="experiments/det_desktop.wav"></audio></div>
+      <div class="ab"><h4 class="w">web (SonicPi.js)</h4><audio controls preload="none" src="experiments/det_web.wav"></audio></div>
+    </div>
+    <img class="spec" src="experiments/det_spectrogram.png" alt="spectrogram diff — tempo isolation" loading="lazy" />
+    <div class="files">
+      <a href="experiments/det_compare.md">6-tier compare report →</a>
+      <a href="experiments/det_eventparity_before.json">event-parity (before) →</a>
+      <a href="experiments/det_eventparity_after.json">event-parity (after) →</a>
+      <a href="experiments/det_desktop.wav">desktop.wav →</a>
+      <a href="experiments/det_web.wav">web.wav →</a>
+      <a href="experiments/det_spectrogram.png">spectrogram.png →</a>
+    </div>
+  </div>
+
+  <!-- Experiment 2 — num_beats -->
+  <div class="card">
+    <div class="verdict pass">EVENT-MATCH ✓ — num_beats path</div>
+    <h3 style="margin:2px 0 6px">Experiment 2 — <code>num_beats: 4</code> (distinct code path)</h3>
+<pre>use_sample_bpm :loop_amen, num_beats: 4
+live_loop :x do
+  sample :loop_amen, amp: 3
+  sleep 4
+end</pre>
+    <table>
+      <tr><th></th><th>player /s_new</th><th>per-beat step</th><th>onset seq</th></tr>
+      <tr><td class="dim">desktop SP</td><td><code>8</code></td><td><code class="ok">1.753 s</code></td><td><code class="ok">match</code></td></tr>
+      <tr><td class="dim">web</td><td><code>8</code></td><td><code class="ok">1.753 s</code></td><td><code class="ok">MATCH, max Δ 0 ms, notes ✓</code></td></tr>
+    </table>
+    <p class="note" style="margin:6px 0 0">At <code>num_beats: 4</code>, BPM = <code>4·60/1.753 = 136.9</code> → <code>sleep 4</code> = 1.753 s = one full loop. Matches desktop exactly.</p>
+    <div class="files"><a href="experiments/numbeats_eventparity.json">event-parity →</a></div>
+  </div>
+
+  <!-- Experiment 3 — faithful -->
+  <div class="card">
+    <div class="verdict pass" style="margin-right:6px">EVENT-MATCH ✓ dispatch</div>
+    <div class="verdict pass">Tier-1 ≈ MATCH ✓ (after #515)</div>
+    <h3 style="margin:2px 0 2px">Experiment 3 — faithful piece (rlpf sweep kept, only <code>rrand</code> removed)</h3>
+    <p class="note" style="margin:0 0 10px">
+      Run on merged <code>main</code> (with #512 control fix). The real <code>rlpf cutoff: 10, cutoff_slide: 4</code>
+      sweep driven by <code>control</code> is kept; only <code>rrand</code> → fixed values.
+    </p>
+    <div class="caveat" style="margin:0 0 12px;background:#13201d;border-color:#1f4a3a">
+      <b style="color:var(--pass)">Capture-pipeline bug found &amp; fixed (#515).</b> The <i>first</i> capture of this
+      fixture showed web flat/darker (filter opening ~3 s, pitch flat <code>41</code>) — but the <b>live engine
+      sounded correct</b>. Root cause: <code>tools/capture.ts --wrap-recording</code> wraps the code with trailing
+      <code>with_bpm 60 do sleep N end</code>, which deferred <code>use_sample_bpm</code> into the synthetic
+      <code>__run_once</code> wrapper → it emitted as <code>__b.use_sample_bpm</code> (builder-local bpm) → the
+      <code>:dnb</code> loop read the unchanged <code>defaultBpm 60</code> → the #513 no-op <b>reappeared in the
+      recording only</b>. Fix: add <code>use_sample_bpm</code> to <code>TOP_LEVEL_SETTINGS</code> (emitted eagerly
+      at top level, like <code>use_bpm</code>; SV55/#420 class). The numbers below are the <b>post-fix</b> capture —
+      filter now opens ~5 s (BPM 34.2), matching desktop and the live engine.
+    </div>
+<pre># faithful filtered_dnb, rrand removed (deterministic) — control sweep kept
+use_sample_bpm :loop_amen
+
+with_fx :rlpf, cutoff: 10, cutoff_slide: 4 do |c|
+  live_loop :dnb do
+    sample :bass_dnb_f, amp: 5
+    sample :loop_amen, amp: 5
+    sleep 1
+    control c, cutoff: 80, cutoff_slide: 2
+  end
+end</pre>
+
+    <h4 style="font-family:var(--mono);font-size:11px;color:var(--text-dim);margin:16px 0 4px;text-transform:uppercase;letter-spacing:.06em">Event diff — dispatch is identical</h4>
+    <table>
+      <tr><th></th><th>player /s_new</th><th>per-beat step</th><th>onset seq</th></tr>
+      <tr><td class="dim">desktop SP</td><td><code>16</code></td><td><code class="ok">1.753 s</code></td><td><code>0, 0, 1.753, 1.753, 3.507, …</code></td></tr>
+      <tr><td class="dim">web</td><td><code>14</code><span class="dim"> (window edge)</span></td><td><code class="ok">1.753 s</code></td><td><code class="ok">MATCH, max Δ 0 ms</code></td></tr>
+    </table>
+
+    <h4 style="font-family:var(--mono);font-size:11px;color:var(--text-dim);margin:16px 0 4px;text-transform:uppercase;letter-spacing:.06em">Audio (Tier-1) — post-fix: pitch + tempo now match</h4>
+    <table>
+      <tr><th></th><th>audible onsets</th><th>onset pitch track</th><th>inter-onset</th><th>peak / RMS</th></tr>
+      <tr><td class="dim">desktop SP</td><td><code>23</code></td><td><code>47,44,60,46,44,60,48,74…</code></td><td><code>0.130 s</code></td><td><code>1.00 / 0.156</code></td></tr>
+      <tr><td class="dim">web (post-fix)</td><td><code class="ok">22</code></td><td><code class="ok">47,41,44,60,46,60,48,74…</code></td><td><code class="ok">0.130 s</code></td><td><code>0.56 / 0.080</code></td></tr>
+      <tr><td class="dim">web (before #515)</td><td><code class="bad">10</code></td><td><code class="bad">41,41,41,41…</code> (BPM-60 no-op)</td><td><code class="bad">1.000 s</code></td><td><code>0.60 / 0.107</code></td></tr>
+    </table>
+    <div class="metricrow">
+      <span class="metric">Tier-1 1.1 pitch-class cos <b class="ok" style="color:var(--pass)">0.992</b></span>
+      <span class="metric">tempo <b class="ok" style="color:var(--pass)">✓ MATCH</b></span>
+      <span class="metric">density ratio <b>0.96</b></span>
+      <span class="metric">mel-L2 <b>10.14</b> <span class="dim">(was 14.66)</span></span>
+      <span class="metric">RMS ratio <b>0.51×</b> <span class="dim">(#504 gain)</span></span>
+      <span class="metric">MFCC <b>107</b> <span class="dim">(gain/PRNG confound)</span></span>
+    </div>
+
+    <div class="grid2" style="margin-top:10px">
+      <div class="ab"><h4 class="d">desktop SP</h4><audio controls preload="none" src="experiments/norand_desktop.wav"></audio></div>
+      <div class="ab"><h4 class="w">web (SonicPi.js)</h4><audio controls preload="none" src="experiments/norand_web.wav"></audio></div>
+    </div>
+    <img class="spec" src="experiments/norand_spectrogram.png" alt="spectrogram diff — faithful piece" loading="lazy" />
+    <div class="files">
+      <a href="experiments/norand_compare.md">6-tier compare report →</a>
+      <a href="experiments/norand_eventparity.json">event-parity →</a>
+      <a href="experiments/norand_desktop.wav">desktop.wav →</a>
+      <a href="experiments/norand_web.wav">web.wav →</a>
+      <a href="experiments/norand_spectrogram.png">spectrogram.png →</a>
+    </div>
+  </div>
+
+  <div class="caveat" style="background:#13201d;border-color:#1f4a3a">
+    <b style="color:var(--pass)">Conclusion.</b> The <b>tempo bug (#513) is fixed</b> — sample <code>/s_new</code>
+    dispatch is bit-identical to desktop (1.753 s/beat, EVENT-MATCH) on all fixtures. The faithful piece's
+    <b>audio now also matches</b> desktop: Tier-1 pitch-class cos <b>0.992</b>, tempo ✓, density 0.96 — the
+    remaining difference is the known <b>~0.5× web gain (#504/#268)</b> and the <b>SV49 PRNG random-walk</b>
+    (both declared v1 non-goals). <b>The apparent "audio divergence" was NOT an engine gap</b> — it was a
+    capture-pipeline bug (<b>#515</b>): <code>--wrap-recording</code>'s trailing bare code deferred
+    <code>use_sample_bpm</code> into <code>__run_once</code>, re-introducing the #513 no-op <i>in the recording only</i>.
+    The live engine was correct all along (confirmed by the unwrapped Rec-button capture + the user's live A/B).
+    <b>Lesson:</b> the capture wrap is part of the measurement apparatus — when a recording disagrees with the
+    live engine, suspect the apparatus, not just the engine (the <code>--wrap-recording</code> transform must
+    preserve top-level execution semantics; SV30 corollary).
+  </div>
+
+  <footer>
+    Hand-built investigation page (#513 + #515). Artifacts in <code>test_results/experiments/</code>, captured via
+    <code>tools/event-parity.ts</code> + <code>tools/compare-desktop-vs-web.ts</code> against running desktop Sonic Pi.
+    Catalogue: SP138 (FIXED), SV66 (IMPLEMENTED), #515 wrap-deferral corollary.
+  </footer>
+</div>
+</body>
+</html>

--- a/test_results/index.html
+++ b/test_results/index.html
@@ -182,6 +182,7 @@
     <a href="launch-gate.html">🚦 launch gate →</a>
     <a href="fx-inspector.html">fx a/b inspector →</a>
     <a href="event-diff.html">event diff (/s_new) →</a>
+    <a href="experiments.html">🧪 experiments (#513 use_sample_bpm tempo) →</a>
     <a href="mono-sample-sp107.html">SP107 mono-sample investigation →</a>
     <a href="raw-lpf.html">raw-lpf investigation →</a>
   </div>

--- a/tools/build-aggregate-index.ts
+++ b/tools/build-aggregate-index.ts
@@ -343,6 +343,7 @@ ${navBlock('desktop ↔ web parity · #446 event diff')}
     <a href="launch-gate.html">🚦 launch gate →</a>
     <a href="fx-inspector.html">fx a/b inspector →</a>
     <a href="event-diff.html">event diff (/s_new) →</a>
+    <a href="experiments.html">🧪 experiments (#513 use_sample_bpm tempo) →</a>
     <a href="mono-sample-sp107.html">SP107 mono-sample investigation →</a>
     <a href="raw-lpf.html">raw-lpf investigation →</a>
   </div>


### PR DESCRIPTION
## Problem

Follow-up to #513/#514. `use_sample_bpm` regressed to a **no-op** whenever it was *not* emitted as a top-level call. It wasn't in the transpiler's `TOP_LEVEL_SETTINGS` set (unlike `use_bpm`), so when trailing/leading bare top-level code defers the surrounding bare statements into the synthetic `__run_once` live_loop, `use_sample_bpm` transpiled to `__b.use_sample_bpm(...)` (builder-local bpm only) — and the separately-registered `live_loop` read the unchanged engine `defaultBpm` (60). Same flow-sensitive class as SV55/#420.

## How it surfaced (the user caught it)

The live engine played `filtered_dnb` correctly (BPM 34.2, matches desktop), but the **captured** WAV on the experiments dashboard sounded darker/flatter. Investigation:

- `compare-desktop-vs-web.ts` uses `capture.ts --wrap-recording`, which wraps code with `recording_start … <code> … with_bpm 60 do sleep N end; recording_save`.
- That trailing bare block deferred `use_sample_bpm` into `__run_once` → no-op → recording played at **BPM 60**.
- **Warm vs cold** capture: identical (cold-start ruled out). **Wrapped vs unwrapped** (Rec-button) capture: the unwrapped path played correctly at BPM 34.2 — isolating the wrap.
- Transpiler proof:
```
WRAPPED before:  live_loop("__run_once", …) { __b.use_sample_bpm("loop_amen") }  live_loop("dnb")  // reads defaultBpm 60
WRAPPED after:   use_sample_bpm("loop_amen")  live_loop("__run_once", …)  live_loop("dnb")          // top-level → defaultBpm 34.2
```

## Fix

One line: add `use_sample_bpm` to `TOP_LEVEL_SETTINGS` (emitted eagerly at top level, like `use_bpm`). Inside a `live_loop` body it stays on the builder path.

## Result

Wrapped capture filter-open moved **3s → 5s** (BPM 60 → 34.2), matching desktop + the live/unwrapped engine. Post-fix Tier-1: pitch-class cos **0.992**, tempo ✓ MATCH, mel-L2 **14.66 → 10.14**. The faithful `filtered_dnb` now matches desktop modulo the known #504 gain + SV49 PRNG (both v1 non-goals).

## Also in this PR

`test_results/experiments.html` — a standalone investigation dashboard page (linked from the index like the SP107/raw-lpf pages) with full evidence (code, event diffs, A/B audio, spectrogram diffs) for both desktop SP and web, including the #515 correction. Binary artifacts live untracked in `test_results/experiments/` per the repo's per-example-asset convention.

## Test plan

- L1: suite **1324/1324** (+3 transpiler regression tests for top-level `use_sample_bpm` survival, `num_beats`, and in-loop builder path) · `tsc` clean.
- L2/L3: event-parity EVENT-MATCH; `compare-desktop-vs-web` Tier-1 ≈ MATCH post-fix, verified against running desktop Sonic Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)