### PR TITLE
🐛 fix(transpiler): N.times evaluates its count once (#546)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1665,11 +1665,17 @@ function transpileReceiverMethodCall(
   const recStr = transpileNode(receiver, ctx)
 
   // N.times do |i| ... end
+  // The count is hoisted into a temp so the receiver is evaluated ONCE (Ruby
+  // `N.times` evaluates its receiver once). Inlining `recStr` into the loop
+  // condition re-ran it every iteration — fatal when the count has side effects,
+  // e.g. `divisors.tick.times` advances the tick counter on every check, and any
+  // `.look` in the body then reads a runaway index (cloud_beat hihat). (#546)
   if (method === 'times' && blockNode) {
     const params = blockNode.namedChildren.find((c: any) => c.type === 'block_parameters')
     const varName = params?.namedChildren[0]?.text ?? '_i'
     const bodyStr = transpileBlockBody(blockNode, ctx)
-    return `for (let ${varName} = 0; ${varName} < ${recStr}; ${varName}++) {\n${ctx.indent}  __b.__checkBudget__()\n${bodyStr}\n${ctx.indent}}`
+    const nTmp = `__times_${ctx.indent.length}`
+    return `{ const ${nTmp} = ${recStr}; for (let ${varName} = 0; ${varName} < ${nTmp}; ${varName}++) {\n${ctx.indent}  __b.__checkBudget__()\n${bodyStr}\n${ctx.indent}} }`
   }
 
   // .each do |item| ... end  /  .each do |a, b| ... end (destructure)

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -61,6 +61,35 @@ describe('TreeSitterTranspiler', () => {
     expect(isTreeSitterReady()).toBe(true)
   })
 
+  describe('#546: N.times evaluates its count once (side-effecting counts)', () => {
+    it('hoists the count into a temp instead of re-evaluating it in the loop condition', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  divisors = ring 2, 4
+  divisors.tick.times do
+    sample :elec_blip
+    sleep 1.0 / divisors.look
+  end
+end`)
+      // count expression must appear exactly ONCE (hoisted), not in the for-condition
+      const tickCalls = (result.code.match(/__b\.tick\(\)/g) ?? []).length
+      expect(tickCalls).toBe(1)
+      expect(result.code).toMatch(/const __times_\d+ = divisors\?\.at\(__b\.tick\(\)\)/)
+      expect(result.code).toMatch(/for \(let _i = 0; _i < __times_\d+; _i\+\+\)/)
+      // the body still reads look (unchanged)
+      expect(result.code).toContain('__b.look()')
+    })
+
+    it('still works for a plain integer count', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  4.times do
+    sample :bd_haus
+  end
+end`)
+      expect(result.code).toMatch(/const __times_\d+ = 4/)
+      expect(result.code).toMatch(/for \(let _i = 0; _i < __times_\d+; _i\+\+\)/)
+    })
+  })
+
   describe('Task 1: Setup & Prototype', () => {
     it('parses and transpiles a basic live_loop', () => {
       const ruby = `live_loop :drums do
@@ -859,7 +888,9 @@ end`)
 end`)
       expect(result.ok).toBe(true)
       expect(result.code).toContain('for (let')
-      expect(result.code).toContain('< 4')
+      // count hoisted into a temp evaluated once (#546)
+      expect(result.code).toMatch(/const __times_\d+ = 4/)
+      expect(result.code).toMatch(/< __times_\d+/)
       expect(result.code).toContain('b.__checkBudget__()')
     })
 


### PR DESCRIPTION
## Problem

`N.times do ... end` transpiled to `for (let _i = 0; _i < <count-expr>; _i++)`, re-evaluating the receiver on **every loop-condition check**. Ruby `N.times` evaluates its receiver **once**. When the count has side effects this corrupts state.

`cloud_beat` hihat:
```ruby
divisors = ring 2, 4, 2, 2, 2, 2, 2, 6
divisors.tick.times do
  hihat
  sleep 1.0 / divisors.look
end
```
`divisors.tick` advanced the tick counter on every check (N+1× per outer iteration), so `divisors.look` in the body read a runaway index → wrong sleep durations → pnoise hihat mis-timed @#2 (Δ800–1100ms vs desktop).

## Fix

Hoist the count into a block-scoped temp evaluated once (mirrors the `each_with_index` idiom):
```js
{ const __times_N = <count-expr>; for (let _i = 0; _i < __times_N; _i++) { ... } }
```

## Verification

- **L3 (desktop A/B event-parity):** minimal `divisors.tick.times { sample; sleep 1.0/divisors.look }` repro DIVERGE (Δ800ms) → **EVENT-MATCH** (50 onsets Δ0ms). `cloud_beat` pnoise hihat DIVERGE → ✓ (67 onsets Δ0ms, notes ✓).
- **L1:** suite green, `tsc --noEmit` clean (+2 tests; 1 pre-existing `.times` test updated to the hoisted shape).

Closes #546. Part of #537. (cloud_beat's remaining `blade` wrong-notes is a separate cross-live_loop seed-ordering issue, tracked separately.)
