### PR TITLE
✅ test(tutorial): CI no-drift guard for ingest-tutorial.ts (closes #333)

### DIFF
--- a/tools/__tests__/ingest-tutorial-drift.test.ts
+++ b/tools/__tests__/ingest-tutorial-drift.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { buildTutorialData, OUT_FILE } from '../ingest-tutorial'
+
+/**
+ * #333 — CI no-drift guard for tools/ingest-tutorial.ts (self-review of #332,
+ * EPIC #309).
+ *
+ * tutorialData.ts is generated + committed, and the ingester is deterministic,
+ * but nothing enforced that the committed file matches a fresh ingest of the
+ * pinned vendored corpus. Editing src/tutorial/content/ or the ingester
+ * without re-running `npm run ingest:tutorial` would silently drift the baked
+ * data from source.
+ *
+ * This asserts byte-identity in-process: buildTutorialData() rebuilds from the
+ * same vendored corpus the ingester reads, and we compare to the committed
+ * tutorialData.ts. No subprocess, no temp path — importing the ingester is
+ * side-effect-free (its main() runs only under direct execution). Lives in
+ * tools/__tests__ (not src/) so the src tsconfig isn't dragged across the
+ * tools boundary, mirroring tools/__tests__/capture-async-heuristic.test.ts.
+ *
+ * If this fails: run `npm run ingest:tutorial` and commit the result.
+ */
+describe('tutorial ingest drift guard (#333)', () => {
+  it('committed tutorialData.ts is byte-identical to a fresh ingest', () => {
+    const fresh = buildTutorialData().content
+    const committed = readFileSync(OUT_FILE, 'utf8')
+    expect(fresh).toBe(committed)
+  })
+})

--- a/tools/ingest-tutorial.ts
+++ b/tools/ingest-tutorial.ts
@@ -26,12 +26,12 @@
  */
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { marked } from 'marked'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const CONTENT_DIR = join(HERE, '..', 'src', 'tutorial', 'content')
-const OUT_FILE = join(HERE, '..', 'src', 'tutorial', 'tutorialData.ts')
+export const OUT_FILE = join(HERE, '..', 'src', 'tutorial', 'tutorialData.ts')
 const PINNED_COMMIT = 'abc844fade22463fa6533215dc9f14ba4710079e'
 
 /** Curated ~12 set (#311 §5, maintainer-locked). Order = chapter sequence. */
@@ -182,7 +182,18 @@ function ingestChapter(slug: string): TutorialChapter {
   }
 }
 
-function main() {
+/**
+ * Build the full text of tutorialData.ts from the vendored corpus, WITHOUT
+ * writing it. Pure + deterministic — same vendored bytes produce the same
+ * `content` every call. Exported so the drift guard (#333,
+ * tools/__tests__/ingest-tutorial-drift.test.ts) can assert the committed
+ * file is byte-identical to a fresh ingest, in-process, with no temp files.
+ */
+export function buildTutorialData(): {
+  content: string
+  chapterCount: number
+  codeBlocks: number
+} {
   const onDisk = new Set(
     readdirSync(CONTENT_DIR).filter((f) => f.endsWith('.md')).map((f) => f.replace(/\.md$/, '')),
   )
@@ -223,15 +234,29 @@ export interface TutorialChapter {
 
 export const TUTORIAL: TutorialChapter[] = `
 
-  writeFileSync(OUT_FILE, header + JSON.stringify(chapters, null, 2) + '\n', 'utf8')
-
   const codeBlocks = chapters.reduce(
     (n, c) => n + c.blocks.filter((b) => b.kind === 'code').length,
     0,
   )
+  return {
+    content: header + JSON.stringify(chapters, null, 2) + '\n',
+    chapterCount: chapters.length,
+    codeBlocks,
+  }
+}
+
+function main() {
+  const { content, chapterCount, codeBlocks } = buildTutorialData()
+  writeFileSync(OUT_FILE, content, 'utf8')
   console.log(
-    `ingest-tutorial: ${chapters.length} chapters, ${codeBlocks} code blocks → ${OUT_FILE}`,
+    `ingest-tutorial: ${chapterCount} chapters, ${codeBlocks} code blocks → ${OUT_FILE}`,
   )
 }
 
-main()
+// Only run the ingester when executed directly (`tsx tools/ingest-tutorial.ts`),
+// NOT when imported (e.g. by the #333 drift guard) — importing must not
+// overwrite the committed tutorialData.ts.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+if (invokedDirectly) main()


### PR DESCRIPTION
## Problem
`src/tutorial/tutorialData.ts` is generated by `tools/ingest-tutorial.ts` and committed, but **nothing enforced** that the committed file matches a fresh ingest of the pinned vendored corpus. Editing `src/tutorial/content/` or the ingester without re-running `npm run ingest:tutorial` silently drifts the baked data from source — the only determinism hole left by T1 (#311), flagged in the #332 self-review.

## Fix
- Extract a pure, deterministic `buildTutorialData()` from the ingester — returns the exact file content (`{ content, chapterCount, codeBlocks }`), no write.
- Guard `main()` with the project's `invokedDirectly` idiom (mirrors `tools/capture.ts`) so **importing** the ingester is side-effect-free; it only writes under direct `tsx` execution.
- New `tools/__tests__/ingest-tutorial-drift.test.ts` rebuilds in-process and asserts **byte-identity** vs the committed file — no subprocess, no temp path.
- Test lives in `tools/__tests__` (not `src/`) so the `src` tsconfig (`include: src/**/*.ts`) isn't dragged across the tools boundary — same reason `capture-async-heuristic.test.ts` lives there. Runs in CI via the standard vitest suite.

## Verification
- **Determinism preserved:** `npx tsx tools/ingest-tutorial.ts` after the refactor → byte-identical `tutorialData.ts` (clean `git diff`).
- **Import is side-effect-free:** importing the module does not overwrite the committed file (proven via `git diff --quiet`).
- **Guard provably catches drift:** appended a probe line to `04-Randomisation.md` → guard **FAILED**; restored → **PASSED** again.
- **L1:** full suite `1346/1346` green · `tsc --noEmit` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)