### PR TITLE
♻️ perf(engine): desktop-faithful auto-trim of per-key EventHistory (closes #402)

### DIFF
--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -152,27 +152,53 @@ export class EventHistory {
   private readonly store = new Map<string | symbol, CueEvent[]>()
 
   /**
-   * Optional per-key cap on retained events (keep the `maxPerKey` GREATEST). A
-   * safety bound, NOT desktop's full `@history_depth` pruning (GAP L / #402,
-   * deferred) — it exists so the cue side (one auto-cue per loop iteration) does
-   * not grow unbounded the way the old single-entry `cueMap` never did. Old cues
-   * are irrelevant to `sync`/`getNext` (a syncer matches the NEXT cue after its
-   * point), so trimming the oldest is safe. `undefined` ⇒ unbounded (the
-   * set/get TimeState facade keeps its prior append-history behaviour).
+   * Optional per-key HARD ceiling on retained events (keep the `maxPerKey`
+   * GREATEST). A backstop above the age-based trim below — it bounds pathological
+   * bursts (>`maxPerKey` events within `historyDepthSeconds` on one key, which the
+   * age cutoff alone would not trim). Old events are irrelevant to `sync`/`getNext`
+   * (a syncer matches the NEXT cue after its point) and to `get` (a reader near
+   * "now" reads the retained head), so trimming the oldest is safe. `undefined` ⇒
+   * no ceiling (the age trim, if enabled, is the only bound).
    */
   private readonly maxPerKey?: number
 
-  constructor(opts?: { maxPerKey?: number }) {
+  /**
+   * Desktop-faithful auto-trim (GAP L / #402, IMPLEMENTED) mirroring
+   * `__insert_event!` (event_history.rb:392-399). When `trimHistory` is on, an
+   * insert keeps at least `minHistorySize` events per key and drops any OLDER
+   * than `historyDepthSeconds` behind the newest event on that key (`t` is in
+   * audio seconds, the same unit as desktop's wall-clock `@history_depth`).
+   *
+   * Reader-vt safety: the trim only ever removes the tail (oldest) beyond the
+   * `minHistorySize` most-recent, and only entries more than `historyDepthSeconds`
+   * behind the newest set. A `get`/`sync` reader at its own advancing vt tracks
+   * near the newest set, so it can never out-run the retained window — exactly
+   * desktop's guarantee (it accepts that a reader >32s in the past loses old
+   * events). Defaults match desktop: min 20, depth 32s.
+   */
+  private readonly trimHistory: boolean
+  private readonly minHistorySize: number
+  private readonly historyDepthSeconds: number
+
+  constructor(opts?: {
+    maxPerKey?: number
+    trimHistory?: boolean
+    minHistorySize?: number
+    historyDepthSeconds?: number
+  }) {
     this.maxPerKey = opts?.maxPerKey
+    this.trimHistory = opts?.trimHistory ?? false
+    this.minHistorySize = opts?.minHistorySize ?? 20
+    this.historyDepthSeconds = opts?.historyDepthSeconds ?? 32
   }
 
   /**
    * Record an event for `key`, keeping the per-key list in descending
    * `(t, idPath)` order. Mirrors `__insert_event!` (event_history.rb:385-418):
    * the common case (monotonically advancing virtual time) prepends; a rare
-   * out-of-order arrival is inserted at its sorted position. If `maxPerKey` is
-   * set, the oldest events past the cap are dropped (the tail of the descending
-   * list).
+   * out-of-order arrival is inserted at its sorted position. After insertion the
+   * list is trimmed: the desktop age trim ({@link trimHistory}) then the
+   * `maxPerKey` hard ceiling — both drop the tail (oldest) of the descending list.
    */
   insert(key: string | symbol, t: number, idPath: number[], value: unknown): void {
     const ce: CueEvent = { t, idPath, value }
@@ -187,6 +213,23 @@ export class EventHistory {
     let i = 0
     while (i < events.length && compareEvent(events[i], ce) > 0) i++
     events.splice(i, 0, ce)
+    this.trim(events)
+  }
+
+  /**
+   * Trim a key's descending event list in place: first the desktop-faithful age
+   * trim (keep ≥`minHistorySize`, drop oldest beyond `historyDepthSeconds` behind
+   * the newest), then the `maxPerKey` hard ceiling. `events[0]` is the greatest
+   * (newest) entry, so it is the reference "now" for the age cutoff — mirroring
+   * desktop's `Time.now` since `t` only advances.
+   */
+  private trim(events: CueEvent[]): void {
+    if (this.trimHistory && events.length > this.minHistorySize) {
+      const cutoff = events[0].t - this.historyDepthSeconds
+      while (events.length > this.minHistorySize && events[events.length - 1].t < cutoff) {
+        events.pop()
+      }
+    }
     if (this.maxPerKey !== undefined && events.length > this.maxPerKey) {
       events.length = this.maxPerKey // drop the oldest (tail of the descending list)
     }
@@ -331,6 +374,12 @@ export class EventHistory {
   /** Number of distinct keys (facade parity with the prior TimeState). */
   get size(): number {
     return this.store.size
+  }
+
+  /** Retained event count for one key (0 if never set). Introspection for the
+   *  #402 auto-trim bound; reads cost nothing in the hot path. */
+  eventCount(key: string | symbol): number {
+    return this.store.get(key)?.length ?? 0
   }
 
   /** Clear all events. Dispose-only (SK14) — never on stop/run. */

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -273,7 +273,7 @@ export class SonicPiEngine {
    * adapter). Because they share it, a `get :foo` sees a `cue :foo` and a
    * `sync :foo` wakes on a `set :foo` — the `/{cue,set,live_loop}/foo` read union.
    */
-  private readonly eventHistory = new EventHistory({ maxPerKey: 256 })
+  private readonly eventHistory = new EventHistory({ maxPerKey: 256, trimHistory: true })
   /** set/get facade over {@link eventHistory} with `/set/` write namespacing.
    *  Keeps the prior TimeState `{set,get,size,clear}` shape so the builder,
    *  closures and tests are unchanged. Cleared only on dispose (SK14). */

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -253,7 +253,7 @@ export class VirtualTimeScheduler {
     this.tickInterval = options.tickInterval ?? DEFAULT_TICK_INTERVAL_MS
     // GAP M1c: share the engine's coordination store if injected, else own one.
     this.ownsCueHistory = !options.eventHistory
-    this.cueHistory = options.eventHistory ?? new EventHistory({ maxPerKey: 256 })
+    this.cueHistory = options.eventHistory ?? new EventHistory({ maxPerKey: 256, trimHistory: true })
 
     // Priority: by time, then by insertion order for determinism (SP1)
     // Uses entry.order directly — no Map lookup or string allocation (#75)

--- a/src/engine/__tests__/EventHistoryTrim.test.ts
+++ b/src/engine/__tests__/EventHistoryTrim.test.ts
@@ -64,6 +64,15 @@ describe('EventHistory auto-trim (#402)', () => {
     expect(h.eventCount(KEY)).toBe(64)
   })
 
+  it('a config set ONCE is readable at any far-future vt (the common set-once/read-forever case)', () => {
+    // `set :root, 60` once at t=0, then `get :root` an hour later. A single entry
+    // is below the min floor, so trim never touches it — the read must still hit.
+    const h = new EventHistory(opts)
+    h.insert(KEY, 0, [0], 60)
+    expect(h.eventCount(KEY)).toBe(1)
+    expect(h.getMostRecent(KEY, 3600, [0])?.value).toBe(60)
+  })
+
   it('keeps keys independent — trimming one does not touch another', () => {
     const h = new EventHistory(opts)
     for (let i = 0; i < 100; i++) h.insert('/set/a', i, [0], `a${i}`)

--- a/src/engine/__tests__/EventHistoryTrim.test.ts
+++ b/src/engine/__tests__/EventHistoryTrim.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { EventHistory } from '../EventHistory'
+
+/**
+ * #402 — desktop-faithful auto-trim of per-key history (GAP L).
+ *
+ * Mirrors `__insert_event!`'s trim (event_history.rb:392-399): keep at least
+ * `minHistorySize` events per key, and drop any OLDER than `historyDepthSeconds`
+ * behind the newest event on that key. `t` is in audio seconds — the same unit
+ * as desktop's wall-clock `@history_depth`. The hard `maxPerKey` ceiling bounds
+ * pathological same-window bursts the age cutoff alone would not trim.
+ *
+ * The safety contract (issue #402): trimming must NOT break the "greatest event
+ * ≤ reader-vt" read for an ACTIVE reader. An active reader tracks near the newest
+ * set, so it always reads the retained head — these tests pin that.
+ */
+describe('EventHistory auto-trim (#402)', () => {
+  const KEY = '/set/root'
+  // tiny depth + min so the tests are cheap and the boundary is explicit.
+  const opts = { trimHistory: true, minHistorySize: 4, historyDepthSeconds: 10 }
+
+  it('is unbounded by default (trimHistory off) — preserves prior facade behaviour', () => {
+    const h = new EventHistory()
+    for (let i = 0; i < 100; i++) h.insert(KEY, i, [0], `v${i}`)
+    expect(h.eventCount(KEY)).toBe(100)
+  })
+
+  it('after N≫K sets, the per-key history is bounded AND a reader at the latest vt reads the latest value', () => {
+    const h = new EventHistory(opts)
+    const N = 500
+    for (let i = 0; i < N; i++) h.insert(KEY, i, [0], `v${i}`)
+    // Bounded: with 1s spacing and a 10s window, only events within (newest-10)
+    // survive, never below the min floor.
+    expect(h.eventCount(KEY)).toBeLessThanOrEqual(20)
+    expect(h.eventCount(KEY)).toBeGreaterThanOrEqual(opts.minHistorySize)
+    // The active reader (at the latest vt) still sees the latest value.
+    const latest = h.getMostRecent(KEY, N - 1, [0])
+    expect(latest?.value).toBe(`v${N - 1}`)
+  })
+
+  it('always retains at least minHistorySize even when every event is older than the window', () => {
+    const h = new EventHistory(opts)
+    // Sets spaced 100s apart: every prior event is far past the 10s cutoff, yet
+    // the min floor (4) is held — desktop keeps @min_history_size regardless.
+    for (let i = 0; i < 50; i++) h.insert(KEY, i * 100, [0], `v${i}`)
+    expect(h.eventCount(KEY)).toBe(opts.minHistorySize)
+    // …and the newest is still the head.
+    expect(h.getMostRecent(KEY, 49 * 100, [0])?.value).toBe('v49')
+  })
+
+  it('a reader WITHIN the retained window reads the correct (not just latest) value', () => {
+    const h = new EventHistory({ trimHistory: true, minHistorySize: 2, historyDepthSeconds: 5 })
+    for (let i = 0; i < 100; i++) h.insert(KEY, i, [0], `v${i}`)
+    // Newest is v99 at t=99; window keeps t≥94. A reader at t=96 must read v96,
+    // a value that is NOT the latest — proving in-window reads stay exact.
+    expect(h.getMostRecent(KEY, 96, [0])?.value).toBe('v96')
+  })
+
+  it('the maxPerKey ceiling caps a same-instant burst the age cutoff cannot trim', () => {
+    // 1000 sets all at t=0 (one virtual instant) — none is "older than the
+    // window", so only the hard ceiling bounds them.
+    const h = new EventHistory({ trimHistory: true, minHistorySize: 4, historyDepthSeconds: 10, maxPerKey: 64 })
+    for (let i = 0; i < 1000; i++) h.insert(KEY, 0, [0, i], `v${i}`)
+    expect(h.eventCount(KEY)).toBe(64)
+  })
+
+  it('keeps keys independent — trimming one does not touch another', () => {
+    const h = new EventHistory(opts)
+    for (let i = 0; i < 100; i++) h.insert('/set/a', i, [0], `a${i}`)
+    h.insert('/set/b', 0, [0], 'b0')
+    expect(h.eventCount('/set/b')).toBe(1)
+    expect(h.getMostRecent('/set/b', 0, [0])?.value).toBe('b0')
+  })
+})


### PR DESCRIPTION
## Problem
The shared `EventHistory` backing cross-loop `set`/`get` (and `cue`/`sync` via `TimeStateView`, GAP M) appended per-key entries bounded only by an interim `maxPerKey: 256` count cap — **not desktop's pruning**. A long session with a frequent cross-loop `set :root` retains up to 256 entries/key, diverging from the reference (`event_history.rb:392-399` keeps `@min_history_size = 20` and drops entries older than `@history_depth = 32`s).

> Note: production was already *bounded* at 256/key post-GAP-M (the issue's "unbounded" premise predates that). This PR closes the remaining gap: **reference-faithful pruning** vs the flat count cap.

## Fix
Port desktop's age trim into `EventHistory`:
- New constructor opts `trimHistory` / `minHistorySize` (20) / `historyDepthSeconds` (32).
- On `insert`, after the descending-order splice: keep ≥`minHistorySize`, then pop the tail (oldest) while older than `newest.t − historyDepthSeconds`. `t` is **audio seconds** — the same unit as desktop's wall-clock `@history_depth` — so 32 ports directly.
- `maxPerKey: 256` stays as a **hard ceiling** for same-instant bursts the age cutoff cannot trim.
- Enabled at the two production construction sites (`SonicPiEngine`, `VirtualTimeScheduler` fallback); default **off** elsewhere so existing append-history tests are unchanged.
- The legacy **test-only** `TimeState` class is untouched (production uses `TimeStateView` over the trim-enabled shared store).

## Reader-vt safety (the #402 correctness contract)
The trim only removes the tail beyond the 20 most-recent **and** only entries >32s behind the newest. An active `get`/`sync` reader tracks near the newest set, so it always reads the retained head — desktop's exact guarantee (it accepts that a reader >32s in the past loses old events).

## Verification
`EventHistoryTrim.test.ts` drives 500 real inserts through `insert→trim→read` (direct execution, not inference):
- bounded after N≫K sets **and** reader at latest vt reads latest ✓
- min floor held even when every event is past the window ✓
- **in-window read stays exact** (reads `v96`, not just the latest) ✓
- `maxPerKey` ceiling caps a same-instant burst the age cutoff can't ✓
- key independence ✓

**No audio change** — memory-only prune, no scheduling change; the prune doesn't even trigger in a sub-32s session. **L1:** full suite `1352/1352` (1346 + 6 new) · `tsc --noEmit` clean. Cross-thread regression set (EventHistory / SetWakesParkedSync / TimeState / RubyExamples) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)