### PR TITLE
🎲 fix(prng): clear the real PRNG random-walk divergers (#540/#541/#542)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -613,8 +613,20 @@ export class ProgramBuilder {
     // stream continue through it (#340/#341 + #343 Defect C). forkBuilder is
     // the single source of truth for sub-builder state threading.
     const inner = this.forkBuilder('same-thread')
-    fn(inner, fxRef)
-    const fxOpts = !this._argBpmScaling ? { ...opts, _argBpmScaling: 0 } : opts
+    // `with_fx :x, reps: N` re-runs the BLOCK N times inside ONE FX scope,
+    // re-executing the body each pass (desktop sound.rb). Unroll at BUILD time —
+    // running the buildFn N times on the same-thread sub-builder — so each rep
+    // re-evaluates its random draws (rrand/choose) on the continuing stream.
+    // Replaying a pre-built body (the interpreter's old reps loop) froze the
+    // first rep's draws and desynced PRNG pieces (#537 lorezzed: every krush
+    // rep reused one release/pan/sleep draw); QueryInterpreter also ignored reps,
+    // so audio/query disagreed. Unrolling fixes both. `reps` is then stripped so
+    // the interpreter runs the (already N-long) body exactly once.
+    const repsRaw = typeof opts.reps === 'number' ? opts.reps : 1
+    const reps = repsRaw > 1 ? Math.floor(repsRaw) : 1
+    for (let r = 0; r < reps; r++) fn(inner, fxRef)
+    const { reps: _droppedReps, ...optsNoReps } = opts
+    const fxOpts = !this._argBpmScaling ? { ...optsNoReps, _argBpmScaling: 0 } : optsNoReps
     this.steps.push({ tag: 'fx', name, opts: fxOpts, body: inner.build(), nodeRef: fxRef })
     return this
   }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -2919,31 +2919,38 @@ function transpileSynthCommand(argsNode: any, ctx: TranspileContext): string {
 // Control flow transpilers
 // ---------------------------------------------------------------------------
 
+// `if` and `elsif` nodes share the shape [condition, then-body?, (elsif|else)?].
+// tree-sitter-ruby NESTS the trailing `elsif`/`else` INSIDE the preceding
+// `elsif` node, so the chain must be walked recursively. A flat loop over the
+// top `if`'s children only ever reaches the FIRST `elsif` and silently drops
+// everything after it (a 2nd `elsif`, or the final `else`) — losing both
+// audible events AND random draws (desyncing the PRNG stream from desktop). #537.
 function transpileIf(node: any, ctx: TranspileContext): string {
   const children = node.namedChildren
   const condition = children[0]
-  const consequence = children[1]
 
   let result = `if (${transpileNode(condition, ctx)}) {\n`
-  if (consequence) result += transpileNode(consequence, ctx) + '\n'
-  result += ctx.indent + '}'
-
-  // Handle elsif/else
-  for (let i = 2; i < children.length; i++) {
+  let tail = ''
+  for (let i = 1; i < children.length; i++) {
     const child = children[i]
     if (child.type === 'elsif') {
-      const elsifCond = child.namedChildren[0]
-      const elsifBody = child.namedChildren[1]
-      result += ` else if (${transpileNode(elsifCond, ctx)}) {\n`
-      if (elsifBody) result += transpileNode(elsifBody, ctx) + '\n'
-      result += ctx.indent + '}'
+      // Recurse: the elsif carries its own then-body AND the rest of the chain.
+      tail += ` else ${transpileIf(child, ctx)}`
     } else if (child.type === 'else') {
-      const elseBody = child.namedChildren[0]
-      result += ` else {\n`
-      if (elseBody) result += transpileNode(elseBody, ctx) + '\n'
-      result += ctx.indent + '}'
+      tail += ` else {\n`
+      // The `else` node is a wrapper containing ALL its statements directly
+      // (unlike the consequence, which is `then`-wrapped). Grab every child,
+      // not just the first — `namedChildren[0]` dropped all but the first stmt.
+      const elseBody = transpileChildren(child, ctx)
+      if (elseBody) tail += elseBody + '\n'
+      tail += ctx.indent + '}'
+    } else {
+      // The consequence — a `then` wrapper (or, rarely, a bare body node).
+      const body = transpileNode(child, ctx)
+      if (body) result += body + '\n'
     }
   }
+  result += ctx.indent + '}' + tail
 
   return result
 }
@@ -2959,9 +2966,14 @@ function transpileUnless(node: any, ctx: TranspileContext): string {
   for (let i = 2; i < node.namedChildren.length; i++) {
     const child = node.namedChildren[i]
     if (child.type === 'else') {
-      const elseBody = child.namedChildren[0]
       result += ` else {\n`
-      if (elseBody) result += transpileNode(elseBody, ctx) + '\n'
+      // The `else` node is a wrapper containing ALL its statements directly
+      // (unlike the consequence/elsif, whose bodies are `then`-wrapped). Grab
+      // every child, not just the first — `namedChildren[0]` silently dropped
+      // every statement after the first, losing both audible events AND random
+      // draws (desyncing the PRNG stream from desktop). #537.
+      const elseBody = transpileChildren(child, ctx)
+      if (elseBody) result += elseBody + '\n'
       result += ctx.indent + '}'
     }
   }
@@ -3018,9 +3030,14 @@ function transpileCase(node: any, ctx: TranspileContext): string {
       if (bodyNode) result += transpileNode(bodyNode, ctx) + '\n'
       result += ctx.indent + '}'
     } else if (child.type === 'else') {
-      const elseBody = child.namedChildren[0]
       result += ` else {\n`
-      if (elseBody) result += transpileNode(elseBody, ctx) + '\n'
+      // The `else` node is a wrapper containing ALL its statements directly
+      // (unlike the consequence/elsif, whose bodies are `then`-wrapped). Grab
+      // every child, not just the first — `namedChildren[0]` silently dropped
+      // every statement after the first, losing both audible events AND random
+      // draws (desyncing the PRNG stream from desktop). #537.
+      const elseBody = transpileChildren(child, ctx)
+      if (elseBody) result += elseBody + '\n'
       result += ctx.indent + '}'
     }
   }

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1155,6 +1155,25 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   const bareCode: any[] = []
   const blocks: any[] = []
 
+  // #537/SV55: `use_random_seed` / `use_random_source` are FLOW-SENSITIVE — their
+  // effect begins at their SOURCE POSITION (desktop SPRand set_seed!). Hoisting
+  // them above the bare-code wrapper (TOP_LEVEL_SETTINGS) is ONLY needed so a
+  // separately-registered loop (live_loop / in_thread / bare `loop` / with_fx-
+  // wrapping-loop) reads the seed from the engine at registration. When the
+  // program registers NO such loop, the hoist is purely wrong: a `use_random_seed`
+  // near the end (dice_hoist, e2e_06) would re-seed the WHOLE bare sequence from
+  // its top instead of only the draws that follow it. Detect the no-loop case and
+  // keep these settings INLINE in bareCode (emitted as `__b.use_random_seed`).
+  const registersLoop = children.some((c: any) => {
+    if (c.type !== 'call' && c.type !== 'method_call') return false
+    const m = c.childForFieldName('method')?.text ?? c.namedChildren[0]?.text
+    if (m === 'live_loop' || m === 'in_thread') return true
+    if (m === 'loop' && c.namedChildren.some((x: any) => x.type === 'do_block' || x.type === 'block')) return true
+    if (m === 'with_fx' && /\b(?:live_loop|loop)\b/.test(c.text ?? '')) return true
+    return false
+  })
+  const FLOW_SENSITIVE_RANDOM = new Set(['use_random_seed', 'use_random_source'])
+
   // #419/SV55: track the top-level `use_synth` in SOURCE ORDER so each block
   // inherits the synth in effect at its definition point (desktop fork-snapshot
   // parity, runtime.rb:1067). `blockSynth` tags each registration-capturing
@@ -1223,7 +1242,8 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     const isBareLoopNode = method === 'loop' &&
       child.namedChildren.some((c: any) => c.type === 'do_block' || c.type === 'block')
 
-    if (method && TOP_LEVEL_SETTINGS.has(method)) {
+    if (method && TOP_LEVEL_SETTINGS.has(method)
+        && !(FLOW_SENSITIVE_RANDOM.has(method) && !registersLoop)) {
       topLevel.push(child)
     // `comment` and `uncomment` are control-flow (like if-true/if-false), NOT
     // structural blocks. They stay in bareCode so their content gets the __b.

--- a/src/engine/__tests__/RubyTranspiler.test.ts
+++ b/src/engine/__tests__/RubyTranspiler.test.ts
@@ -136,7 +136,12 @@ end`
       expect(prophetIdx).toBeLessThan(secondPlayIdx)
     })
 
-    it('use_bpm and use_random_seed still hoist above the wrapper (commutative)', () => {
+    it('use_bpm hoists above the wrapper; use_random_seed stays INLINE (flow-sensitive, #537)', () => {
+      // use_bpm is a run-level tempo setting → hoisted above the wrapper.
+      // use_random_seed is FLOW-SENSITIVE — its effect begins at its source
+      // position. With NO loop to read an engine-global seed, hoisting it would
+      // re-seed any preceding bare draws (dice_hoist / e2e_06). So it stays inline
+      // as `__b.use_random_seed` at source position.
       const code = `use_bpm 120\nuse_random_seed 42\nplay 60`
       const result = autoTranspileDetailed(code)
       expect(result.hasError).toBe(false)
@@ -144,8 +149,33 @@ end`
       const wrapperStart = out.indexOf('live_loop("__run_once"')
       expect(wrapperStart).toBeGreaterThanOrEqual(0)
       const before = out.slice(0, wrapperStart)
+      const inside = out.slice(wrapperStart)
       expect(before).toContain('use_bpm(120)')
-      expect(before).toContain('use_random_seed(42)')
+      expect(before).not.toContain('use_random_seed(42)') // NOT hoisted
+      expect(inside).toContain('__b.use_random_seed(42)')  // emitted inline
+    })
+
+    it('use_random_seed AFTER bare draws does not re-seed them (no-loop, #537)', () => {
+      // The bug: a trailing use_random_seed hoisted to the top re-seeded the whole
+      // sequence. It must emit inline so `rrand` before it uses the default seed.
+      const code = `play rrand_i(50, 80)\nsleep 0.25\nuse_random_seed 42\nplay 90`
+      const result = autoTranspileDetailed(code)
+      expect(result.hasError).toBe(false)
+      const out = result.code
+      const seedIdx = out.indexOf('use_random_seed(42)')
+      const drawIdx = out.indexOf('rrand_i(50, 80)')
+      expect(drawIdx).toBeGreaterThanOrEqual(0)
+      expect(seedIdx).toBeGreaterThan(drawIdx) // seed emitted AFTER the draw, inline
+      expect(out).toContain('__b.use_random_seed(42)')
+    })
+
+    it('use_random_seed STILL hoists when a live_loop needs the engine seed (#537)', () => {
+      // When a separately-registered loop is present, the seed must reach the
+      // engine at registration → keep the eager top-level emission (registersLoop).
+      const code = `use_random_seed 42\nlive_loop :x do\n  play rrand_i(50, 80)\n  sleep 1\nend`
+      const result = autoTranspileDetailed(code)
+      expect(result.hasError).toBe(false)
+      expect(result.code).toContain('use_random_seed(42)')
     })
 
     it('wraps bare code alongside existing live_loops', () => {

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -2596,4 +2596,62 @@ describe('#484/SP130 — __run_once wrap gate is structural (bare DSL reaching t
     expect(wraps('with_fx :reverb do\n  play 60\nend')).toBe(true)
     expect(hasBarePlay('with_fx :reverb do\n  play 60\nend')).toBe(false)
   })
+
+  // #537 — conditional branch bodies must emit EVERY statement. tree-sitter-ruby
+  // holds an `else`'s statements directly (not `then`-wrapped) and NESTS the
+  // trailing elsif/else inside each elsif node. The old handler read only
+  // `namedChildren[0]` of the else and never recursed past the first elsif, so it
+  // silently dropped statements — losing audible events AND random draws, which
+  // desynced PRNG pieces from desktop (orchard_improv: every `mode != 2` iteration
+  // dropped a `rrand_i` draw → the whole walk diverged).
+  describe('#537: conditional branches emit all statements (no dropped events/draws)', () => {
+    it('multi-statement else keeps every statement (was: only the first)', () => {
+      const code = treeSitterTranspile(
+        `if x == 2 then\n  play 52\nelse\n  tr = rrand_i(0, 4)\n  play 57, amp: tr\nend`
+      ).code
+      expect(code).toContain('tr = __b.rrand_i(0, 4)')
+      expect(code).toContain('__b.play(57')
+    })
+
+    it('else after elsif is not dropped (nested inside the elsif node)', () => {
+      const code = treeSitterTranspile(
+        `if x == 1 then\n  play 1\nelsif x == 2 then\n  play 3\nelse\n  play 5\nend`
+      ).code
+      expect(code).toContain('__b.play(1')
+      expect(code).toContain('} else if (x == 2)')
+      expect(code).toContain('__b.play(3')
+      expect(code).toContain('} else {')
+      expect(code).toContain('__b.play(5')
+    })
+
+    it('chained elsif + multi-statement bodies all survive', () => {
+      const code = treeSitterTranspile(
+        `if x == 1 then\n  a = 1\n  play 1\nelsif x == 2 then\n  play 3\nelsif x == 3 then\n  b = 2\n  play 4\nelse\n  c = 5\n  play 6\nend`
+      ).code
+      // every branch's draws/assignments and plays present
+      for (const frag of ['a = 1', '__b.play(1', '__b.play(3', 'b = 2', '__b.play(4', 'c = 5', '__b.play(6']) {
+        expect(code).toContain(frag)
+      }
+      // two `else if` plus a final `else`
+      expect(code.match(/else if/g)?.length).toBe(2)
+    })
+
+    it('multi-statement unless/else keeps every statement', () => {
+      const code = treeSitterTranspile(
+        `unless x then\n  a = 1\n  play 7\nelse\n  b = 2\n  play 8\nend`
+      ).code
+      for (const frag of ['a = 1', '__b.play(7', 'b = 2', '__b.play(8']) {
+        expect(code).toContain(frag)
+      }
+    })
+
+    it('multi-statement case/else keeps every statement', () => {
+      const code = treeSitterTranspile(
+        `case x\nwhen 1 then\n  play 9\n  play 10\nelse\n  c = 3\n  play 11\nend`
+      ).code
+      for (const frag of ['__b.play(9', '__b.play(10', 'c = 3', '__b.play(11']) {
+        expect(code).toContain(frag)
+      }
+    })
+  })
 })

--- a/src/engine/__tests__/WithFx.test.ts
+++ b/src/engine/__tests__/WithFx.test.ts
@@ -343,4 +343,46 @@ describe('with_fx', () => {
     // Outer sleep after fx block
     expect(program[1]).toMatchObject({ tag: 'sleep', beats: 999999 })
   })
+
+  // #537 — `with_fx reps: N` re-runs the BLOCK N times, re-executing the body
+  // each pass (fresh random draws). The body is unrolled at BUILD time so the
+  // draws advance per rep; replaying a pre-built body froze the first rep's draw
+  // and desynced PRNG pieces (lorezzed). `reps` is stripped from the step opts so
+  // the interpreter runs the (already N-long) body exactly once.
+  describe('#537: with_fx reps unrolls the body with fresh draws per rep', () => {
+    it('reps: 4 produces 4 play steps with 4 DISTINCT rrand amps', () => {
+      const program = new ProgramBuilder(0)
+        .with_fx('krush', { reps: 4, amp: 3 }, (b) => b.play(60, { amp: b.rrand(0, 1) }))
+        .build()
+      const fxStep = program[0] as { tag: 'fx'; body: import('../Program').Step[]; opts: Record<string, unknown> }
+      const amps = fxStep.body
+        .filter((s) => s.tag === 'play')
+        .map((s) => (s as { opts: Record<string, number> }).opts.amp)
+      expect(amps).toHaveLength(4)
+      expect(new Set(amps).size).toBe(4) // every rep drew a fresh value
+      // reps is consumed at build time — must NOT linger in the step opts (else
+      // the interpreter would loop the already-unrolled body N×N).
+      expect(fxStep.opts.reps).toBeUndefined()
+    })
+
+    it('reps draws advance the SHARED stream — a draw after the block continues it', () => {
+      // Two builders: one with reps:3, one with three plain plays. The post-block
+      // draw must read the same stream position in both (reps consumes 3 draws).
+      const withReps = new ProgramBuilder(0)
+        .with_fx('krush', { reps: 3 }, (b) => b.play(60, { amp: b.rrand(0, 1) }))
+      const afterReps = withReps.rrand(0, 1)
+      const plain = new ProgramBuilder(0)
+      for (let i = 0; i < 3; i++) plain.rrand(0, 1)
+      const afterPlain = plain.rrand(0, 1)
+      expect(afterReps).toBe(afterPlain)
+    })
+
+    it('no reps (or reps: 1) keeps a single body pass (regression)', () => {
+      const program = new ProgramBuilder(0)
+        .with_fx('reverb', { room: 0.5 }, (b) => b.play(60, { amp: b.rrand(0, 1) }))
+        .build()
+      const fxStep = program[0] as { tag: 'fx'; body: import('../Program').Step[] }
+      expect(fxStep.body.filter((s) => s.tag === 'play')).toHaveLength(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Three transpiler/build bugs that desynced PRNG random walks (and dropped events) in real pieces, surfaced after the EPIC #531 Phase 5b comparator flip graded PRNG pieces by `/s_new` event-parity. Each is a distinct root cause, fixed and verified note-for-note against running desktop Sonic Pi.

- **#540 — Transpiler dropped conditional-branch statements.** `transpileIf` kept only the first statement of a multi-statement `else`, and dropped `else`/2nd `elsif` after an `elsif` (tree-sitter nests the chain). Dropped statements lose both events and random draws → downstream PRNG desync. Fix: `transpileChildren(elseNode)` + recursive elsif-chain walk. → `orchard_improv` EVENT-MATCH (was DIVERGE@#2 Δ1960ms).
- **#541 — `with_fx reps: N` froze random draws.** The interpreter replayed the pre-built body N× (so `rrand` resolved once at build, frozen), and QueryInterpreter ignored `reps` entirely. Fix: unroll at build time in `ProgramBuilder.with_fx` (re-run the block N× on the continuing stream → fresh draws) + strip `reps` so interpreters run once. → `lorezzed` + `sw_shufflit` EVENT-MATCH.
- **#542 — `use_random_seed` eager-hoisted out of `__run_once`.** In no-loop bare code a trailing `use_random_seed N` was hoisted above `__run_once`, re-seeding the whole preceding sequence (flow-insensitive). Fix: `registersLoop` pre-scan routes `use_random_seed`/`use_random_source` inline (source-position-faithful) when no loop is present; loop case keeps the eager hoist. → `dice_hoist` + `sw_e2e_06_random` EVENT-MATCH.

## Verification

- **L1:** `npx vitest run` → 1419/1419, `npx tsc --noEmit` → clean. (+11 tests across TreeSitterTranspiler / WithFx / RubyTranspiler.)
- **L3 (desktop A/B, event-parity):** each fixed piece confirmed EVENT-MATCH (structure + onset sequence + per-tick notes) against running desktop Sonic Pi.
- **Verification sweep:** re-captured every dashboard diverger fresh against the current engine. The remaining residual PRNG candidates (`compus_beats`, `idm_simple`, `sonic_dreams`, and others) all already EVENT-MATCH — they were stale pre-fix dashboard captures, not bugs. The only genuinely-diverging pieces left are **non-PRNG** and tracked separately (#543 sample-group ring; cloud_beat Class-C tick-hihat; e2e_08/iso_density desktop-side anomalies).

Closes #540. Closes #541. Closes #542. Part of #537.
