### PR TITLE
🎲 feat(engine): per-op consumption parity — shuffle + draw-count edges (EPIC #531 Phase 2)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -1134,7 +1134,10 @@ export class ProgramBuilder {
     const span = rangeSpan(args[0])
     if (span) return this.rng.rrand_i(span.from, span.to)
     const max = (args[0] as number) ?? 2
-    return this.rng.rrand_i(0, max - 1)
+    // Desktop rand_i (lang/core.rb:3208) = rand_i!(max) directly, NOT rrand_i —
+    // so rand_i(1) still draws (rand_i!(1)=0), unlike rrand_i(0,0) which doesn't.
+    if (max === 0) return 0
+    return this.rng.randI(max)
   }
 
   rand_look(): number {
@@ -1146,12 +1149,10 @@ export class ProgramBuilder {
   }
 
   shuffle<T>(arr: T[] | Ring<T>): Ring<T> {
+    // Desktop's derived-seed shuffle (consumes exactly one outer draw), NOT a
+    // plain Fisher-Yates — see SPRand.shuffle (#531 Phase 2).
     const items = arr instanceof Ring ? arr.toArray() : [...arr]
-    for (let i = items.length - 1; i > 0; i--) {
-      const j = this.rng.rrand_i(0, i)
-      ;[items[i], items[j]] = [items[j], items[i]]
-    }
-    return new Ring(items)
+    return new Ring(this.rng.shuffle(items))
   }
 
   /**
@@ -1180,7 +1181,9 @@ export class ProgramBuilder {
   }
 
   dice(sides: number, bonus: number = 0): number {
-    return this.rng.dice(sides) + bonus
+    // Desktop dice (lang/core.rb:3046) = rrand_i(1, sides) — so dice(1) returns 1
+    // WITHOUT a draw (min==max), unlike a direct table read.
+    return this.rng.rrand_i(1, sides) + bonus
   }
 
   one_in(n: number): boolean {

--- a/src/engine/SPRand.ts
+++ b/src/engine/SPRand.ts
@@ -80,24 +80,65 @@ export class SPRand {
     return this.randBang(1)
   }
 
-  /** Random float in [min, max) — `min + rand!(max - min)`. */
-  rrand(min: number, max: number): number {
-    return min + this.randBang(max - min)
+  /** `rand_i!(max)` — `floor(rand!(max))`, one draw (Ruby Float#to_i truncates). */
+  randI(max: number): number {
+    return Math.floor(this.randBang(max))
   }
 
-  /** Random int in [min, max] inclusive. */
+  /**
+   * `rrand(min, max)` — desktop lang/core.rb:3117. Returns min WITHOUT a draw when
+   * `min == max` (the consumption-exact edge a `min + rand!(0)` would get wrong by
+   * drawing); otherwise `min(min,max) + rand!(|min-max|)`. The `|range|` + smallest
+   * form also handles `min > max` like desktop.
+   */
+  rrand(min: number, max: number): number {
+    if (min === max) return min
+    const r = this.randBang(Math.abs(min - max))
+    return Math.min(min, max) + r
+  }
+
+  /** `rrand_i(min, max)` — desktop lang/core.rb:3159. No draw when `min == max`;
+   *  else `min(min,max) + rand_i!(|min-max| + 1)`. */
   rrand_i(min: number, max: number): number {
-    return Math.floor(this.rrand(min, max + 1))
+    if (min === max) return min
+    const r = Math.floor(this.randBang(Math.abs(min - max) + 1))
+    return Math.min(min, max) + r
   }
 
   /** Random element from an array (`arr[rand_i!(len)]`). */
   choose<T>(arr: T[]): T {
-    return arr[Math.floor(this.randBang(arr.length))]
+    return arr[this.randI(arr.length)]
   }
 
-  /** Random integer in [1, sides]. */
-  dice(sides: number): number {
-    return Math.floor(this.randBang(sides)) + 1
+  /**
+   * `Array#shuffle` — desktop's SPRand override (sprand_core.rb:1083-1100), NOT a
+   * plain Fisher-Yates. It derives a fresh seed from ONE outer draw, runs `s`
+   * random-swap iterations on that DERIVED stream, then restores the outer stream
+   * advanced by EXACTLY ONE. So shuffle consumes exactly one value from the
+   * caller's stream regardless of list size — the property a plain Fisher-Yates
+   * (which consumes `s` draws) breaks, misaligning every subsequent rand.
+   * Returns a new array; the input is not mutated.
+   */
+  shuffle<T>(arr: readonly T[]): T[] {
+    const origSeed = this.seed
+    const origIdx = this.idx
+    // rand_i!(441000): one outer draw → the derived shuffle seed.
+    const derived = Math.floor(this.randBang(RAND_STREAM_LENGTH))
+    this.seed = derived
+    this.idx = 0
+    const a = arr.slice()
+    const s = a.length
+    for (let k = 0; k < s; k++) {
+      const ia = Math.floor(this.randBang(s))
+      const ib = Math.floor(this.randBang(s))
+      const tmp = a[ia]
+      a[ia] = a[ib]
+      a[ib] = tmp
+    }
+    // Restore the outer stream, advanced by exactly one (set_seed!(orig, idx+1)).
+    this.seed = origSeed
+    this.idx = origIdx + 1
+    return a
   }
 
   /** `use_random_seed s` / `set_seed!(s)` — set seed, reset idx to 0. */

--- a/src/engine/__tests__/SPRandOps.test.ts
+++ b/src/engine/__tests__/SPRandOps.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { ProgramBuilder } from '../ProgramBuilder'
+
+/**
+ * EPIC #531 Phase 2 — every random op consumes the frozen stream exactly like
+ * desktop (value AND draw count). Verified at the top-level builder, which
+ * respects use_random_seed today (loop-body seeding is Phase 3).
+ *
+ * Golden values are hand-computed from rand-stream.wav after use_random_seed 0:
+ *   table[1..7] = 0.75006103515625, 0.733917236328125, 0.464202880859375,
+ *                 0.24249267578125, 0.10821533203125, 0.54010009765625,
+ *                 0.822113037109375
+ * Each draw reads table[seed+idx+1] then advances idx (the +1 lookahead).
+ * Draw-COUNT exactness matters most: one extra/missing draw misaligns every
+ * subsequent random, so the "no-draw" edges (min==max) are tested explicitly.
+ */
+const T1 = 0.75006103515625
+const T2 = 0.733917236328125
+
+const seeded = () => {
+  const b = new ProgramBuilder()
+  b.use_random_seed(0)
+  return b
+}
+
+describe('SPRand op values match desktop (#531 Phase 2)', () => {
+  it('rand() / rand(max) = table[1] * max', () => {
+    expect(seeded().rand()).toBe(T1)
+    expect(seeded().rand(12)).toBe(T1 * 12)
+  })
+
+  it('rand_i(max) = floor(table[1] * max) — and rand_i(1) DRAWS (= 0)', () => {
+    expect(seeded().rand_i(12)).toBe(9)
+    expect(seeded().rand_i(1)).toBe(0) // rand_i!(1) = floor(0.75) = 0, one draw
+  })
+
+  it('rrand(min,max) = min + table[1]*(max-min)', () => {
+    expect(seeded().rrand(10, 20)).toBe(10 + T1 * 10)
+  })
+
+  it('rrand_i(min,max) = min + floor(table[1]*(range+1))', () => {
+    expect(seeded().rrand_i(0, 9)).toBe(7) // floor(0.75006*10)=7
+  })
+
+  it('dice(6) = rrand_i(1,6) = 5', () => {
+    expect(seeded().dice(6)).toBe(5) // 1 + floor(0.75006*6) = 1+4
+  })
+
+  it('choose picks arr[rand_i!(len)]', () => {
+    expect(seeded().choose(Array.from({ length: 10 }, (_, i) => i))).toBe(7)
+  })
+
+  it('rdist(width,centre) = rrand(centre-width, centre+width)', () => {
+    expect(seeded().rdist(1, 0)).toBe(-1 + T1 * 2) // 0.5001220703125
+  })
+
+  it('rand_look peeks the next value without consuming', () => {
+    const b = seeded()
+    expect(b.rand_look()).toBe(T1)
+    expect(b.rand()).toBe(T1) // same value then consumed
+  })
+})
+
+describe('SPRand draw-count exactness — the no-draw edges (#531 Phase 2)', () => {
+  it('rrand(x,x) returns x WITHOUT consuming a draw', () => {
+    const b = seeded()
+    expect(b.rrand(5, 5)).toBe(5)
+    expect(b.rand()).toBe(T1) // stream untouched ⇒ still table[1]
+  })
+
+  it('dice(1) returns 1 WITHOUT consuming (rrand_i(1,1))', () => {
+    const b = seeded()
+    expect(b.dice(1)).toBe(1)
+    expect(b.rand()).toBe(T1)
+  })
+
+  it('rand_i(1) DOES consume (rand_i! always draws)', () => {
+    const b = seeded()
+    expect(b.rand_i(1)).toBe(0)
+    expect(b.rand()).toBe(T2) // advanced ⇒ table[2]
+  })
+})
+
+describe('shuffle — desktop derived-seed algorithm (#531 Phase 2)', () => {
+  it('consumes EXACTLY ONE outer draw regardless of list size', () => {
+    const b = seeded()
+    expect(b.current_random_seed()).toBe(0)
+    b.shuffle([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(b.current_random_seed()).toBe(1) // seed 0 + idx 1, not + list size
+  })
+
+  it('after shuffle, the next rand reads table[2] (outer advanced by one)', () => {
+    const b = seeded()
+    b.shuffle([10, 20, 30, 40, 50])
+    expect(b.rand()).toBe(T2)
+  })
+
+  it('is a permutation of the input (same elements, length preserved)', () => {
+    const out = seeded().shuffle([1, 2, 3, 4, 5]).toArray()
+    expect([...out].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('is deterministic — same seed ⇒ same order', () => {
+    expect(seeded().shuffle([1, 2, 3, 4, 5, 6]).toArray()).toEqual(
+      seeded().shuffle([1, 2, 3, 4, 5, 6]).toArray(),
+    )
+  })
+})


### PR DESCRIPTION
Part of **#531** (PRNG parity). Phase 2 = make every random op consume the frozen stream exactly like desktop (value **and** draw count).

## What already matched (Phase 1)
The SPRand primitives made `rand`, `rand_i`, `rrand`, `rrand_i`, `choose`, `rdist`, `one_in` match desktop on both value and 1-draw consumption. Phase 2 fixes the ones that didn't, grounded in `lang/core.rb` + `sprand_core.rb`.

## Fixes
- **`shuffle`** — was a plain Fisher-Yates consuming **N** draws on the caller's stream. Desktop (`sprand_core.rb:1083-1100`) derives a fresh seed from **one** outer draw, shuffles on that derived stream, then restores the outer stream advanced by exactly one → shuffle consumes **exactly 1** value regardless of list size. A wrong draw-count here misaligns *every* subsequent random. Ported to `SPRand.shuffle`.
- **`rrand` / `rrand_i`** — now return `min` with **no draw** when `min == max` (desktop early-return), and use `|range| + smallest` so `min > max` matches too. Also fixes `rdist(0,…)` and any `rrand(x,x)` from consuming a spurious draw.
- **`rand_i(max)`** routed through `rand_i!` (always draws — `rand_i(1)=0`) instead of `rrand_i(0,max-1)` (no draw at `max==1`). **`dice(n)`** routed through `rrand_i(1,n)` so `dice(1)=1` without a draw.

## Verification
`SPRandOps.test.ts` golden-locks every op against hand-computed `rand-stream.wav` values after `use_random_seed 0`, plus:
- the **no-draw edges**: `rrand(x,x)` and `dice(1)` leave the stream untouched (next `rand` still reads `table[1]`); `rand_i(1)` advances it (next `rand` reads `table[2]`).
- shuffle's **exactly-one-outer-draw** invariant, determinism, and permutation.

15 new tests, **1388/1388** suite, `tsc --noEmit` clean. No blast radius (existing shuffle tests are property-based).

## Scope
End-to-end loop-body parity still awaits **Phase 3** (replace the name-hash `loopSeeds` with desktop's stream-derived child seeding + `use_random_seed` propagation). Shuffle's exact *order* parity is verified-by-construction (faithful port) + the consumption invariant; full order A/B is Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)