### PR TITLE
🎚️ fix(engine): use_transpose/use_synth_defaults inherited at loop registration (closes #421)

### DIFF
--- a/src/engine/DslNames.ts
+++ b/src/engine/DslNames.ts
@@ -156,6 +156,12 @@ export const DSL_NAMES = [
   'set_mixer_control', 'reset_mixer',
   'scsynth_info', 'status',
   'vt', 'bt', 'rt',
+  // #421/SV55 — top-level use_transpose / use_synth_defaults. Bound so the
+  // transpiler's eager source-order prefix (emitted before a loop registration
+  // to carry the setting into the loop's task) resolves at top level. Inside
+  // live_loops these still route through __b (BARE_DSL_CALLS), unchanged.
+  // MUST stay index-aligned with dslValues in SonicPiEngine (SP37).
+  'use_transpose', 'use_synth_defaults',
 ] as const
 
 export type DslName = typeof DSL_NAMES[number]

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -279,6 +279,12 @@ export class ProgramBuilder {
    *  synth, not the engine-level `defaultSynth`. */
   get currentDefaultSynth(): string { return this.currentSynth }
 
+  /** #421/SV55: parent's in-flight transpose / synth_defaults — nested loop
+   *  registrations inherit these from the parent builder (desktop fork-snapshot
+   *  parity, runtime.rb:1067), mirroring `currentDefaultSynth` for `use_synth`. */
+  get currentTranspose(): number { return this._transpose }
+  get currentSynthDefaultsMap(): Record<string, number> { return { ...this._synthDefaults } }
+
   /**
    * Set BPM to match a sample's natural tempo. Desktop `sound.rb:542-552`:
    * disable bpm-scaling, read the RAW-seconds sample duration, then

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -609,17 +609,25 @@ export class SonicPiEngine {
       // Top-level DSL state
       let defaultBpm = 60
       let defaultSynth = 'beep'
+      // #421/SV55: top-level transpose / synth_defaults — read into each loop's
+      // task at registration (mirrors defaultSynth). Desktop snapshots both
+      // thread-locals at fork (runtime.rb:1067; sound.rb:1481-1484, :4139).
+      let defaultTranspose = 0
+      let defaultSynthDefaults: Record<string, number> = {}
       const scheduler = this.scheduler!
 
       const topLevelUseBpm = (bpm: number) => { defaultBpm = bpm }
       const topLevelUseSynth = (name: string) => { defaultSynth = name }
+      const topLevelUseTranspose = (semitones: number) => { defaultTranspose = semitones }
+      // use_synth_defaults REPLACES prior defaults (desktop sound.rb:1481-1484).
+      const topLevelUseSynthDefaults = (opts: Record<string, number>) => { defaultSynthDefaults = { ...opts } }
       // Top-level use_arg_bpm_scaling — no-op at top level (inside live_loops, b.use_arg_bpm_scaling handles it)
       const topLevelUseArgBpmScaling = (_enabled: boolean) => { /* no-op */ }
       const topLevelWithArgBpmScaling = (_enabled: boolean, fn: () => void) => { fn() }
 
       // Collection map for re-evaluate hot-swap path
       const pendingLoops = new Map<string, () => Promise<void>>()
-      const pendingDefaults = new Map<string, { bpm: number; synth: string }>()
+      const pendingDefaults = new Map<string, { bpm: number; synth: string; transpose: number; synthDefaults: Record<string, number> }>()
 
       // Top-level set_volume! — Desktop SP range is 0-5, maps to mixer pre_amp.
       // currentVolume is captured by closures (set_volume + current_volume_fn +
@@ -963,6 +971,14 @@ export class SonicPiEngine {
           if (task.currentSynth && task.currentSynth !== 'beep') {
             builder.use_synth(task.currentSynth)
           }
+          // #421/SV55: seed transpose / synth_defaults inherited at registration
+          // (mirrors use_synth). Re-seeded each iteration from the inherited
+          // value; a use_transpose/use_synth_defaults inside the body overrides
+          // for that iteration, matching desktop's per-iteration fork-snapshot.
+          if (task.transpose) builder.use_transpose(task.transpose)
+          if (task.synthDefaults && Object.keys(task.synthDefaults).length > 0) {
+            builder.use_synth_defaults(task.synthDefaults)
+          }
           // Seed introspection state for current_time / current_beat (#226).
           // task.virtualTime is the iteration-start audio time (advances on sleep).
           // loopBeats persists current_beat across iterations like loopTicks does.
@@ -1092,10 +1108,13 @@ export class SonicPiEngine {
         // from top-level use_bpm/use_synth). Read from the parent builder if
         // we have one, else fall back to engine defaults.
         const parentBuilder = this.currentBuildBuilder
-        const inheritedBpm = (this.buildNestingDepth > 0 && parentBuilder)
-          ? parentBuilder.currentBpm : defaultBpm
-        const inheritedSynth = (this.buildNestingDepth > 0 && parentBuilder)
-          ? parentBuilder.currentDefaultSynth : defaultSynth
+        const nestedFromParent = this.buildNestingDepth > 0 && parentBuilder
+        const inheritedBpm = nestedFromParent ? parentBuilder.currentBpm : defaultBpm
+        const inheritedSynth = nestedFromParent ? parentBuilder.currentDefaultSynth : defaultSynth
+        // #421/SV55: transpose / synth_defaults follow the same inheritance as
+        // synth — parent builder when nested (SP72/SV28), engine default at top.
+        const inheritedTranspose = nestedFromParent ? parentBuilder.currentTranspose : defaultTranspose
+        const inheritedSynthDefaults = nestedFromParent ? parentBuilder.currentSynthDefaultsMap : defaultSynthDefaults
         // #480: a nested registration (depth>0) forks at the parent thread's
         // current vtime, not the deferred-registration getAudioTime(). Top-level
         // (depth 0) registrations keep getAudioTime() (undefined anchor) — their
@@ -1141,16 +1160,25 @@ export class SonicPiEngine {
             // SP72: nested hot-swap inherits from parent builder, not defaults.
             existing.bpm = inheritedBpm
             existing.currentSynth = inheritedSynth
+            existing.transpose = inheritedTranspose
+            existing.synthDefaults = inheritedSynthDefaults
             existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
-            scheduler.registerLoop(name, asyncFn, { bpm: inheritedBpm, synth: inheritedSynth, virtualTime: nestedAnchorVt, idPath: consumeIdPath() })
+            scheduler.registerLoop(name, asyncFn, {
+              bpm: inheritedBpm, synth: inheritedSynth,
+              transpose: inheritedTranspose, synthDefaults: inheritedSynthDefaults,
+              virtualTime: nestedAnchorVt, idPath: consumeIdPath(),
+            })
             const task = scheduler.getTask(name)
             if (task) task.outBus = loopBus
           }
         } else if (isReEvaluate) {
           pendingLoops.set(name, asyncFn)
-          pendingDefaults.set(name, { bpm: defaultBpm, synth: defaultSynth })
+          pendingDefaults.set(name, {
+            bpm: defaultBpm, synth: defaultSynth,
+            transpose: inheritedTranspose, synthDefaults: inheritedSynthDefaults,
+          })
         } else {
           // #480: nestedAnchorVt is undefined at depth 0 → registerLoop keeps
           // getAudioTime() (top-level launch seed, unchanged). At depth>0 it
@@ -1165,6 +1193,8 @@ export class SonicPiEngine {
             // engine-level defaults — unchanged from prior behavior.
             task.bpm = inheritedBpm
             task.currentSynth = inheritedSynth
+            task.transpose = inheritedTranspose
+            task.synthDefaults = inheritedSynthDefaults
             task.outBus = loopBus
           }
         }
@@ -1861,6 +1891,13 @@ export class SonicPiEngine {
         () => scheduler.audioTime - this._spiderTimeOrigin,          // vt: thread's local virtual run time (rebased)
         (t: number) => t * 60 / defaultBpm,                          // bt: beats → seconds at current bpm
         (t: number) => t * defaultBpm / 60,                          // rt: seconds → beats (bypasses bpm scaling)
+        // #421/SV55 — top-level use_transpose / use_synth_defaults set the engine
+        // defaults read into each loop's task at registration (mirrors
+        // topLevelUseSynth). The transpiler emits these as an eager source-order
+        // prefix before each loop-registering block. MUST stay last to align with
+        // the trailing DSL_NAMES entries (SP37 positional-list invariant).
+        topLevelUseTranspose,
+        topLevelUseSynthDefaults,
       ]
 
       const codeWarnings = validateCode(transpiledCode)
@@ -2035,6 +2072,8 @@ export class SonicPiEngine {
           if (task) {
             task.bpm = defaults.bpm
             task.currentSynth = defaults.synth
+            task.transpose = defaults.transpose
+            task.synthDefaults = defaults.synthDefaults
             task.outBus = this.bridge?.getLoopBus(name) ?? 0
           }
         }
@@ -2444,6 +2483,12 @@ export class SonicPiEngine {
               // Apply the loop's synth default so QueryInterpreter shows the correct synth
               if (task?.currentSynth && task.currentSynth !== 'beep') {
                 builder.use_synth(task.currentSynth)
+              }
+              // #421/SV55: seed transpose / synth_defaults so the query view
+              // matches the audio path (same as the live builder seeding above).
+              if (task?.transpose) builder.use_transpose(task.transpose)
+              if (task?.synthDefaults && Object.keys(task.synthDefaults).length > 0) {
+                builder.use_synth_defaults(task.synthDefaults)
               }
               builderFn(builder)
               return { program: builder.build(), ticks: builder.getTicks() }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1081,6 +1081,31 @@ function extractLiteralSynthArg(callNode: any): string | null {
   return null
 }
 
+// #421/SV55: a numeric literal (incl. signed) — the only arg shape we will
+// hoist into an eager prefix for use_transpose / use_synth_defaults. Runtime
+// expressions (vars, rrand) are NOT hoisted: re-emitting them before the loop
+// would evaluate against an empty top-level scope (or double-evaluate a random)
+// — so we leave those deferred in __run_once (no eager prefix).
+function isNumericLiteralNode(n: any): boolean {
+  if (!n) return false
+  if (n.type === 'integer' || n.type === 'float') return true
+  // `-12` / `+3` parse as a unary node wrapping a number.
+  if (n.type === 'unary' && /^[-+]?\d/.test(n.text)) return true
+  return false
+}
+// `use_transpose <number>` — hoistable iff the sole arg is a numeric literal.
+function isLiteralTransposeCall(callNode: any): boolean {
+  const args = callNode.childForFieldName('arguments')?.namedChildren ?? []
+  return args.length === 1 && isNumericLiteralNode(args[0])
+}
+// `use_synth_defaults amp: 0.5, cutoff: 80` — hoistable iff every arg is a
+// keyword pair with a numeric-literal value (the common shape).
+function isLiteralSynthDefaultsCall(callNode: any): boolean {
+  const args = callNode.childForFieldName('arguments')?.namedChildren ?? []
+  if (args.length === 0) return false
+  return args.every((a: any) => a.type === 'pair' && isNumericLiteralNode(a.namedChildren[1]))
+}
+
 function transpileProgram(node: any, ctx: TranspileContext): string {
   const children = node.namedChildren
 
@@ -1137,6 +1162,14 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   // flows to bareCode (deferred) for bare-play interleave — this only records.
   let currentTopSynth: string | null = null
   const blockSynth = new Map<any, string | null>()
+  // #421/SV55: same source-order tracking for use_transpose / use_synth_defaults
+  // (also fork-snapshotted thread-locals in desktop, sound.rb:1481-1484/:4139).
+  // We store the CALL NODE (re-transpiled into the eager prefix) when its args
+  // are numeric literals, else null (non-literal → leave deferred, no hoist).
+  let currentTopTranspose: any = null
+  let currentTopDefaults: any = null
+  const blockTranspose = new Map<any, any>()
+  const blockDefaults = new Map<any, any>()
 
   // #448/SP118: source-position START-GATE for top-level `in_thread`. When an
   // in_thread is declared after vtime-advancing bare code (`sleep`/`sync`), it
@@ -1165,6 +1198,14 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     if (method === 'use_synth') {
       currentTopSynth = extractLiteralSynthArg(child)
     }
+    // #421/SV55: same for use_transpose / use_synth_defaults (literal args only;
+    // a non-literal arg → null → no eager prefix, stays deferred in __run_once).
+    if (method === 'use_transpose') {
+      currentTopTranspose = isLiteralTransposeCall(child) ? child : null
+    }
+    if (method === 'use_synth_defaults') {
+      currentTopDefaults = isLiteralSynthDefaultsCall(child) ? child : null
+    }
 
     // Bare with_fx (no live_loop inside) should be treated as bare code, not a
     // block — UNLESS it wraps a bare `loop do`, which is hoisted to a live_loop
@@ -1191,6 +1232,8 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
                           method === 'in_thread' || isBareLoopNode)) {
       blocks.push(child)
       blockSynth.set(child, currentTopSynth)
+      blockTranspose.set(child, currentTopTranspose)
+      blockDefaults.set(child, currentTopDefaults)
       // #448/SP118: gate a top-level loop/thread declared after vtime-advancing
       // bare code so it forks at the source-position vtime (desktop fork-at-
       // current-vtime), not vt 0. Assign a unique cue and drop a marker into
@@ -1267,6 +1310,11 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   // loops sharing the same source-order synth emits the prefix only once
   // (defaultSynth persists across registrations at runtime).
   let lastEagerSynth: string | null = null
+  // #421/SV55: same dedup for the transpose / synth_defaults eager prefixes,
+  // keyed by emitted source text (so two distinct nodes with the same value
+  // emit once — defaultTranspose/defaultSynthDefaults persist across registrations).
+  let lastEagerTranspose: string | null = null
+  let lastEagerDefaults: string | null = null
   const blockJS = blocks.map(c => {
     const m = (c.type === 'call' || c.type === 'method_call')
       ? (c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text)
@@ -1285,13 +1333,28 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     // live_loop (else it is bareCode), so `m === 'with_fx'` here always wraps a
     // registering loop. Skipped for non-literal args (tagged === null) and when
     // the value is unchanged from the last eager emit.
+    const isLoopRegister = m === 'live_loop' || m === 'loop' || m === 'in_thread' || m === 'with_fx'
     const tagged = blockSynth.get(c) ?? null
     let eagerPrefix = ''
-    if (tagged !== null &&
-        (m === 'live_loop' || m === 'loop' || m === 'in_thread' || m === 'with_fx') &&
-        tagged !== lastEagerSynth) {
+    if (tagged !== null && isLoopRegister && tagged !== lastEagerSynth) {
       eagerPrefix = `use_synth(${JSON.stringify(tagged)})\n`
       lastEagerSynth = tagged
+    }
+    // #421/SV55: transpose / synth_defaults eager prefixes — re-transpile the
+    // recorded literal call node at top level (a bare call → topLevelUseTranspose
+    // / topLevelUseSynthDefaults, NOT __b.* since we're outside a loop body here).
+    // Dedup by emitted source text. Same loop-registering scope as the synth prefix.
+    if (isLoopRegister) {
+      const tNode = blockTranspose.get(c)
+      if (tNode) {
+        const code = transpileNode(tNode, ctx)
+        if (code && code !== lastEagerTranspose) { eagerPrefix += code + '\n'; lastEagerTranspose = code }
+      }
+      const dNode = blockDefaults.get(c)
+      if (dNode) {
+        const code = transpileNode(dNode, ctx)
+        if (code && code !== lastEagerDefaults) { eagerPrefix += code + '\n'; lastEagerDefaults = code }
+      }
     }
     if (m === 'loop') {
       const body = c.namedChildren.find((x: any) => x.type === 'do_block' || x.type === 'block')

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -79,6 +79,11 @@ export interface TaskState {
   bpm: number
   density: number
   currentSynth: string
+  /** #421/SV55: transpose (semitones) and synth_defaults inherited at the loop's
+   *  source position — seeded into each iteration's builder, mirroring
+   *  currentSynth. Desktop snapshots both thread-locals at fork (runtime.rb:1067). */
+  transpose: number
+  synthDefaults: Record<string, number>
   outBus: number
   /** The async loop body */
   asyncFn: () => Promise<void>
@@ -267,6 +272,10 @@ export class VirtualTimeScheduler {
   registerLoop(name: string, asyncFn: () => Promise<void>, options?: {
     bpm?: number
     synth?: string
+    // #421/SV55: transpose / synth_defaults snapshotted at the loop's source
+    // position (mirrors `synth`), seeded into TaskState below.
+    transpose?: number
+    synthDefaults?: Record<string, number>
     outBus?: number
     // #475: anchor the new task's start virtual time to a specific cursor
     // instead of the wall-clock getAudioTime(). A thread spawned mid-run by a
@@ -298,6 +307,8 @@ export class VirtualTimeScheduler {
       bpm: options?.bpm ?? 60,
       density: 1,
       currentSynth: options?.synth ?? 'beep',
+      transpose: options?.transpose ?? 0,
+      synthDefaults: options?.synthDefaults ?? {},
       outBus: options?.outBus ?? 0,
       asyncFn,
       running: true,

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -424,6 +424,73 @@ sleep 5`)
         expect(synthIdx).toBeLessThan(itIdx)
       })
 
+      // #421 item 3 — the same fork-snapshot semantics apply to use_transpose
+      // and use_synth_defaults (desktop: both thread-locals snapshotted at fork,
+      // sound.rb:1481-1484 / :4139, runtime.rb:1067). A top-level use_transpose /
+      // use_synth_defaults before a loop must reach the loop's registration via
+      // an eager top-level prefix (→ topLevelUseTranspose / topLevelUseSynthDefaults).
+      it('T-J (#421): top-level use_transpose prefixes the loop registration', () => {
+        const result = treeSitterTranspile(`use_transpose 7
+live_loop :s do
+  play 60
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const loopIdx = result.code.indexOf('live_loop("s"')
+        const tIdx = eagerIdx(result.code, 'use_transpose(7)')
+        expect(tIdx).toBeGreaterThanOrEqual(0)
+        expect(loopIdx).toBeGreaterThanOrEqual(0)
+        expect(tIdx).toBeLessThan(loopIdx)
+      })
+
+      it('T-K (#421): top-level use_synth_defaults prefixes the loop registration', () => {
+        const result = treeSitterTranspile(`use_synth_defaults amp: 0.5, cutoff: 80
+live_loop :s do
+  play 60
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const loopIdx = result.code.indexOf('live_loop("s"')
+        const dIdx = eagerIdx(result.code, 'use_synth_defaults(')
+        expect(dIdx).toBeGreaterThanOrEqual(0)
+        expect(dIdx).toBeLessThan(loopIdx)
+        // The eager prefix carries the literal opts.
+        const prefix = result.code.slice(dIdx, loopIdx)
+        expect(prefix).toMatch(/amp:\s*0\.5/)
+        expect(prefix).toMatch(/cutoff:\s*80/)
+      })
+
+      it('T-L (#421): use_transpose AFTER the loop does NOT prefix it (forward-only)', () => {
+        const result = treeSitterTranspile(`live_loop :s do
+  play 60
+  sleep 1
+end
+use_transpose 7
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const loopIdx = result.code.indexOf('live_loop("s"')
+        const tIdx = eagerIdx(result.code, 'use_transpose(7)')
+        expect(tIdx === -1 || tIdx > loopIdx).toBe(true)
+      })
+
+      it('T-M (#421): a NON-literal use_transpose arg is NOT hoisted (stays deferred)', () => {
+        // `use_transpose n` can't be re-emitted eagerly (n is a runtime var with
+        // no top-level binding) — leave it deferred in __run_once, no eager prefix.
+        const result = treeSitterTranspile(`n = 7
+use_transpose n
+live_loop :s do
+  play 60
+  sleep 1
+end
+sleep 5`)
+        expect(result.ok).toBe(true)
+        const loopIdx = result.code.indexOf('live_loop("s"')
+        const tIdx = eagerIdx(result.code, 'use_transpose(n)')
+        expect(tIdx === -1 || tIdx > loopIdx).toBe(true)
+      })
+
       // #448/SP118: a top-level in_thread declared after vtime-advancing bare
       // code must fork at the source-position vtime — gated via a start-gate cue
       // __run_once fires at the in_thread's source position.


### PR DESCRIPTION
## Summary

Completes the SV55 fork-snapshot class (#421 item 3). A top-level `use_transpose` / `use_synth_defaults` placed **before** a `live_loop` was dropped when trailing bare code deferred it into `__run_once` — the loop played untransposed / without the defaults. `use_synth` already had this fix (#419/#420, extended to with_fx/in_thread in items 1+2); transpose & synth_defaults never got the registration plumbing.

Desktop SP stores both as thread-locals (`sound.rb:1481-1484` synth_defaults, `:4139` transpose) snapshotted at fork (`runtime.rb:1067`), so a loop inherits both at its source position — exactly like `current_synth`.

## ⚠ Provenance note (catalogue drift, the inverse of SP139)

This was authored on the **unmerged** branch `fix/sv55-class-withfx-inthread-421` (commit `5f968e9`) and the SV55 catalogue recorded it as *landed* — but that branch is 39 commits behind main and **never merged**. The triage "item 3 not done" note was correct; the catalogue over-claimed. Caught by `git merge-base --is-ancestor` + a transpile reproducer (not by trusting the catalogue). Re-applied fresh on current main using `5f968e9` as reference; the catalogue's claimed tests T-J/K/L never existed either — written fresh here (+T-M). The SV55 catalogue entry is corrected.

## Mechanism (the SP72/SV28 build-phase-visible-at-registration pattern)

- **ProgramBuilder**: `currentTranspose` / `currentSynthDefaultsMap` getters (parent inheritance read, mirror `currentDefaultSynth`).
- **VirtualTimeScheduler**: `TaskState.transpose` / `.synthDefaults` + `registerLoop` opts.
- **SonicPiEngine**: `defaultTranspose` / `defaultSynthDefaults` state + `topLevelUseTranspose` / `topLevelUseSynthDefaults` handlers (synth_defaults REPLACES, per desktop); `inherited*` read at registration (parent when nested, engine default at top); applied at all 3 registration branches + the pendingDefaults hot-swap; seeded into each iteration's builder (live + query, re-seeded per iteration so a body-level `use_*` overrides).
- **DslNames + dslValues**: bind both at top level (index-aligned — SP37) so the eager prefix resolves; inside loops still route `__b.*`.
- **TreeSitterTranspiler**: track source-order `use_transpose` / `use_synth_defaults` (numeric-literal args only — non-literal stays deferred), tag each loop-registering block, emit an eager prefix before registration (mirrors the `use_synth` eager prefix).

## Test plan

- L1: `npx vitest run` → **1342/1342** (+4: T-J transpose-before, T-K synth_defaults-before, T-L after=no-prefix, T-M non-literal-not-hoisted); `npx tsc --noEmit` clean.
- L2 (the verification — `/s_new` boundary, SV61), captured vs main:
  - `use_transpose 12; live_loop :x { play 60 }; sleep 5` → `/s_new ... note: 72` (was 60) ✓
  - `use_synth_defaults cutoff: 80, amp: 0.7; live_loop :y { play 60 }; sleep 5` → `/s_new ... {cutoff: 80, amp: 0.7, note: 60}` ✓
  - non-literal `use_transpose n` → correctly NOT hoisted ✓

Closes #421.