### PR TITLE
🎚️ fix(engine): use_osc target inherited by nested live_loop (closes #353)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -285,6 +285,14 @@ export class ProgramBuilder {
   get currentTranspose(): number { return this._transpose }
   get currentSynthDefaultsMap(): Record<string, number> { return { ...this._synthDefaults } }
 
+  /** #353: parent's in-flight `use_osc` target — a nested `live_loop`
+   *  registration inherits these from the parent builder (the surrounding
+   *  in_thread's `use_osc`), mirroring `currentDefaultSynth`/`currentTranspose`.
+   *  Desktop `:sonic_pi_osc_client` is a thread-local snapshotted at fork
+   *  (core.rb:649-653). */
+  get currentOscHost(): string { return this._oscHost }
+  get currentOscPort(): number { return this._oscPort }
+
   /**
    * Set BPM to match a sample's natural tempo. Desktop `sound.rb:542-552`:
    * disable bpm-scaling, read the RAW-seconds sample duration, then

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -627,7 +627,7 @@ export class SonicPiEngine {
 
       // Collection map for re-evaluate hot-swap path
       const pendingLoops = new Map<string, () => Promise<void>>()
-      const pendingDefaults = new Map<string, { bpm: number; synth: string; transpose: number; synthDefaults: Record<string, number> }>()
+      const pendingDefaults = new Map<string, { bpm: number; synth: string; transpose: number; synthDefaults: Record<string, number>; oscHost: string; oscPort: number }>()
 
       // Top-level set_volume! — Desktop SP range is 0-5, maps to mixer pre_amp.
       // currentVolume is captured by closures (set_volume + current_volume_fn +
@@ -979,6 +979,13 @@ export class SonicPiEngine {
           if (task.synthDefaults && Object.keys(task.synthDefaults).length > 0) {
             builder.use_synth_defaults(task.synthDefaults)
           }
+          // #353: seed the inherited use_osc target so `osc` inside the body
+          // targets the surrounding in_thread's host, not localhost:4560. Re-seeded
+          // each iteration like transpose; a use_osc inside the body overrides for
+          // that iteration (desktop per-iteration fork-snapshot).
+          if (task.oscHost !== 'localhost' || task.oscPort !== 4560) {
+            builder.use_osc(task.oscHost, task.oscPort)
+          }
           // Seed introspection state for current_time / current_beat (#226).
           // task.virtualTime is the iteration-start audio time (advances on sleep).
           // loopBeats persists current_beat across iterations like loopTicks does.
@@ -1115,6 +1122,12 @@ export class SonicPiEngine {
         // synth — parent builder when nested (SP72/SV28), engine default at top.
         const inheritedTranspose = nestedFromParent ? parentBuilder.currentTranspose : defaultTranspose
         const inheritedSynthDefaults = nestedFromParent ? parentBuilder.currentSynthDefaultsMap : defaultSynthDefaults
+        // #353: use_osc target follows the same inheritance — parent builder when
+        // nested (the surrounding in_thread's `use_osc`), engine-level top-level
+        // default (`oscDefaultHost`/`oscDefaultPort`) otherwise. Same SP72/SV28
+        // "field the inherited list missed" class as transpose.
+        const inheritedOscHost = nestedFromParent ? parentBuilder.currentOscHost : oscDefaultHost
+        const inheritedOscPort = nestedFromParent ? parentBuilder.currentOscPort : oscDefaultPort
         // #480: a nested registration (depth>0) forks at the parent thread's
         // current vtime, not the deferred-registration getAudioTime(). Top-level
         // (depth 0) registrations keep getAudioTime() (undefined anchor) — their
@@ -1162,12 +1175,15 @@ export class SonicPiEngine {
             existing.currentSynth = inheritedSynth
             existing.transpose = inheritedTranspose
             existing.synthDefaults = inheritedSynthDefaults
+            existing.oscHost = inheritedOscHost
+            existing.oscPort = inheritedOscPort
             existing.outBus = loopBus
           } else {
             // New inner declared during hot-swap (e.g. user added it on Run).
             scheduler.registerLoop(name, asyncFn, {
               bpm: inheritedBpm, synth: inheritedSynth,
               transpose: inheritedTranspose, synthDefaults: inheritedSynthDefaults,
+              oscHost: inheritedOscHost, oscPort: inheritedOscPort,
               virtualTime: nestedAnchorVt, idPath: consumeIdPath(),
             })
             const task = scheduler.getTask(name)
@@ -1178,6 +1194,7 @@ export class SonicPiEngine {
           pendingDefaults.set(name, {
             bpm: defaultBpm, synth: defaultSynth,
             transpose: inheritedTranspose, synthDefaults: inheritedSynthDefaults,
+            oscHost: inheritedOscHost, oscPort: inheritedOscPort,
           })
         } else {
           // #480: nestedAnchorVt is undefined at depth 0 → registerLoop keeps
@@ -1195,6 +1212,8 @@ export class SonicPiEngine {
             task.currentSynth = inheritedSynth
             task.transpose = inheritedTranspose
             task.synthDefaults = inheritedSynthDefaults
+            task.oscHost = inheritedOscHost
+            task.oscPort = inheritedOscPort
             task.outBus = loopBus
           }
         }
@@ -2074,6 +2093,8 @@ export class SonicPiEngine {
             task.currentSynth = defaults.synth
             task.transpose = defaults.transpose
             task.synthDefaults = defaults.synthDefaults
+            task.oscHost = defaults.oscHost
+            task.oscPort = defaults.oscPort
             task.outBus = this.bridge?.getLoopBus(name) ?? 0
           }
         }

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -84,6 +84,12 @@ export interface TaskState {
    *  currentSynth. Desktop snapshots both thread-locals at fork (runtime.rb:1067). */
   transpose: number
   synthDefaults: Record<string, number>
+  /** #353: use_osc target (host/port) inherited at the loop's source position,
+   *  mirroring transpose/synth — a nested live_loop inherits the surrounding
+   *  in_thread's `use_osc` so `osc` inside the body targets the right host.
+   *  Desktop `:sonic_pi_osc_client` thread-local snapshotted at fork. */
+  oscHost: string
+  oscPort: number
   outBus: number
   /** The async loop body */
   asyncFn: () => Promise<void>
@@ -276,6 +282,9 @@ export class VirtualTimeScheduler {
     // position (mirrors `synth`), seeded into TaskState below.
     transpose?: number
     synthDefaults?: Record<string, number>
+    // #353: use_osc target snapshotted at the loop's source position (mirrors transpose).
+    oscHost?: string
+    oscPort?: number
     outBus?: number
     // #475: anchor the new task's start virtual time to a specific cursor
     // instead of the wall-clock getAudioTime(). A thread spawned mid-run by a
@@ -309,6 +318,8 @@ export class VirtualTimeScheduler {
       currentSynth: options?.synth ?? 'beep',
       transpose: options?.transpose ?? 0,
       synthDefaults: options?.synthDefaults ?? {},
+      oscHost: options?.oscHost ?? 'localhost',
+      oscPort: options?.oscPort ?? 4560,
       outBus: options?.outBus ?? 0,
       asyncFn,
       running: true,

--- a/src/engine/__tests__/OscNestedInherit.test.ts
+++ b/src/engine/__tests__/OscNestedInherit.test.ts
@@ -1,0 +1,103 @@
+/**
+ * #353 — a `live_loop` nested inside an `in_thread` must inherit the
+ * surrounding thread's `use_osc` target, so `osc` inside the loop body fires at
+ * the in_thread's host/port, not the default localhost:4560.
+ *
+ *   in_thread do
+ *     use_osc "remote.host", 9000
+ *     live_loop :nested do
+ *       osc "/path", 1
+ *       sleep 1
+ *     end
+ *   end
+ *
+ * Same SP72/#421 "inherited field the registration list missed" class that was
+ * fixed for `current_synth` / `transpose` / `synth_defaults`. The in_thread
+ * sub-builder already inherited `_oscHost`/`_oscPort` (#345), but the nested
+ * live_loop's fresh per-iteration ProgramBuilder defaulted to localhost:4560.
+ *
+ * Fix: thread `use_osc` target through TaskState (oscHost/oscPort), derived from
+ * the parent builder when nested, and re-seed each iteration's builder — exactly
+ * mirroring transpose. Verified at the OSC-send boundary via engine.setOscHandler
+ * (osc is pure transport — no Level-3 audio path).
+ */
+import { describe, it, expect } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+type Task = { oscHost: string; oscPort: number }
+type Sched = { tick: (t: number) => void; getTask: (n: string) => Task | undefined }
+
+async function flush(rounds = 8) {
+  for (let i = 0; i < rounds; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+type OscSend = { host: string; port: number; path: string; args: unknown[] }
+
+async function runAndCaptureOsc(code: string): Promise<{ sends: OscSend[]; engine: SonicPiEngine }> {
+  const engine = new SonicPiEngine()
+  await engine.init()
+  const sends: OscSend[] = []
+  engine.setOscHandler((host, port, path, ...args) => { sends.push({ host, port, path, args }) })
+  await engine.evaluate(code)
+  engine.play()
+  const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+  // Several ticks so the in_thread body runs, the nested loop registers, and its
+  // first iteration interprets the `osc` step (osc fires before its first sleep).
+  for (let i = 0; i < 6; i++) { scheduler.tick(20); await flush() }
+  return { sends, engine }
+}
+
+describe('#353 osc target inherited by nested live_loop', () => {
+  it('nested live_loop inside in_thread inherits the in_thread use_osc target', async () => {
+    const { sends, engine } = await runAndCaptureOsc(`
+      in_thread do
+        use_osc "remote.host", 9000
+        live_loop :nested do
+          osc "/path", 1
+          sleep 1
+        end
+      end
+    `)
+    const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+    const task = scheduler.getTask('nested')
+    expect(task, ':nested should have registered').toBeDefined()
+    // Inheritance plumbing: the task carries the in_thread's use_osc target.
+    expect(task!.oscHost).toBe('remote.host')
+    expect(task!.oscPort).toBe(9000)
+    // End-to-end: the `osc` step actually fired at that target, not localhost:4560.
+    const send = sends.find((s) => s.path === '/path')
+    expect(send, 'osc "/path" should have fired').toBeDefined()
+    expect(send!.host).toBe('remote.host')
+    expect(send!.port).toBe(9000)
+    engine.dispose()
+  })
+
+  it('top-level use_osc is inherited by a top-level live_loop (same class)', async () => {
+    const { sends, engine } = await runAndCaptureOsc(`
+      use_osc "top.host", 4000
+      live_loop :solo do
+        osc "/solo", 7
+        sleep 1
+      end
+    `)
+    const send = sends.find((s) => s.path === '/solo')
+    expect(send, 'osc "/solo" should have fired').toBeDefined()
+    expect(send!.host).toBe('top.host')
+    expect(send!.port).toBe(4000)
+    engine.dispose()
+  })
+
+  it('regression: a live_loop with no use_osc targets the default localhost:4560', async () => {
+    const { sends, engine } = await runAndCaptureOsc(`
+      live_loop :plain do
+        osc "/plain", 1
+        sleep 1
+      end
+    `)
+    const send = sends.find((s) => s.path === '/plain')
+    expect(send, 'osc "/plain" should have fired').toBeDefined()
+    expect(send!.host).toBe('localhost')
+    expect(send!.port).toBe(4560)
+    engine.dispose()
+  })
+})


### PR DESCRIPTION
## Problem

A `live_loop` nested inside an `in_thread` did **not** inherit the surrounding thread's `use_osc` target. #345 fixed the in_thread *sub-builder* (`_oscHost`/`_oscPort` propagate to `with_fx`/`in_thread`/`at`), but when the nested `live_loop` **registers**, its own fresh per-iteration `ProgramBuilder` defaulted to `localhost:4560` — so `osc` inside the loop targeted the default, not the in_thread's host.

```ruby
in_thread do
  use_osc "remote.host", 9000
  live_loop :nested do
    osc "/path", 1   # was → localhost:4560,  now → remote.host:9000
    sleep 1
  end
end
```

Same **SP72 / SV55** "inherited field the registration list missed" class already fixed for `current_synth` / `transpose` / `synth_defaults` — `osc` target was the one field the nested-registration inheritance list omitted.

## Fix

Thread the `use_osc` target through `TaskState` (`oscHost`/`oscPort`), exactly mirroring `transpose`:

- **ProgramBuilder** — `currentOscHost` / `currentOscPort` getters (mirror `currentTranspose`).
- **VirtualTimeScheduler** — `TaskState.oscHost`/`oscPort` fields + `registerLoop` options + task-creation defaults (`localhost`/`4560`).
- **SonicPiEngine** — derive `inheritedOscHost`/`inheritedOscPort` (parent builder when nested, engine `oscDefaultHost`/`oscDefaultPort` at top level), thread through all 3 registration branches + `pendingDefaults` (hot-swap), and re-seed each iteration's builder via `use_osc` so `osc` reads the inherited target.

Also fixes **top-level `use_osc` → top-level `live_loop`** (same class, previously also defaulting to `localhost`) for free via the `oscDefaultHost` fallback.

## Verification

`osc` is pure transport — unit-level is the correct observation level (per the issue). New **`OscNestedInherit.test.ts`** captures the **actual dispatched OSC message** through the full `evaluate → tick → interpret` path via `engine.setOscHandler` (observation, not inference):

- Nested `in_thread`+`use_osc` → osc fires at `remote.host:9000` (+ asserts `task.oscHost`/`oscPort`).
- Top-level `use_osc` → osc fires at `top.host:4000`.
- No `use_osc` → stays `localhost:4560` (regression guard).

**Proven to fail without the iteration-seeding** (`expected 'localhost' to be 'remote.host'`) — a real guard, not a tautology.

- L1: `npx vitest run` → **1345/1345** · `npx tsc --noEmit` → 0 errors.

## Scope notes
Part of EPIC #342, follow-up from #345's self-review. Mirrors the `transpose`/`synth_defaults` plumbing 1:1 so the inheritance boundary stays a single consistent pattern (not scattered). The SP72/SP94/SV55 flow-sensitive-inheritance class is now closed for the `osc` target too.

closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)