### PR TITLE
🔊 fix(play): opts-only `play release: 0.01` (no note) plays at default note 52, not silence (closes #522)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -151,6 +151,27 @@ export class ProgramBuilder {
   get lastRef(): number { return this._lastRef }
 
   play(noteVal: number | string | Ring<number> | number[] | null | undefined, opts?: Record<string, unknown>): this {
+    // Opts-only form: `play release: 0.01, amp: 13` (no positional note).
+    // Desktop `sound.rb:1197-1203`: `play(n)` where `n.is_a?(Hash) && args.empty?`
+    // → `synth nil, n` — play the current synth with those opts and NO explicit
+    // note (the synthdef's default). The transpiler emits this as a single object
+    // arg, so the hash lands in the `noteVal` position at runtime (the TS type
+    // never permits it, but no internal caller passes an object — only transpiled
+    // user code does). Without this, `noteVal + this._transpose` coerces the object
+    // to the string "[object Object]0" → an invalid note → the play is skipped →
+    // silence (SP35 family; e.g. cloud_beat's pnoise hihat). Shift the hash to
+    // `opts` and default the note to 52 (Sonic Pi convention; matches the SP35
+    // `transpileSynthCommand` default).
+    if (
+      opts === undefined &&
+      noteVal !== null &&
+      typeof noteVal === 'object' &&
+      !(noteVal instanceof Ring) &&
+      !Array.isArray(noteVal)
+    ) {
+      opts = noteVal as Record<string, unknown>
+      noteVal = 52
+    }
     // Chord: Ring or array — push one play step per note (all at the same virtual time).
     if (noteVal instanceof Ring || Array.isArray(noteVal)) {
       const notes: number[] = noteVal instanceof Ring ? noteVal.toArray() : noteVal

--- a/src/engine/__tests__/ProgramBuilder.test.ts
+++ b/src/engine/__tests__/ProgramBuilder.test.ts
@@ -17,6 +17,40 @@ describe('ProgramBuilder', () => {
     expect(step.synth).toBe('beep') // default synth
   })
 
+  it('play(opts) with no note plays at default note 52 with the opts (SP35 / #522)', () => {
+    // Desktop sound.rb:1199 — `play release: 0.01, amp: 13` (no positional note)
+    // → synth nil, n. The transpiler emits __b.play({ release, amp }); the hash
+    // must NOT be swallowed as the note (→ "[object Object]0" → skipped/silence).
+    const b = new ProgramBuilder()
+    b.play({ release: 0.01, amp: 13 } as unknown as number)
+    const steps = b.build()
+    expect(steps).toHaveLength(1)
+    const step = steps[0] as Extract<(typeof steps)[0], { tag: 'play' }>
+    expect(step.note).toBe(52)
+    expect(step.opts.amp).toBe(13)
+    expect(step.opts.release).toBe(0.01)
+    expect(step.noteName).toBeUndefined() // 52 is a valid numeric note, not skipped
+  })
+
+  it('play(opts) honors the current synth and transpose, not "[object Object]0"', () => {
+    const b = new ProgramBuilder()
+    b.use_synth('pnoise')
+    b.use_transpose(2)
+    b.play({ amp: 2 } as unknown as number)
+    const step = b.build().find((s) => s.tag === 'play') as Extract<ReturnType<ProgramBuilder['build']>[0], { tag: 'play' }>
+    expect(step.synth).toBe('pnoise')
+    expect(step.note).toBe(54) // 52 + transpose 2
+    expect(Number.isNaN(step.note)).toBe(false)
+  })
+
+  it('play(note, opts) is unaffected by the opts-only shift', () => {
+    const b = new ProgramBuilder()
+    b.play(60, { amp: 0.5 })
+    const step = b.build()[0] as Extract<ReturnType<ProgramBuilder['build']>[0], { tag: 'play' }>
+    expect(step.note).toBe(60)
+    expect(step.opts.amp).toBe(0.5)
+  })
+
   it('play() converts string notes to MIDI', () => {
     const b = new ProgramBuilder()
     b.play('c4')


### PR DESCRIPTION
## Summary
A `play` call with **no positional note** — only an options hash (`play release: 0.01, amp: 13`) — was silently dropped. The transpiler emits `__b.play({ release: 0.01, amp: 13 })`; `ProgramBuilder.play` treated the hash as the note, coerced it to the string `"[object Object]0"`, and skipped the play → **total silence** (`[Warning] play skipped — note resolved to [object Object]0`). This is the **SP35 family** (options hash swallowed as noteVal); the earlier SP35 fix covered the `synth :NAME` form but not the opts-only `play` form.

### Not a `:pnoise` bug, not PRNG-related
Surfaced in `cloud_beat`, whose `:pnoise` hihat is `play release: 0.01, amp: 13` triggered by a **deterministic** ticked ring (`divisors.tick.times` — no `rand`/`choose`/`one_in`). It emitted 0 `/s_new` on web vs 58 on desktop. This was previously filed as "`:pnoise` renders nothing", but:
- `:pnoise` plays fine — a `play 60` pnoise loop produces `/s_new "sonic-pi-pnoise"` + audio. The CDN ships the synthdef; `triggerSynth` lazy-loads it.
- Pink noise's sound comes from scsynth's *internal* UGen RNG, **not** Sonic Pi's seeded `rand`. And the hihat trigger is deterministic. So the "58 vs 0" is structural (the opts-only `play` skip), not PRNG variance — which is why it was exactly **0**.

## Desktop ground truth (`sound.rb:1197-1203`)
```ruby
def play(n, *args, &blk)
  if n.is_a?(Hash) && args.empty?
    synth nil, n        # play current synth, no explicit note → synthdef default
  else
    synth nil, {note: n}, *args
  end
end
```
Desktop handles the Hash-first arg **inside `play`**, so the fix belongs in our `ProgramBuilder.play` (the domain-aligned boundary), covering every call path in one place.

## Fix
In `ProgramBuilder.play`: when the note position holds a plain options object (not a `Ring`/`Array`/number/string) and `opts` is absent, shift it to `opts` and default the note to **52** (Sonic Pi convention; matches the existing SP35 `transpileSynthCommand` default at `TreeSitterTranspiler.ts:2843`).

## Test plan
- **L1:** `tsc` clean; vitest **1337/1337** (+3: opts-only → note 52 + opts carried; current-synth/transpose honored; `play(note, opts)` unaffected).
- **L3 (web audio):** the opts-only pnoise loop went from **0 events / silence (peak 0.0)** to **7 `/s_new "sonic-pi-pnoise"` with `note: 52`** + the opts (`release: 0.01, amp: 13`) carried, **real audio (peak 0.83, RMS 0.06)**, no skip warning.
- **Desktop parity** is source-grounded (`sound.rb:1199`). A live desktop A/B was apparatus-blocked this session — desktop Sonic Pi stopped producing WAVs mid-session (even a `:beep` control gave no WAV; the SV57 singleton-flakiness, not this change). Can re-run after a desktop restart if a parity number is wanted.

closes #522