### PR TITLE
🔀 fix(sandbox): cross-live_loop shared variable mutations propagate (#548)

### DIFF
--- a/src/engine/Sandbox.ts
+++ b/src/engine/Sandbox.ts
@@ -118,6 +118,20 @@ export function createIsolatedExecutor(
           // canonical pattern works (#206):
           //   m = [:c4, :e4, :g4]
           //   loop do; play choose(m); sleep 1; end
+          //
+          // …and EXCEPT for a variable that already exists in the shared scope
+          // (#548 — Ruby closure-capture semantics). A live_loop's `do…end` is
+          // a block closure over the main-thread binding: assigning a variable
+          // that was bound BEFORE the loop (top-level / __run_once) mutates that
+          // outer binding in place, so sibling live_loops observe the new value.
+          // Only a variable FIRST introduced inside the loop body is block-local
+          // (stays in per-loop storage). Without this, each loop froze its own
+          // copy of a shared counter/selector var (e.g. a `:chord_selector` loop
+          // that updates `chord_high` was invisible to the `:chord_loop` reader).
+          if (prop in target) {
+            target[prop] = value
+            return true
+          }
           let locals = scopeLocals.get(currentScopeName)
           if (!locals) {
             locals = new Map()

--- a/src/engine/__tests__/Sandbox.test.ts
+++ b/src/engine/__tests__/Sandbox.test.ts
@@ -136,6 +136,66 @@ describe('Sandbox', () => {
     expect(result).toBe(99)
   })
 
+  it('#548: a top-level var mutated in loop A IS visible in loop B (Ruby closure capture)', async () => {
+    // A variable bound at top level (before any loop) is the main-thread
+    // binding. A live_loop body assigning it mutates that shared binding in
+    // place, so a sibling loop observes the new value (desktop semantics).
+    const { execute, scopeHandle } = createIsolatedExecutor(
+      `
+      const results = []
+      // Top-level binding (no scope active) — shared main-thread variable.
+      counter = 0
+      // Loop A increments the SHARED counter.
+      __enterScope__("loopA")
+      counter = counter + 5
+      results.push(counter)
+      __exitScope__()
+      // Loop B reads the shared counter — must see loop A's mutation.
+      __enterScope__("loopB")
+      results.push(counter)
+      __exitScope__()
+      storeResults(results)
+      `,
+      ['storeResults', '__enterScope__', '__exitScope__']
+    )
+    let captured: unknown[] = []
+    await execute(
+      (r: unknown[]) => { captured = r },
+      (name: string) => scopeHandle.enterScope(name),
+      () => scopeHandle.exitScope()
+    )
+    expect(captured[0]).toBe(5)   // Loop A mutated the shared counter
+    expect(captured[1]).toBe(5)   // Loop B observes the mutation (NOT frozen at 0)
+  })
+
+  it('#548: a var first assigned INSIDE a loop stays block-local (isolation preserved)', async () => {
+    // The fix narrows isolation to Ruby semantics: only a variable introduced
+    // inside the loop (never bound at top level) is block-local. This guards the
+    // Chesterton's-fence behavior — sibling loops must NOT leak truly-local vars.
+    const { execute, scopeHandle } = createIsolatedExecutor(
+      `
+      const results = []
+      __enterScope__("loopA")
+      local_only = 42   // first introduced here — never bound at top level
+      results.push(local_only)
+      __exitScope__()
+      __enterScope__("loopB")
+      results.push(typeof local_only === "undefined" ? "undefined" : local_only)
+      __exitScope__()
+      storeResults(results)
+      `,
+      ['storeResults', '__enterScope__', '__exitScope__']
+    )
+    let captured: unknown[] = []
+    await execute(
+      (r: unknown[]) => { captured = r },
+      (name: string) => scopeHandle.enterScope(name),
+      () => scopeHandle.exitScope()
+    )
+    expect(captured[0]).toBe(42)
+    expect(captured[1]).toBe('undefined')  // loop B does NOT see loop A's local
+  })
+
   it('per-loop scope: DSL functions accessible from all loops', async () => {
     const { execute, scopeHandle } = createIsolatedExecutor(
       `


### PR DESCRIPTION
## Problem

Each `live_loop` got its **own copy** of every variable assigned inside its body. A top-level variable mutated in one loop was invisible to sibling loops, because the Sandbox `set` trap routed *all* in-loop writes to per-loop local storage (except `__run_once`). Desktop Sonic Pi shares the main-thread binding across all live_loops.

Real impact: the canonical **selector/player** idiom broke. In `cloud_beat`, a `:chord_selector` loop updates `chord_high`/`chord_low`; the `:chord_loop` reader picks notes from them. Web froze the reader on the initial chord forever → **wrong notes**.

Proven during #537 triage (vyapti SV70):
- `counter.rb` (cross-loop) — web reader frozen `60,60,60…` vs desktop `61,64,65…`
- `selfcount.rb` (single-loop self-increment) — web `61,62,63…` **matches** desktop → the failure is purely cross-loop scope sharing, not a build-time snapshot.

## Fix

Mirror **Ruby closure-capture semantics** in the `set` trap. A `do…end` block is a closure over the main-thread binding: assigning a variable that was bound *before* the loop (top-level / `__run_once`) mutates that outer binding in place, so siblings observe it. Only a variable **first introduced inside** the loop body is block-local.

One extra condition inside the existing scope branch:

```js
if (prop in target) { target[prop] = value; return true }   // shared binding → write through
// else: truly loop-local var → per-loop storage (unchanged)
```

### Why this is safe (existence check)
- **Capture / QueryInterpreter path never calls `enterScope`** (scopeStack stays empty in `queryRange`), so it already routes everything to the shared `target`. The new branch is *inside* `currentScopeName !== null` → capture behavior is **unchanged**; S1/S2 isomorphism holds.
- **Grading** (`event-parity.ts`) reads the real audio `/s_new` stream — the path being fixed.
- **Genuinely loop-local vars stay isolated** — all 5 pre-existing isolation tests still pass (they assign vars first *inside* a loop, so `prop in target` is false).
- **Hot-swap**: a fresh sandbox per Run re-runs top-level init → shared vars reset (desktop-faithful).

## Test plan
- **L1**: `1429/1429` vitest + `tsc --noEmit` clean. Added 2 Sandbox tests — top-level var mutated in loop A visible in loop B (propagate), and a loop-introduced var stays block-local (isolation preserved).
- **L3 desktop A/B** (`event-parity.ts`):
  - `counter.rb` — reader now increments `61,62,63…` (was frozen). Residual divergence is a degenerate same-period (`use_bpm 600`, both loops 1-beat) thread-interleave race in the probe, not a propagation bug.
  - `crossloop.rb` — ✓ **EVENT-MATCH** (9 onsets, Δ0ms, notes ✓)
  - `cloud_beat.rb` — ✓ **EVENT-MATCH** all layers incl `blade` (45 onsets, Δ0ms, **notes ✓**), pnoise/beep/basic_stereo_player match, FX counts match.

closes #548