### PR TITLE
✅ test(sync): regression guard — sync inside with_fx stays interleaved (verifies #490 fixed)

### DIFF
--- a/src/engine/__tests__/SyncCue.test.ts
+++ b/src/engine/__tests__/SyncCue.test.ts
@@ -429,4 +429,40 @@ describe('sync/cue — SP95(d) build-time payload + wake-phase (#350/#351)', () 
     expect(ret).toBe(b)
     expect(b.build()).toEqual([{ tag: 'sync', name: 'beat', bpmSync: true }])
   })
+
+  it('sync inside with_fx stays a runtime-step even when the outer builder is sync-wired — N synced plays interleave, never batch (#490)', () => {
+    // #490: `with_fx :reverb { 8.times { sync :tick; synth :saw } }` must spread
+    // the saws at the cue cadence, not pile them at one vt. The outer __run_once
+    // builder IS sync-wired (top-level `sync; play get(:x)` needs the build-time
+    // await), but `with_fx` builds its body through forkBuilder('same-thread'),
+    // which deliberately does NOT propagate _syncScheduler/_syncTaskId. So the
+    // inner `sync` falls to the RUNTIME-STEP path: it pushes a `{tag:'sync'}`
+    // step interleaved with each play, and AudioInterpreter `case 'sync'` blocks
+    // on it at interpret time — exactly like desktop's blocking with_fx thread.
+    //
+    // If forkBuilder were ever "consistency-refactored" to inherit the scheduler,
+    // the inner sync would build-await (return a Promise) inside the SYNCHRONOUS
+    // with_fx buildFn — un-awaited, dropped — pushing NO sync step and piling the
+    // plays. This test catches exactly that regression: the body would collapse
+    // to ['play','play','play'] and the assertion below would fail.
+    const scheduler = new VirtualTimeScheduler({ getAudioTime: () => 0, schedAheadTime: 100 })
+    scheduler.registerLoop('__run_once', async () => {})
+    const b = new ProgramBuilder(0)
+    b.setSyncContext(scheduler, '__run_once') // build-time-await wiring on the OUTER builder
+
+    b.with_fx('reverb', (inner) => {
+      for (let i = 0; i < 3; i++) {
+        const ret = inner.sync('tick')
+        expect(ret).toBe(inner) // runtime-step path: chainable, NOT a Promise
+        inner.play(52, { synth: 'saw' })
+      }
+      return inner
+    })
+
+    const fx = b.build().find((s) => s.tag === 'fx')
+    expect(fx).toBeDefined()
+    const body = (fx as { body: { tag: string }[] }).body
+    // Interleaved runtime steps — proof the syncs were NOT consumed at build time.
+    expect(body.map((s) => s.tag)).toEqual(['sync', 'play', 'sync', 'play', 'sync', 'play'])
+  })
 })


### PR DESCRIPTION
## Summary

#490 reported `with_fx :reverb { 8.times { sync :tick; synth :saw } }` batching all synced plays at the final virtual time. **Grounding against desktop SP shows it does not reproduce on `main`** — it is already correct. This PR adds the missing regression guard that locks the behavior in, rather than re-implementing a shipped fix (SP139 anti-trap).

## Why it was already fixed

The `__run_once` builder is sync-wired for build-time await (top-level `sync; play get(:x)` needs it), **but** `with_fx` builds its body through `forkBuilder('same-thread')`, which deliberately does **not** propagate `_syncScheduler`/`_syncTaskId`. So the inner `sync` falls to the runtime-step path (`ProgramBuilder.ts:481`), and `AudioInterpreter` `case 'sync'` (`:378`) blocks on it at interpret time — interleaving each sync with its play, exactly like desktop's blocking `with_fx` thread.

## Grounded observation (desktop ↔ web onset EVENT-MATCH)

| | saw onsets (s) | inter-onset Δ |
|---|---|---|
| Desktop SP | 1.40, 1.89, 2.37, 2.89, 3.39, 3.89, 4.37, 4.89 | ≈0.49–0.52s |
| Web (`/s_new`) | 2.32, 2.82, 3.32, 3.82, 4.32, 4.82, 5.32, 5.82 | exactly 0.5s |

Identical 8-saw sequence at the 0.5s cue cadence; the only delta is cold-start offset (#504-class, not musical).

## The guard

New unit test in `SyncCue.test.ts`: with the outer builder sync-wired, `with_fx { 3× (sync; play) }` must build an interleaved `[sync, play, sync, play, sync, play]` body. If `forkBuilder` were ever refactored to inherit the scheduler, the inner `sync` would build-await (return a Promise) inside the synchronous `with_fx` buildFn — un-awaited, dropped — collapsing the body to `[play, play, play]`. **Verified the test fails under exactly that mutation** (sync returns a Promise, breaking the chainable assertion).

## Test plan

- `npx vitest run` → **1338/1338** (+1 guard)
- `npx tsc --noEmit` → clean
- Mutation-tested: inject `_syncScheduler` propagation into `forkBuilder` → guard FAILS; revert → green
- Level-3 desktop A/B: onset EVENT-MATCH (table above)

Verifies + closes #490.