### PR TITLE
🧪 fix(tooling): flag desktop-side non-gradeable fixtures in the event-diff dashboard (#549)

### DIFF
--- a/tools/__tests__/non-gradeable.test.ts
+++ b/tools/__tests__/non-gradeable.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { NON_GRADEABLE, isNonGradeable, nonGradeableReason } from '../lib/non-gradeable.ts'
+
+describe('non-gradeable fixtures (#549)', () => {
+  it('flags the two known desktop-side non-gradeable fixtures', () => {
+    expect(isNonGradeable('iso_density')).toBe(true)
+    expect(isNonGradeable('e2e_08_math_misc')).toBe(true)
+  })
+
+  it('does NOT flag a normal gradeable fixture', () => {
+    expect(isNonGradeable('cloud_beat')).toBe(false)
+    expect(isNonGradeable('crossloop')).toBe(false)
+    expect(isNonGradeable('')).toBe(false)
+  })
+
+  it('every entry carries a non-empty documented reason', () => {
+    for (const [name, entry] of Object.entries(NON_GRADEABLE)) {
+      expect(entry.reason, `reason for ${name}`).toBeTruthy()
+      expect(entry.reason.length).toBeGreaterThan(20)
+    }
+  })
+
+  it('nonGradeableReason returns the reason for listed fixtures, null otherwise', () => {
+    expect(nonGradeableReason('iso_density')).toContain('non-looping')
+    expect(nonGradeableReason('e2e_08_math_misc')).toContain('halts early')
+    expect(nonGradeableReason('cloud_beat')).toBeNull()
+  })
+
+  it('is not driven by a fragile own/inherited-property confusion', () => {
+    // hasOwnProperty guards against Object.prototype keys leaking in as "flagged".
+    expect(isNonGradeable('toString')).toBe(false)
+    expect(isNonGradeable('constructor')).toBe(false)
+    expect(isNonGradeable('hasOwnProperty')).toBe(false)
+  })
+})

--- a/tools/build-event-diff.ts
+++ b/tools/build-event-diff.ts
@@ -20,6 +20,7 @@ import { readdirSync, readFileSync, writeFileSync, statSync, existsSync } from '
 import { resolve, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { navBlock } from './lib/dashboard-nav.ts'
+import { isNonGradeable, nonGradeableReason } from './lib/non-gradeable.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = resolve(__dirname, '..')
@@ -79,8 +80,13 @@ interface ParityReport {
  *  #537 PRNG-divergence class). Fold the onset-sequence verdict in so the dashboard
  *  counts what event-parity actually decided. Old captures (no sequenceParity) keep
  *  their structure verdict. */
-type EffVerdict = 'EVENT-MATCH' | 'STRUCTURE-DIVERGE' | 'SEQUENCE-DIVERGE' | 'DESKTOP-EMPTY' | 'WEB-EMPTY'
-function effectiveVerdict(r: ParityReport): EffVerdict {
+type EffVerdict = 'EVENT-MATCH' | 'STRUCTURE-DIVERGE' | 'SEQUENCE-DIVERGE' | 'DESKTOP-EMPTY' | 'WEB-EMPTY' | 'NON-GRADEABLE'
+function effectiveVerdict(r: ParityReport, name?: string): EffVerdict {
+  // #549: a fixture whose DESKTOP reference side can't be graded (desktop
+  // produces ~no usable events — see tools/lib/non-gradeable.ts) is never a
+  // web-engine divergence. Decided BEFORE any structure/sequence check so a
+  // desktop-side fixture failure can't masquerade as a SEQUENCE-DIVERGE.
+  if (name && isNonGradeable(name)) return 'NON-GRADEABLE'
   if (r.verdict === 'DESKTOP-EMPTY' || r.verdict === 'WEB-EMPTY') return r.verdict
   if (r.verdict === 'STRUCTURE-DIVERGE') return 'STRUCTURE-DIVERGE'
   // STRUCTURE-MATCH: defer to onset-sequence/notes when judged.
@@ -89,6 +95,10 @@ function effectiveVerdict(r: ParityReport): EffVerdict {
 }
 const isMatchEff = (v: EffVerdict) => v === 'EVENT-MATCH'
 const isDivergeEff = (v: EffVerdict) => v === 'STRUCTURE-DIVERGE' || v === 'SEQUENCE-DIVERGE'
+// Inconclusive = not a pass, but NOT counted against the web engine either:
+// desktop produced nothing this run (EMPTY) or the fixture is structurally
+// non-gradeable on the desktop side (#549). Badged ⚠, excluded from divergers.
+const isInconEff = (v: EffVerdict) => v.includes('EMPTY') || v === 'NON-GRADEABLE'
 interface OscEvent {
   addr: string
   synthdef?: string
@@ -125,10 +135,11 @@ function loadCaptures(): Capture[] {
       /* skip malformed */
     }
   }
-  // stable display order: diverge first, then empty, then match; alpha within.
+  // stable display order: diverge first, then inconclusive (empty/non-gradeable),
+  // then match; alpha within.
   const rank = (v: EffVerdict) =>
-    isDivergeEff(v) ? 0 : v.includes('EMPTY') ? 1 : 2
-  out.sort((a, b) => rank(effectiveVerdict(a.report)) - rank(effectiveVerdict(b.report)) || a.name.localeCompare(b.name))
+    isDivergeEff(v) ? 0 : isInconEff(v) ? 1 : 2
+  out.sort((a, b) => rank(effectiveVerdict(a.report, a.name)) - rank(effectiveVerdict(b.report, b.name)) || a.name.localeCompare(b.name))
   return out
 }
 
@@ -145,8 +156,8 @@ function fmtStamp(ts: string): string {
 
 // ── HTML fragments ───────────────────────────────────────────────────────────
 function verdictBadge(v: EffVerdict): string {
-  const cls = isMatchEff(v) ? 'pass' : v.includes('EMPTY') ? 'incon' : 'fail'
-  const icon = isMatchEff(v) ? '✓' : v.includes('EMPTY') ? '⚠' : '✗'
+  const cls = isMatchEff(v) ? 'pass' : isInconEff(v) ? 'incon' : 'fail'
+  const icon = isMatchEff(v) ? '✓' : isInconEff(v) ? '⚠' : '✗'
   return `<span class="verdict ${cls}">${icon} ${esc(v)}</span>`
 }
 
@@ -194,8 +205,14 @@ function streamRows(evs: OscEvent[]): string {
 
 function fixtureCard(c: Capture): string {
   const r = c.report
-  const eff = effectiveVerdict(r)
-  const reasons = r.reasons.map((x) => `<li>${esc(x)}</li>`).join('')
+  const eff = effectiveVerdict(r, c.name)
+  // #549: lead with the non-gradeable reason and suppress the structure/onset
+  // reasons + sequence line below — for these fixtures the desktop side is the
+  // limit, so those signals describe a desktop fixture failure, not the engine.
+  const ngReason = eff === 'NON-GRADEABLE' ? nonGradeableReason(c.name) : null
+  const reasons = ngReason
+    ? `<li>Not gradeable against desktop — ${esc(ngReason)}</li>`
+    : r.reasons.map((x) => `<li>${esc(x)}</li>`).join('')
   const voiceRows = r.rows.map(rowCells).join('')
   const fxRows = r.fxRows.length
     ? `<div class="tbl-h">FX</div><table class="diff"><thead><tr><th>synthdef</th><th>desktop</th><th>web</th><th>ratio</th><th>d@onset</th><th>w@onset</th><th>status</th></tr></thead><tbody>${r.fxRows.map(rowCells).join('')}</tbody></table>`
@@ -203,7 +220,7 @@ function fixtureCard(c: Capture): string {
   const stamp = fmtStamp(c.ts)
   // SV61/SV69 onset-sequence + per-tick NOTE parity line (when judged).
   const sp = r.sequenceParity
-  const seqLine = sp && sp.match !== null
+  const seqLine = ngReason ? '' : sp && sp.match !== null
     ? `<div class="totals">Onset-sequence + note parity (SV61/SV69, ε=${sp.epsilonMs}ms): <b style="color:${sp.match ? 'var(--pass)' : 'var(--fail)'}">${sp.match ? '✓ MATCH' : '✗ DIVERGE'}</b>${sp.match === false ? ` — ${esc(sp.reasons.find(x => /mis-timed|NOTE multiset|wrong notes/.test(x)) ?? sp.reasons[0] ?? 'onset/notes diverge')}` : ''}</div>`
     : ''
   return `<section class="fx-card" id="${esc(c.name)}">
@@ -234,9 +251,11 @@ const captures = loadCaptures()
 // match = EVENT-MATCH; structure-match but onset/notes diverge = SEQUENCE-DIVERGE
 // (a real divergence, the #537 PRNG class) — folded into `diverge`, not `match`.
 const counts = {
-  match: captures.filter((c) => isMatchEff(effectiveVerdict(c.report))).length,
-  diverge: captures.filter((c) => isDivergeEff(effectiveVerdict(c.report))).length,
-  empty: captures.filter((c) => effectiveVerdict(c.report).includes('EMPTY')).length,
+  match: captures.filter((c) => isMatchEff(effectiveVerdict(c.report, c.name))).length,
+  diverge: captures.filter((c) => isDivergeEff(effectiveVerdict(c.report, c.name))).length,
+  empty: captures.filter((c) => effectiveVerdict(c.report, c.name).includes('EMPTY')).length,
+  // #549: desktop-side non-gradeable fixtures — reported, never counted as divergers.
+  nonGradeable: captures.filter((c) => effectiveVerdict(c.report, c.name) === 'NON-GRADEABLE').length,
   total: captures.length,
 }
 const now = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC'
@@ -249,7 +268,7 @@ writeFileSync(
       counts,
       fixtures: captures.map((c) => ({
         name: c.name,
-        verdict: effectiveVerdict(c.report),       // SV61/SV69 effective (folds onset/note parity)
+        verdict: effectiveVerdict(c.report, c.name), // SV61/SV69 effective (folds onset/note parity; #549 non-gradeable)
         structureVerdict: c.report.verdict,         // raw multiset verdict (pre-sequence)
         sequenceMatch: c.report.sequenceParity?.match ?? null,
         isPrng: c.report.isPrng,
@@ -353,6 +372,7 @@ ${navBlock('event-level /s_new parity · #446')}
     <span class="stat pass">EVENT-MATCH <b>${counts.match}</b></span>
     <span class="stat fail">DIVERGE <b>${counts.diverge}</b></span>
     <span class="stat incon">EMPTY <b>${counts.empty}</b></span>
+    <span class="stat incon">NON-GRADEABLE <b>${counts.nonGradeable}</b></span>
     <span class="stat">fixtures <b>${counts.total}</b></span>
   </div>
   <div class="caveat">
@@ -368,5 +388,5 @@ ${navBlock('event-level /s_new parity · #446')}
 writeFileSync(join(TR, 'event-diff.html'), html)
 console.log(`✓ wrote test_results/event-diff.html + event-diff.json`)
 console.log(
-  `  ${counts.total} fixtures · MATCH ${counts.match} · DIVERGE ${counts.diverge} · EMPTY ${counts.empty}`,
+  `  ${counts.total} fixtures · MATCH ${counts.match} · DIVERGE ${counts.diverge} · EMPTY ${counts.empty} · NON-GRADEABLE ${counts.nonGradeable}`,
 )

--- a/tools/lib/non-gradeable.ts
+++ b/tools/lib/non-gradeable.ts
@@ -1,0 +1,54 @@
+/**
+ * non-gradeable.ts — the single source of truth for fixtures that CANNOT be
+ * graded by desktop↔web `/s_new` event-parity, because the DESKTOP REFERENCE
+ * side produces ~no usable events (#549). The web output is correct; there is
+ * simply nothing trustworthy to diff against.
+ *
+ * This is DISTINCT from a `DESKTOP-EMPTY` verdict. DESKTOP-EMPTY means desktop
+ * produced zero voice events in THIS run — which is usually a transient
+ * scsynth/harness failure worth investigating (so it stays surfaced). The
+ * entries below are KNOWN-STRUCTURAL desktop-side limits that recur on every
+ * run, so counting them as divergences (or even as "empty, check scsynth") is
+ * an over-report (the SP139 class — the dashboard claiming a web bug where the
+ * web engine is correct).
+ *
+ * Keep this list EXPLICIT and reasoned. Never replace it with a heuristic like
+ * "desktop produced far fewer events than web" — that would silently swallow a
+ * genuine web over-production regression. A fixture earns a place here only
+ * after a grounded desktop A/B observation shows the desktop side is the limit.
+ */
+
+export interface NonGradeableEntry {
+  /** Why this fixture cannot be graded against the desktop reference. */
+  reason: string
+}
+
+/**
+ * Keyed by the capture `name` (the .rb basename without extension, as written
+ * by event-parity.ts into `eventparity_*.json`).
+ */
+export const NON_GRADEABLE: Record<string, NonGradeableEntry> = {
+  iso_density: {
+    reason:
+      'Ultra-short (~0.75s) non-looping piece: desktop produces 0 voice /s_new ' +
+      'because the run finishes before/around the dumpOSC capture window. Web ' +
+      'emits the correct 5 beeps (with_density 2 → 60,64 ×2, plus 72).',
+  },
+  e2e_08_math_misc: {
+    reason:
+      'Synthetic E2E coverage fixture (factor_q / bools / play_pattern_timed / ' +
+      'play_chord soup) ending in `stop`. Desktop halts early (~2 events) when a ' +
+      'helper not present on this Sonic Pi version raises; web runs the full ~18. ' +
+      'Web is correct — the divergence is the desktop fixture, not the engine.',
+  },
+}
+
+/** True when this fixture is a known non-gradeable desktop-side case. */
+export function isNonGradeable(name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(NON_GRADEABLE, name)
+}
+
+/** The documented reason a fixture is non-gradeable, or null if it is gradeable. */
+export function nonGradeableReason(name: string): string | null {
+  return NON_GRADEABLE[name]?.reason ?? null
+}


### PR DESCRIPTION
## Problem

Two event-diff dashboard "divergers" were **comparator false-positives** — the **desktop reference side** produces ~no usable events, so there is nothing trustworthy to grade and the web output is correct (the SP139 over-report class).

| fixture | desktop | web | was counted as |
|---|---|---|---|
| `iso_density` | **0** voice `/s_new` (~0.75s non-looping piece finishes before/around the dumpOSC window) | 5 correct beeps | `DESKTOP-EMPTY` (⚠) |
| `e2e_08_math_misc` | **2** then halts (synthetic helper raises on this SP version; ends in `stop`) | full ~18 | `SEQUENCE-DIVERGE` (✗ diverger) |

Observed live (`event-parity.ts`): iso_density → `⚠ DESKTOP-EMPTY`; e2e_08 → effective `SEQUENCE-DIVERGE` (`beep d2/w18`, mis-timed @#1). Neither is a web-engine bug.

## Fix

Add **`tools/lib/non-gradeable.ts`** — a single, **explicit, reasoned** source of truth for fixtures that cannot be graded against the desktop reference. The event-diff dashboard (`build-event-diff.ts`) `effectiveVerdict` now returns `NON-GRADEABLE` for listed fixtures **before** any structure/sequence check, so a desktop-side fixture failure can't masquerade as a web divergence.

`NON-GRADEABLE` is:
- badged **⚠ inconclusive** (like `EMPTY`) and ranked with the inconclusives,
- **excluded from the diverger count** (new `counts.nonGradeable`, surfaced in the hero + console summary),
- shown leading with its **documented reason**, with the structure/onset reasons + sequence line suppressed (those describe the desktop fixture, not the engine).

### Why a list, not a heuristic
Deliberately **not** `"desktop produced far fewer events than web → skip"` — that would silently swallow a genuine web **over-production** regression. A fixture earns a place only after a grounded desktop A/B observation shows the desktop side is the limit. Distinct from `DESKTOP-EMPTY` (a transient scsynth/harness failure worth investigating — stays surfaced).

## Test plan
- **L1**: `1432/1432` vitest + `tsc --noEmit` clean. New `tools/__tests__/non-gradeable.test.ts` (5 cases incl. a `hasOwnProperty` guard so `toString`/`constructor` aren't mistaken for flagged fixtures).
- **Observed**: regenerated the dashboard against live captures → `iso_density` + `e2e_08_math_misc` both classify `NON-GRADEABLE` and drop out of the diverger count.

> The generated `event-diff.json/html` are **not** committed — a dashboard regen is a full-SK22-sweep artifact; a partial regen re-mixes stale per-fixture captures (SP139). This PR ships only the classification code; the next full sweep picks it up.

closes #549