### PR TITLE
🎲 PRNG parity Phase 3: stream-derived loop/thread seeding — live_loop respects use_random_seed (EPIC #531)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -121,6 +121,15 @@ export class ProgramBuilder {
   // anywhere the no-op can occur, not just the top level.
   private _warnHandler?: (name: string) => void
 
+  /**
+   * EPIC #531 Phase 3: per-thread spawn counter — desktop's
+   * `:sonic_pi_spider_new_thread_random_gen_idx` (runtime.rb:1062-1064). Each
+   * child thread forked from this builder reads the next gen_idx position, so
+   * sibling threads (live_loops) get DIFFERENT deterministic streams. Reset to 0
+   * by `use_random_seed` (matches desktop core.rb:3415).
+   */
+  private newThreadGenIdx = 0
+
   constructor(seed: number = 0, initialTicks?: Map<string, number>) {
     // EPIC #531: index desktop's shared frozen rand stream (loaded at boot),
     // not a per-builder MT19937. getWhiteRandStream() throws if boot didn't load
@@ -333,6 +342,37 @@ export class ProgramBuilder {
 
   use_random_seed(seed: number): this {
     this.rng.reset(seed)
+    // EPIC #531 Phase 3: desktop's use_random_seed resets the per-thread spawn
+    // counter to 0 (core.rb:3415) so re-running re-derives the SAME child seeds.
+    this.newThreadGenIdx = 0
+    return this
+  }
+
+  /**
+   * EPIC #531 Phase 3: derive a forked sub-thread's child seed and advance this
+   * thread's spawn counter (desktop runtime.rb:1062-1064). Each call reads the
+   * next gen_idx position from the parent stream, so sibling threads (sibling
+   * live_loops / in_threads) fork DIFFERENT deterministic streams.
+   */
+  deriveChildSeed(): number {
+    const seed = this.rng.deriveChildSeed(this.newThreadGenIdx)
+    this.newThreadGenIdx++
+    return seed
+  }
+
+  /**
+   * EPIC #531 Phase 3: snapshot the rand (seed, idx) so a live_loop's stream
+   * PERSISTS and advances continuously across iterations — desktop's live_loop is
+   * one thread with one stream (it does NOT re-seed per iteration). The engine
+   * restores this before each iteration's build and saves it after.
+   */
+  getRandomState(): { seed: number; idx: number } {
+    return this.rng.getState()
+  }
+
+  /** EPIC #531 Phase 3: restore a (seed, idx) snapshot (see getRandomState). */
+  setRandomState(state: { seed: number; idx: number }): this {
+    this.rng.setState(state)
     return this
   }
 
@@ -643,12 +683,11 @@ export class ProgramBuilder {
    *    (runtime.rb:1062-1067 only re-seeds on a new thread).
    */
   private forkBuilder(mode: 'same-thread' | 'forked'): ProgramBuilder {
-    // 'forked' re-seeds the rng from the parent stream (deterministic fork);
-    // 'same-thread' shares the parent rng instance (set below) so the seed
-    // here is irrelevant and must NOT consume from the parent stream.
-    const inner = mode === 'forked'
-      ? new ProgramBuilder(this.rng.next() * 0xFFFFFFFF)
-      : new ProgramBuilder()
+    // Both modes start with a default rng; the seed is set below per mode
+    // ('forked' → desktop child-seed derivation; 'same-thread' → shares the
+    // parent rng instance). The constructor seed must NOT consume from the
+    // parent stream.
+    const inner = new ProgramBuilder()
     // Common — inherited by every sub-builder regardless of mode.
     inner.currentSynth = this.currentSynth
     inner.densityFactor = this.densityFactor
@@ -686,9 +725,17 @@ export class ProgramBuilder {
       // with_fx forks no thread: tick map AND random stream continue. Sharing
       // the tick Map by reference is the #340/#341 fix; sharing the rng
       // instance is its seed-fork analog (#343 Defect C). 'forked' leaves
-      // inner.ticks a fresh Map and inner.rng the re-seeded generator.
+      // inner.ticks a fresh Map and gets a desktop-derived child stream below.
       inner.ticks = this.ticks
       inner.rng = this.rng
+    } else {
+      // EPIC #531 Phase 3: a forked thread (in_thread / at) gets its OWN stream
+      // derived from the parent at fork — desktop runtime.rb:1062-1067:
+      // child_seed = rand!(441000, gen_idx) + parent_seed, gen_idx++ per spawn.
+      // Replaces the old `rng.next()*0xFFFFFFFF` which both CONSUMED a parent
+      // draw (desktop's explicit-idx peek does not) and produced a non-desktop
+      // seed. idx 0 so the child stream starts at its seed position.
+      inner.rng.setState({ seed: this.deriveChildSeed(), idx: 0 })
     }
     return inner
   }

--- a/src/engine/SPRand.ts
+++ b/src/engine/SPRand.ts
@@ -148,6 +148,24 @@ export class SPRand {
   }
 
   /**
+   * Derive a forked child thread's seed (EPIC #531 Phase 3). Desktop forks every
+   * spider thread (live_loop / in_thread / at) with its OWN deterministic stream
+   * derived from the PARENT's stream at spawn (runtime.rb:1062-1067):
+   *   new_rand_seed = SPRand.rand!(441000, gen_idx)   # explicit idx ⇒ NO consume
+   *   child_seed    = new_rand_seed + SPRand.get_seed  # + parent seed
+   * The EXPLICIT `gen_idx` makes the lookup a peek at the fixed position
+   * `(parent_seed + gen_idx + 1)`, so the derivation does NOT advance the parent
+   * stream and is independent of how many draws the parent already made — only
+   * the parent SEED and the spawn-order `gen_idx` matter. `gen_idx` increments per
+   * spawn (the caller advances it), so sibling threads get DIFFERENT streams.
+   * The result is a FLOAT; randPeek floors the table position, so a float seed
+   * indexes correctly downstream.
+   */
+  deriveChildSeed(genIdx: number): number {
+    return this.randPeek(RAND_STREAM_LENGTH, genIdx) + this.seed
+  }
+
+  /**
    * `current_random_seed` = `get_seed_plus_idx` = seed + idx (the position the
    * next draw resolves from, modulo the +1 lookahead).
    */

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -168,8 +168,15 @@ export class SonicPiEngine {
   // S1/S2 bodies stay synchronous; `await` on their void return is identity, and
   // the QueryInterpreter path (capture, S1/S2 only) ignores the return value.
   private loopBuilders = new Map<string, (b: ProgramBuilder) => void | Promise<void>>()
-  /** Per-loop seed counters for deterministic random */
-  private loopSeeds = new Map<string, number>()
+  /**
+   * Per-loop random stream state — EPIC #531 Phase 3. Replaces the old name-hash
+   * `loopSeeds`. The loop's child seed is derived ONCE at registration from the
+   * top-level stream (desktop's per-thread fork seeding, runtime.rb:1062-1067);
+   * the (seed, idx) then PERSISTS and advances across iterations so a live_loop's
+   * `rand` is one continuous stream — desktop semantics (live_loop is one thread,
+   * one stream). Cleared/derived on the same lifecycle as loopTicks.
+   */
+  private loopRngState = new Map<string, { seed: number; idx: number }>()
   /** Per-loop tick counters — persisted across iterations so ring.tick() advances correctly */
   private loopTicks = new Map<string, Map<string, number>>()
   /** Per-loop beat counter — persisted across iterations so current_beat keeps growing (#226) */
@@ -588,7 +595,7 @@ export class SonicPiEngine {
         })
 
         this.loopBuilders.clear()
-        this.loopSeeds.clear()
+        this.loopRngState.clear()
       }
 
       // Transpile: Ruby DSL → JS builder chain (TreeSitter only).
@@ -890,14 +897,21 @@ export class SonicPiEngine {
 
         // Store builder function for capture path
         this.loopBuilders.set(name, builderFn)
-        if (!this.loopSeeds.has(name)) {
-          // Seed derived from loop name — each loop gets a unique PRNG sequence
-          // (matches desktop Sonic Pi's per-loop deterministic seeding)
-          let hash = 0
-          for (let i = 0; i < name.length; i++) {
-            hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0
-          }
-          this.loopSeeds.set(name, Math.abs(hash))
+        if (!this.loopRngState.has(name)) {
+          // EPIC #531 Phase 3: derive this loop's child random seed from the
+          // top-level stream, exactly as desktop forks a spider thread's seed
+          // from its parent (runtime.rb:1062-1067):
+          //   child_seed = SPRand.rand!(441000, gen_idx) + parent_seed
+          // with gen_idx incremented per spawn (sibling loops → different
+          // streams). The parent (topLevelBuilder) already carries the user's
+          // use_random_seed value — `use_random_seed` is a TOP_LEVEL_SETTING, so
+          // the eager top-level seed runs BEFORE any loop registers here. This
+          // REPLACES the old name-hash seed, which ignored use_random_seed and
+          // never matched desktop (SP140 / the Phase-3 E2E unlock). Derived once
+          // at registration; persists across iterations (continuous stream) and
+          // across hot-swaps (a running loop keeps its stream, like desktop).
+          const childSeed = topLevelBuilder.deriveChildSeed()
+          this.loopRngState.set(name, { seed: childSeed, idx: 0 })
         }
 
         // Create the async function that builds a Program each iteration
@@ -974,10 +988,13 @@ export class SonicPiEngine {
             }
           }
 
-          const seed = this.loopSeeds.get(name) ?? 0
-          this.loopSeeds.set(name, seed + 1)
-
-          const builder = new ProgramBuilder(seed, this.loopTicks.get(name))
+          // EPIC #531 Phase 3: restore this loop's persistent random stream so it
+          // advances CONTINUOUSLY across iterations (desktop live_loop = one
+          // thread, one stream — no per-iteration re-seed). Saved back after the
+          // build (below). Replaces the old per-iteration `seed++` scheme.
+          const rngState = this.loopRngState.get(name) ?? { seed: 0, idx: 0 }
+          const builder = new ProgramBuilder(0, this.loopTicks.get(name))
+          builder.setRandomState(rngState)
           // #513: loop bodies that call sample_duration / use_sample_bpm need the
           // real decoded buffer length, not the stub.
           builder.setSampleDurationProvider(this.sampleDurationLookup)
@@ -1098,6 +1115,10 @@ export class SonicPiEngine {
           this.loopTicks.set(name, builder.getTicks())
           // Persist beat counter so current_beat keeps advancing across iterations (#226)
           this.loopBeats.set(name, builder.currentBeatRaw)
+          // EPIC #531 Phase 3: persist the random (seed, idx) so the loop's stream
+          // continues from where this iteration left off (desktop one-stream-per-
+          // thread). Saved AFTER builderFn so it captures every draw this iteration.
+          this.loopRngState.set(name, builder.getRandomState())
           const program = builder.build()
 
           await runProgram(program, {
@@ -1995,12 +2016,12 @@ export class SonicPiEngine {
         //   - loopSynced.has(name) → true → restored loop SKIPS waiting for
         //     its `sync:` target → starts at registerLoop's getAudioTime()
         //     instead of the next met1 cue → music drifts out of phase.
-        //   - loopTicks/loopBeats/loopSeeds → tick state resumes from where
+        //   - loopTicks/loopBeats/loopRngState → tick state resumes from where
         //     it left off pre-removal → wrong notes from .tick/.shuffle/etc.
         //   - loopBuilders → stale closure could be re-invoked from edge paths.
         for (const name of removedLoops) {
           this.loopBuilders.delete(name)
-          this.loopSeeds.delete(name)
+          this.loopRngState.delete(name)
           this.loopTicks.delete(name)
           this.loopBeats.delete(name)
           this.loopSynced.delete(name)
@@ -2272,7 +2293,7 @@ export class SonicPiEngine {
     this.scheduler?.dispose()
     this.scheduler = null
     this.loopBuilders.clear()
-    this.loopSeeds.clear()
+    this.loopRngState.clear()
     this.loopTicks.clear()
     this.loopBeats.clear()
     this.loopSynced.clear()
@@ -2343,7 +2364,7 @@ export class SonicPiEngine {
     this.initialized = false
     this.currentStratum = Stratum.S3  // Reset to S3 so capture is unavailable
     this.loopBuilders.clear()
-    this.loopSeeds.clear()
+    this.loopRngState.clear()
     this.globalStore.clear()
     this.definedFns.clear()
     this.defonceCache.clear()

--- a/src/engine/__tests__/PrngLoopSeeding.test.ts
+++ b/src/engine/__tests__/PrngLoopSeeding.test.ts
@@ -1,0 +1,177 @@
+/**
+ * EPIC #531 Phase 3 — loop/thread random seeding parity (the E2E unlock).
+ *
+ * Phases 1+2 made random VALUES and per-op draw COUNTS match desktop at the
+ * builder level, but NO real piece matched end-to-end: a live_loop's `rand`
+ * ignored `use_random_seed` entirely. Loop builders were seeded from a HASH OF
+ * THE LOOP NAME (the old `loopSeeds`), so `rand` inside any live_loop read a
+ * name-derived position, not desktop's stream-derived child seed.
+ *
+ * Phase 3 replaces that with desktop's per-thread fork seeding
+ * (runtime.rb:1062-1067): each spider thread (live_loop / in_thread) gets its OWN
+ * stream derived from the parent at spawn:
+ *   child_seed = SPRand.rand!(441000, gen_idx) + parent_seed   (gen_idx++ per spawn)
+ * and the loop's stream then ADVANCES CONTINUOUSLY across iterations (desktop
+ * live_loop is one thread = one stream — it does NOT re-seed per iteration).
+ *
+ * THE METHOD (SP140 lesson): a DIRECT `new ProgramBuilder(); b.rand()` test
+ * PASSES while the real pipeline is WRONG, because it bypasses transpile +
+ * evaluate + loop-registration seeding. So every assertion below drives the FULL
+ * pipeline (engine.evaluate → play → scheduler ticks → captured `puts`).
+ *
+ * GROUND TRUTH: the expected values are computed from desktop's exact arithmetic
+ * over desktop's exact frozen table (public/rand-stream.wav — the same wav
+ * desktop ships). For `use_random_seed 0`, parent_seed=0, the first live_loop
+ * (gen_idx 0) forks child_seed = table[1]*441000 = 330776.9165, whose stream
+ * reads table[330777], table[330778], … :
+ *   0.9287109375, 0.1043701171875, 0.7489013671875, 0.093414306640625, …
+ * The second sibling (gen_idx 1) forks child_seed = table[2]*441000 = 323657.50,
+ * first rand = 0.957244873046875. Verified independently against the raw wav.
+ * (Desktop SP A/B is the Level-3 check; these ARE desktop's values by
+ * construction — identical table, identical arithmetic.)
+ */
+import { describe, it, expect } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+import { SPRand } from '../SPRand'
+import { RAND_STREAM_LENGTH } from '../RandStream'
+
+async function flush(n = 8): Promise<void> {
+  for (let i = 0; i < n; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+type Sched = { tick: (t: number) => void }
+
+/** Drive code through the full engine pipeline, capturing numeric `puts` lines. */
+async function runAndCapture(code: string, iterations = 8): Promise<string[]> {
+  const engine = new SonicPiEngine()
+  await engine.init()
+  const printed: string[] = []
+  engine.setPrintHandler((m) => printed.push(m))
+  await engine.evaluate(code)
+  const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+  engine.play()
+  for (let i = 0; i < iterations; i++) {
+    scheduler.tick(20)
+    await flush()
+  }
+  engine.dispose()
+  return printed
+}
+
+// Desktop ground truth for `use_random_seed 0`, first live_loop (gen_idx 0).
+const FOO_SEED0 = [
+  '0.9287109375',
+  '0.1043701171875',
+  '0.7489013671875',
+  '0.093414306640625',
+  '0.03045654296875',
+]
+// Second sibling live_loop (gen_idx 1) — a DIFFERENT derived stream.
+const BAR_SEED0_FIRST = '0.957244873046875'
+
+describe('EPIC #531 Phase 3 — live_loop rand respects use_random_seed (E2E pipeline)', () => {
+  it('a live_loop rand stream matches desktop after use_random_seed 0', async () => {
+    const printed = await runAndCapture(`use_random_seed 0
+live_loop :foo do
+  puts rand
+  sleep 1
+end`)
+    const nums = printed.filter((m) => /^[0-9.]/.test(m))
+    expect(nums.slice(0, FOO_SEED0.length)).toEqual(FOO_SEED0)
+  })
+
+  it('the loop stream ADVANCES continuously across iterations (no per-iteration re-seed)', async () => {
+    const printed = await runAndCapture(`use_random_seed 0
+live_loop :foo do
+  puts rand
+  sleep 1
+end`)
+    const nums = printed.filter((m) => /^[0-9.]/.test(m))
+    // Distinct values per iteration — a per-iteration re-seed would repeat or
+    // shift-by-one, not produce desktop's continuous sequence.
+    expect(new Set(nums.slice(0, 5)).size).toBe(5)
+    expect(nums[1]).not.toBe(nums[0])
+  })
+
+  it('sibling live_loops fork DIFFERENT deterministic streams (gen_idx per spawn)', async () => {
+    const printed = await runAndCapture(`use_random_seed 0
+live_loop :foo do
+  puts "foo " + rand.to_s
+  sleep 1
+end
+live_loop :bar do
+  puts "bar " + rand.to_s
+  sleep 1
+end`, 4)
+    const foo = printed.filter((m) => m.startsWith('foo ')).map((m) => m.slice(4))
+    const bar = printed.filter((m) => m.startsWith('bar ')).map((m) => m.slice(4))
+    expect(foo[0]).toBe(FOO_SEED0[0])
+    expect(bar[0]).toBe(BAR_SEED0_FIRST)
+    expect(bar[0]).not.toBe(foo[0]) // siblings diverge
+  })
+
+  it('no use_random_seed defaults to seed 0 (desktop default)', async () => {
+    const printed = await runAndCapture(`live_loop :foo do
+  puts rand
+  sleep 1
+end`)
+    const nums = printed.filter((m) => /^[0-9.]/.test(m))
+    expect(nums.slice(0, FOO_SEED0.length)).toEqual(FOO_SEED0)
+  })
+
+  it('re-running re-derives the SAME stream (deterministic across Runs)', async () => {
+    const code = `use_random_seed 0
+live_loop :foo do
+  puts rand
+  sleep 1
+end`
+    const a = (await runAndCapture(code)).filter((m) => /^[0-9.]/.test(m))
+    const b = (await runAndCapture(code)).filter((m) => /^[0-9.]/.test(m))
+    expect(b.slice(0, 5)).toEqual(a.slice(0, 5))
+  })
+
+  it('a different seed yields a DIFFERENT loop stream', async () => {
+    const s0 = (await runAndCapture(`use_random_seed 0
+live_loop :foo do
+  puts rand
+  sleep 1
+end`)).filter((m) => /^[0-9.]/.test(m))
+    const s1 = (await runAndCapture(`use_random_seed 1
+live_loop :foo do
+  puts rand
+  sleep 1
+end`)).filter((m) => /^[0-9.]/.test(m))
+    expect(s1[0]).not.toBe(s0[0])
+  })
+})
+
+describe('EPIC #531 Phase 3 — SPRand.deriveChildSeed mechanics (synthetic table)', () => {
+  // Synthetic ramp table: table[i] = i / N, so table[k]*N == k exactly — makes
+  // the arithmetic checkable by hand independent of the real wav.
+  const N = RAND_STREAM_LENGTH
+  const ramp = new Float64Array(N)
+  for (let i = 0; i < N; i++) ramp[i] = i / N
+
+  it('derives child_seed = table[(seed+genIdx+1)%N]*N + seed (runtime.rb:1062)', () => {
+    const r = new SPRand(ramp, 0)
+    // genIdx 0, seed 0 → table[1]*N + 0 == 1
+    expect(r.deriveChildSeed(0)).toBe(1)
+    // genIdx 1 → table[2]*N == 2 ; genIdx 5 → 6
+    expect(r.deriveChildSeed(1)).toBe(2)
+    expect(r.deriveChildSeed(5)).toBe(6)
+  })
+
+  it('a non-zero parent seed offsets the derivation by seed', () => {
+    const r = new SPRand(ramp, 100)
+    // table[(100+0+1)%N]*N + 100 == 101 + 100 == 201
+    expect(r.deriveChildSeed(0)).toBe(201)
+  })
+
+  it('does NOT consume the parent stream (explicit-idx peek, no idx advance)', () => {
+    const r = new SPRand(ramp, 0)
+    const before = r.getState()
+    r.deriveChildSeed(0)
+    r.deriveChildSeed(3)
+    expect(r.getState()).toEqual(before) // seed + idx unchanged
+  })
+})


### PR DESCRIPTION
## EPIC #531 Phase 3 — the E2E unlock

Phases 1 (SPRand generator) + 2 (per-op consumption) made random **values** and draw **counts** match desktop at the *builder* level — but no real piece matched end-to-end, because **a live_loop's `rand` ignored `use_random_seed` entirely.**

### The bug (grounded)
Loop builders were seeded from a **hash of the loop name** (the old `loopSeeds`), and each iteration re-seeded with `seed++`. So `rand` inside any live_loop read a name-derived table position that never matched desktop and never changed when the user set a seed. This was pre-existing (the old MT `SeededRandom` had the same gap) and invisible — no test ever compared the **transpiled-pipeline** `rand` vs desktop (SP140).

### The fix — port desktop's per-thread fork seeding (`runtime.rb:1062-1067`)
Each spider thread (live_loop / in_thread / at) forks its **own** stream from the parent at spawn:

```
child_seed = SPRand.rand!(441000, gen_idx) + parent_seed   # gen_idx++ per spawn
```

The explicit `gen_idx` makes the lookup a **peek** (no parent-stream consume), independent of the parent's draws; `gen_idx` increments per spawn so sibling loops get different streams. The loop's `(seed, idx)` then **persists and advances continuously across iterations** — desktop's live_loop is one thread = one stream, not a per-iteration re-seed.

- **`SPRand.deriveChildSeed(genIdx)`** — `table[(seed+genIdx+1)%N]*N + seed`.
- **`ProgramBuilder`** — `newThreadGenIdx` counter (reset by `use_random_seed`, matching `core.rb:3415`); `deriveChildSeed()`; `get/setRandomState()`; `forkBuilder('forked')` now derives the child seed instead of `rng.next()*0xFFFFFFFF` (which both consumed a parent draw and produced a non-desktop seed).
- **`SonicPiEngine`** — `loopSeeds` name-hash → `loopRngState`. Child seed derived once at registration from `topLevelBuilder` (which already carries the eager `TOP_LEVEL_SETTINGS` `use_random_seed`); restored before each iteration, saved after. Same lifecycle (clear/delete) as `loopTicks`.

## Verification — all 3 levels, real pipeline (SP140 method: never a direct builder call)

**L1 — full pipeline** (`PrngLoopSeeding.test.ts`, +9 tests): captured `use_random_seed 0; live_loop :foo { puts rand }` through transpile→evaluate→play prints
`0.9287109375, 0.1043701171875, 0.7489013671875, 0.093414306640625, …` — exactly desktop's stream (computed from the shipped `rand-stream.wav`). Sibling `:bar` (gen_idx 1) forks a different stream (`0.957244…`).

**L2 — real browser** (`tools/capture.ts`, Chromium, real `/rand-stream.wav` + AudioWorklet): the live_loop prints the **identical** sequence. (Pre-fix the browser printed `0.0903` — the name-hash.)

**L3 — desktop A/B** (running desktop Sonic Pi v4.6, `compare-desktop-vs-web.ts`): `use_random_seed 0; live_loop { play choose([60,64,67,72]) }` — **all 24 notes identical**:
```
web:     72,60,67,60,60,60,64,72,72,64,60,64,72,64,72,67,64,67,60,64,72,72,72,60
desktop: 72,60,67,60,60,60,64,72,72,64,60,64,72,64,72,67,64,67,60,64,72,72,72,60
```
A seeded live_loop now plays the same random sequence as desktop, note-for-note.

> The A/B tool still prints the stale "PRNG-VARIANT — not a v1 goal" verdict — it never actually compared seeds. Flipping that default + closing #369 is **Phase 5** (full sweep).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — **1397/1397** (+9)
- [x] L2 browser capture = desktop stream
- [x] L3 desktop A/B — 24/24 notes match

Part of EPIC #531. Next: Phase 4 (pink/perlin distributions) → Phase 5 (E2E sweep + flip SV49 + close #369).