### PR TITLE
🔊 fix(samples): sample_names(group) returns the group's sorted ring (#543)

### DIFF
--- a/src/engine/SampleCatalog.ts
+++ b/src/engine/SampleCatalog.ts
@@ -267,6 +267,120 @@ const SAMPLES: SampleInfo[] = [
   { name: 'tbd_voctone', category: 'tbd' },
 ]
 
+/**
+ * Desktop Sonic Pi's sample GROUPS — a 1:1 port of `@@grouped_samples` in
+ * `synthinfo.rb:9304-9604` (18 groups). This is the source of truth for the
+ * DSL `sample_names(group)` / `sample_groups` / `all_sample_names` — distinct
+ * from the flat `SAMPLES` list above, which drives the UI sample browser
+ * (category-based, alphabetical).
+ *
+ * The member ORDER here mirrors synthinfo.rb for auditability, but it is
+ * IRRELEVANT to behavior: desktop `sample_names(group)` returns
+ * `g[:samples].sort.ring` (sound.rb:3229-3233) — alphabetically SORTED — so the
+ * insertion order never reaches user code. (#543)
+ */
+const GROUPED_SAMPLES: Record<string, string[]> = {
+  drum: [
+    'drum_heavy_kick', 'drum_tom_mid_soft', 'drum_tom_mid_hard', 'drum_tom_lo_soft',
+    'drum_tom_lo_hard', 'drum_tom_hi_soft', 'drum_tom_hi_hard', 'drum_splash_soft',
+    'drum_splash_hard', 'drum_snare_soft', 'drum_snare_hard', 'drum_cymbal_soft',
+    'drum_cymbal_hard', 'drum_cymbal_open', 'drum_cymbal_closed', 'drum_cymbal_pedal',
+    'drum_bass_soft', 'drum_bass_hard', 'drum_cowbell', 'drum_roll',
+  ],
+  elec: [
+    'elec_triangle', 'elec_snare', 'elec_lo_snare', 'elec_hi_snare', 'elec_mid_snare',
+    'elec_cymbal', 'elec_soft_kick', 'elec_filt_snare', 'elec_fuzz_tom', 'elec_chime',
+    'elec_bong', 'elec_twang', 'elec_wood', 'elec_pop', 'elec_beep', 'elec_blip',
+    'elec_blip2', 'elec_ping', 'elec_bell', 'elec_flip', 'elec_tick', 'elec_hollow_kick',
+    'elec_twip', 'elec_plip', 'elec_blup',
+  ],
+  guit: ['guit_harmonics', 'guit_e_fifths', 'guit_e_slide', 'guit_em9'],
+  misc: ['misc_burp', 'misc_crow', 'misc_cineboom'],
+  perc: [
+    'perc_bell', 'perc_bell2', 'perc_snap', 'perc_snap2', 'perc_swash', 'perc_till',
+    'perc_door', 'perc_impact1', 'perc_impact2', 'perc_swoosh',
+  ],
+  ambi: [
+    'ambi_soft_buzz', 'ambi_swoosh', 'ambi_drone', 'ambi_glass_hum', 'ambi_glass_rub',
+    'ambi_haunted_hum', 'ambi_piano', 'ambi_lunar_land', 'ambi_dark_woosh', 'ambi_choir',
+    'ambi_sauna',
+  ],
+  bass: [
+    'bass_hit_c', 'bass_hard_c', 'bass_thick_c', 'bass_drop_c', 'bass_woodsy_c',
+    'bass_voxy_c', 'bass_voxy_hit_c', 'bass_dnb_f', 'bass_trance_c',
+  ],
+  sn: ['sn_dub', 'sn_dolf', 'sn_zome', 'sn_generic'],
+  ride: ['ride_tri', 'ride_via'],
+  hat: [
+    'hat_snap', 'hat_zan', 'hat_zap', 'hat_tap', 'hat_cats', 'hat_bdu', 'hat_psych',
+    'hat_raw', 'hat_zild', 'hat_gump', 'hat_noiz', 'hat_sci', 'hat_star', 'hat_gem',
+    'hat_yosh', 'hat_mess', 'hat_cab', 'hat_gnu', 'hat_hier', 'hat_metal', 'hat_len',
+  ],
+  bd: [
+    'bd_ada', 'bd_pure', 'bd_808', 'bd_zum', 'bd_gas', 'bd_sone', 'bd_haus', 'bd_zome',
+    'bd_boom', 'bd_klub', 'bd_fat', 'bd_tek', 'bd_mehackit', 'bd_chip', 'bd_jazz',
+  ],
+  loop: [
+    'loop_industrial', 'loop_compus', 'loop_amen', 'loop_amen_full', 'loop_garzul',
+    'loop_mika', 'loop_breakbeat', 'loop_safari', 'loop_tabla', 'loop_3d_printer',
+    'loop_drone_g_97', 'loop_electric', 'loop_mehackit1', 'loop_mehackit2', 'loop_perc1',
+    'loop_perc2', 'loop_weirdo',
+  ],
+  tabla: [
+    'tabla_tas1', 'tabla_tas2', 'tabla_tas3', 'tabla_ke1', 'tabla_ke2', 'tabla_ke3',
+    'tabla_na', 'tabla_na_o', 'tabla_tun1', 'tabla_tun2', 'tabla_tun3', 'tabla_te1',
+    'tabla_te2', 'tabla_te_ne', 'tabla_te_m', 'tabla_ghe1', 'tabla_ghe2', 'tabla_ghe3',
+    'tabla_ghe4', 'tabla_ghe5', 'tabla_ghe6', 'tabla_ghe7', 'tabla_ghe8', 'tabla_dhec',
+    'tabla_na_s', 'tabla_re',
+  ],
+  glitch: [
+    'glitch_bass_g', 'glitch_perc1', 'glitch_perc2', 'glitch_perc3', 'glitch_perc4',
+    'glitch_perc5', 'glitch_robot1', 'glitch_robot2',
+  ],
+  vinyl: ['vinyl_backspin', 'vinyl_rewind', 'vinyl_scratch', 'vinyl_hiss'],
+  mehackit: [
+    'mehackit_phone1', 'mehackit_phone2', 'mehackit_phone3', 'mehackit_phone4',
+    'mehackit_robot1', 'mehackit_robot2', 'mehackit_robot3', 'mehackit_robot4',
+    'mehackit_robot5', 'mehackit_robot6', 'mehackit_robot7',
+  ],
+  arovane: ['arovane_beat_a', 'arovane_beat_b', 'arovane_beat_c', 'arovane_beat_d', 'arovane_beat_e'],
+  tbd: [
+    'tbd_fxbed_loop', 'tbd_highkey_c4', 'tbd_pad_1', 'tbd_pad_2', 'tbd_pad_3', 'tbd_pad_4',
+    'tbd_perc_blip', 'tbd_perc_hat', 'tbd_perc_tap_1', 'tbd_perc_tap_2', 'tbd_voctone',
+  ],
+}
+
+/** The raw desktop group → members map (for tests / introspection). */
+export function getGroupedSamples(): Record<string, string[]> {
+  return GROUPED_SAMPLES
+}
+
+/**
+ * `sample_names(group)` — the SORTED member list of a sample group, mirroring
+ * desktop `sound.rb:3229` (`g[:samples].sort.ring`). Throws on an unknown group,
+ * exactly as desktop `raise`s, so `choose(sample_names(:typo))` fails loudly
+ * instead of silently picking from the wrong (or whole) catalog. (#543)
+ */
+export function getSampleNamesByGroup(group: string): string[] {
+  const g = GROUPED_SAMPLES[group]
+  if (!g) throw new Error(`Unknown sample group :${group}`)
+  return [...g].sort()
+}
+
+/** `sample_groups` — the SORTED group keys (desktop sound.rb:3264). */
+export function getSampleGroupNames(): string[] {
+  return Object.keys(GROUPED_SAMPLES).sort()
+}
+
+/**
+ * `all_sample_names` — every grouped sample, SORTED (desktop sound.rb:3248,
+ * `all_samples.sort.ring`; all_samples = flatten of grouped_samples). Groups are
+ * disjoint by prefix so no dedupe is needed. (#543)
+ */
+export function getAllGroupedSampleNames(): string[] {
+  return Object.values(GROUPED_SAMPLES).flat().sort()
+}
+
 /** Get all samples. */
 export function getAllSamples(): SampleInfo[] {
   return SAMPLES

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -42,7 +42,12 @@ import { MidiBridge } from './MidiBridge'
 import { spread } from './EuclideanRhythm'
 import { noteToMidi, midiToFreq, noteToFreq, hzToMidi, noteInfo } from './NoteToFreq'
 import { chord, scale, chord_invert, note, note_range, chord_degree, degree, chord_names, scale_names } from './ChordScale'
-import { getSampleNames, getCategories } from './SampleCatalog'
+import {
+  getSampleNames,
+  getSampleNamesByGroup,
+  getSampleGroupNames,
+  getAllGroupedSampleNames,
+} from './SampleCatalog'
 import { loadAllCustomSamples, type CustomSampleRecord } from './CustomSampleStore'
 import type { Program } from './Program'
 
@@ -796,8 +801,8 @@ export class SonicPiEngine {
         return dur !== undefined ? { duration: dur } : null
       }
 
-      // all_sample_names — from the sample catalog
-      const all_sample_names_fn = () => sample_names()
+      // all_sample_names — every grouped sample, sorted (desktop sound.rb:3248)
+      const all_sample_names_fn = () => getAllGroupedSampleNames()
 
       // Top-level print handler
       const topLevelPuts = (...args: unknown[]) => {
@@ -1522,8 +1527,15 @@ export class SonicPiEngine {
         this.midiBridge.getPitchBend(channel)
 
       // ----- Sample catalog -----
-      const sample_names = (): string[] => getSampleNames()
-      const sample_groups = (): string[] => getCategories()
+      // sample_names(group) → SORTED ring of that group's members (desktop
+      // sound.rb:3229 `g[:samples].sort.ring`); raises on unknown group. The
+      // group arg is required — `sample_names :ambi` transpiles to
+      // `sample_names("ambi")`. Returning a Ring keeps choose/tick/shuffle
+      // faithful. (#543)
+      const sample_names = (group: string): Ring<string> =>
+        ring(...getSampleNamesByGroup(group))
+      // sample_groups → SORTED ring of group keys (desktop sound.rb:3264). (#543)
+      const sample_groups = (): Ring<string> => ring(...getSampleGroupNames())
       const sample_loaded = (name: string): boolean => {
         if (!this.bridge) return false
         return this.bridge.isSampleLoaded(name)
@@ -1904,7 +1916,7 @@ export class SonicPiEngine {
         // matches the upstream sound.rb behavior loosely. Without `filter`,
         // returns every name we know about.
         (filter?: string) => {
-          const all = sample_names()
+          const all = getSampleNames()
           const loaded = this.bridge?.getLoadedSampleNames() ?? []
           // Union: bundled catalog + any extras already loaded (e.g. user uploads
           // not in the static catalog). Dedupe via Set, preserve catalog order.

--- a/src/engine/__tests__/SampleGroups.test.ts
+++ b/src/engine/__tests__/SampleGroups.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getSampleNamesByGroup,
+  getSampleGroupNames,
+  getAllGroupedSampleNames,
+  getGroupedSamples,
+  getSampleNames,
+} from '../SampleCatalog'
+
+/**
+ * #543 — `sample_names(group)` returned the WHOLE flat catalog (~270 names)
+ * regardless of the group argument, so `choose(sample_names :ambi)` picked from
+ * the wrong set and diverged from desktop (ambient_noctrl / sw_ambient).
+ *
+ * Desktop ground truth (sound.rb:3229-3266):
+ *   sample_names(group) = grouped_samples[group][:samples].sort.ring  (raise if unknown)
+ *   all_sample_names    = all_samples.sort.ring
+ *   sample_groups       = grouped_samples.keys.sort.ring
+ * grouped_samples is synthinfo.rb:9304-9604. The `.sort` means INSERTION order
+ * never reaches user code — membership + alphabetical order are what matter.
+ */
+describe('sample groups (#543)', () => {
+  it('sample_names(:ambi) returns the 11 ambi members, alphabetically sorted', () => {
+    expect(getSampleNamesByGroup('ambi')).toEqual([
+      'ambi_choir', 'ambi_dark_woosh', 'ambi_drone', 'ambi_glass_hum',
+      'ambi_glass_rub', 'ambi_haunted_hum', 'ambi_lunar_land', 'ambi_piano',
+      'ambi_sauna', 'ambi_soft_buzz', 'ambi_swoosh',
+    ])
+  })
+
+  it('sample_names is sorted (matches desktop .sort) and group-scoped, not the full catalog', () => {
+    const drums = getSampleNamesByGroup('drum')
+    expect(drums).toEqual([...drums].sort())
+    expect(drums).toHaveLength(20)
+    // every member belongs to the group (prefix) — no leakage of other groups
+    expect(drums.every(n => n.startsWith('drum_'))).toBe(true)
+    // NOT the whole catalog (the bug returned ~270)
+    expect(drums.length).toBeLessThan(getSampleNames().length)
+  })
+
+  it('raises on an unknown group (desktop `raise`), never silently returns all', () => {
+    expect(() => getSampleNamesByGroup('not_a_group')).toThrow(/Unknown sample group/)
+  })
+
+  it('sample_groups returns the 18 group keys, sorted', () => {
+    const groups = getSampleGroupNames()
+    expect(groups).toEqual([...groups].sort())
+    expect(groups).toEqual([
+      'ambi', 'arovane', 'bass', 'bd', 'drum', 'elec', 'glitch', 'guit', 'hat',
+      'loop', 'mehackit', 'misc', 'perc', 'ride', 'sn', 'tabla', 'tbd', 'vinyl',
+    ])
+  })
+
+  it('all_sample_names is every grouped member, sorted, disjoint (no dupes)', () => {
+    const all = getAllGroupedSampleNames()
+    expect(all).toEqual([...all].sort())
+    expect(new Set(all).size).toBe(all.length)
+    const grouped = getGroupedSamples()
+    const flatCount = Object.values(grouped).reduce((n, g) => n + g.length, 0)
+    expect(all).toHaveLength(flatCount)
+  })
+
+  it('every grouped sample exists in the loadable flat catalog (consistency guard)', () => {
+    const loadable = new Set(getSampleNames())
+    const missing = getAllGroupedSampleNames().filter(n => !loadable.has(n))
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

`sample_names(group)` ignored its argument and returned the whole flat catalog (~270 names), so `choose(sample_names :ambi)` picked from 270 samples (`randI(270)`) instead of desktop's 11-element `:ambi` ring (`randI(11)`) — usually a *mono* player where desktop picks a stereo one, diverging the event stream. `sample_groups` likewise returned UI category strings instead of desktop's group keys.

## Fix

Port desktop `@@grouped_samples` (`synthinfo.rb:9304-9604`, 18 groups) into `SampleCatalog` as the DSL source of truth, mirroring `sound.rb:3229-3266`:
- `sample_names(group)` → group members **sorted**, as a `Ring`; raises on unknown group (desktop `raise`).
- `sample_groups` → group keys sorted, as a `Ring`.
- `all_sample_names` → every grouped member sorted (was the no-arg `sample_names()`).

The `.sort` matches desktop exactly — synthinfo insertion order never reaches user code, so membership + alphabetical order are all that matter.

## Verification

- **L3 (desktop A/B event-parity):** `ambient_noctrl` and `sw_ambient` both go from DIVERGE (basic_stereo_player mis-timed Δ5001/6000ms, mono leakage) → **EVENT-MATCH** (Δ0–1ms, notes ✓, no mono leakage).
- **L1:** 1415/1415 (+6 SampleGroups tests, incl. a guard that every grouped sample exists in the loadable catalog), `tsc --noEmit` clean.

Closes #543. Part of #537.
