### PR TITLE
🔥 perf(app): warm audio engine on first user gesture, not first Run (closes #524)

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -167,6 +167,14 @@ const BUFFER_COUNT = 10
 
 export class App {
   private engine: SonicPiEngine | null = null
+  /** In-flight engine init, shared so concurrent callers (first-gesture
+   *  warmup + a near-simultaneous Run — a Run *click* is itself a
+   *  `pointerdown` that fires the warmup) await one boot instead of
+   *  racing into two scsynth/AudioContext instances. Cleared on settle so
+   *  a failed init can retry on the next gesture/Run (cf. SV43). */
+  private engineInitPromise: Promise<boolean> | null = null
+  /** One-shot guard so the first-gesture warmup arms its listeners once. */
+  private firstGestureWarmupArmed = false
   private editor!: Editor
   private scope!: Scope
   private console!: Console
@@ -393,6 +401,10 @@ export class App {
         }
       }
     })
+
+    // Warm the audio engine on the first user gesture so the ~300ms scsynth
+    // cold-start overlaps with the user reading/typing, not the first Run (#524).
+    this.armFirstGestureWarmup()
 
     // Apply saved preferences
     this.applyAllPrefs()
@@ -800,6 +812,36 @@ export class App {
   }
 
   /**
+   * Boot the audio engine on the first qualifying user gesture instead of
+   * the first Run (#524). The passive splash (Preloader) can warm the JS+WASM
+   * *bytes* pre-gesture, but the AudioContext + scsynth AudioWorklet can only
+   * start inside a user gesture (autoplay policy). So we listen for the first
+   * `pointerdown` / `keydown` / `touchstart` and kick off `ensureEngineInitialised`
+   * then — the ~300ms boot overlaps with the user reading/typing, and by the
+   * time they hit Run scsynth + COMMON_SYNTHDEFS are loaded → near-instant
+   * first sound. The lazy first-Run path stays as the fallback for a user who
+   * never interacts before Run (handlePlay calls the same idempotent method).
+   */
+  private armFirstGestureWarmup(): void {
+    if (this.firstGestureWarmupArmed) return
+    this.firstGestureWarmupArmed = true
+
+    const events: Array<keyof DocumentEventMap> = ['pointerdown', 'keydown', 'touchstart']
+    const warm = () => {
+      for (const ev of events) document.removeEventListener(ev, warm, true)
+      // Fire-and-forget: idempotent + concurrency-guarded. A failed boot here
+      // just leaves the lazy first-Run path to retry.
+      void this.ensureEngineInitialised()
+    }
+    // Capture phase + passive so we never interfere with editor/toolbar
+    // handlers and never block scrolling. The listener removes itself on
+    // first fire (above) — `once` would only cover the event that fired.
+    for (const ev of events) {
+      document.addEventListener(ev, warm, { capture: true, passive: true })
+    }
+  }
+
+  /**
    * Initialise the audio engine if not already initialised. Idempotent.
    * Used both by handlePlay (which then evaluates the editor buffer) and by
    * the sample-browser preview, which wants engine without disturbing the
@@ -807,6 +849,21 @@ export class App {
    */
   private async ensureEngineInitialised(): Promise<boolean> {
     if (this.engine) return true
+    // Dedup concurrent boots. The first-gesture warmup and a near-simultaneous
+    // Run (a Run *click* is itself a `pointerdown` that arms the warmup) would
+    // otherwise both see a null engine and boot two scsynth/AudioContext
+    // instances. Share one in-flight promise; clear it on settle so a failed
+    // init can retry on the next gesture/Run (cf. SV43).
+    if (this.engineInitPromise) return this.engineInitPromise
+    this.engineInitPromise = this._initEngine()
+    try {
+      return await this.engineInitPromise
+    } finally {
+      this.engineInitPromise = null
+    }
+  }
+
+  private async _initEngine(): Promise<boolean> {
     try {
       this.toolbar.setLoading(true)
       const t0 = performance.now()


### PR DESCRIPTION
## Problem

The first **Run** of a session paid a one-time ~300ms scsynth cold-start — WASM instantiation + AudioContext + `COMMON_SYNTHDEFS` load + mixer/graph setup, all lazily done by `ensureEngineInitialised()` → `engine.init()`. The passive splash (`Preloader`) already preloads the JS+WASM **bytes** pre-gesture, but it can't boot scsynth: the AudioContext + scsynth AudioWorklet are gated on a **user gesture** by the browser autoplay policy. So the ~300ms was stranded on first Run — a small but real first-impression hitch (P1).

## Fix

Move warmup from "first Run" to "first user gesture":

- **`armFirstGestureWarmup()`** (called in `init()`) attaches one-shot document listeners — `pointerdown` / `keydown` / `touchstart`, **capture + passive** so it never interferes with editor/toolbar handlers or blocks scrolling. The first qualifying gesture fires `ensureEngineInitialised()`, so the ~300ms boot overlaps with the user reading/typing. By the time they hit Run, scsynth + synthdefs are loaded → near-instant first sound.
- **Concurrency guard** (correctness prerequisite this change introduces): a Run *click* is itself a `pointerdown`, so the warmup and `handlePlay`→`ensureEngineInitialised` would race, both see a null engine, and boot **two** scsynth/AudioContext instances. `ensureEngineInitialised` now dedups via a shared in-flight `engineInitPromise`, cleared on settle so a failed boot retries on the next gesture/Run (cf. SV43).
- **Lazy fallback preserved**: a user who never interacts before Run still gets today's behavior — `handlePlay` calls the same idempotent method.

Skipped the optional silent `amp: 0` warmup note (issue says marginal — measure first). No audio-rendering path changed, so Tier-1 parity is structurally unaffected.

## Verification

**L1** — `npx vitest run` → **1342/1342** pass · `npx tsc --noEmit` → 0 errors.

**L2/L3 observation** (Playwright, real headed Chromium — direct observation, not inference):

| Check | Expected | Observed |
|---|---|---|
| Engine present *before* any gesture/Run | false | ✅ false |
| Engine boots on **one keydown, no Run** | true | ✅ true |
| `Initialising audio engine` count after gesture | 1 | ✅ 1 |
| Same count after gesture **+** Run (dedup held, no re-boot) | 1 | ✅ 1 |
| `Audio engine ready` count | 1 | ✅ 1 |

**VERDICT: PASS** — engine warms on the first gesture before Run, and the introduced race is closed (single boot across gesture + Run).

## Non-goals (verified in #524 grounding)
- Warmup persists for the whole session (`init()` boots scsynth once; bridge + AudioContext live for the session).
- Stop/pause does **not** re-warm — `engine.stop()` preserves the bridge; only `dispose()` tears scsynth down.

closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)