### PR TITLE
🎚️ fix(transpiler): ring `.look(:name)` forwards its tick-name arg (#552)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1755,8 +1755,15 @@ function transpileReceiverMethodCall(
     return `${recStr}?.at(__b.tick())`
   }
 
-  // .look / .look() → .at(__b.look())
+  // .look / .look(:name) → .at(__b.look()) / .at(__b.look("name"))
+  // Forward the tick-name arg (mirrors .tick above). Without it, `ring.look(:note)`
+  // read the DEFAULT tick instead of the :note tick — wrong notes whenever the
+  // default tick is independently advanced (square_skit: `tick(:note) if factor? tick, 4`
+  // bumps the default tick every iteration, so the dropped-name look incremented the
+  // ring index every play instead of holding it). Issue #552.
   if (method === 'look') {
+    const args = argsNode ? transpileArgList(argsNode, ctx) : ''
+    if (args) return `${recStr}?.at(__b.look(${args}))`
     return `${recStr}?.at(__b.look())`
   }
 

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -2247,6 +2247,18 @@ end`)
       expect(result.ok).toBe(true)
       expect(result.code).toContain('?.at(__b.look())')
     })
+
+    it('#552: ring .look(:name) forwards the tick name (not the default tick)', () => {
+      const result = treeSitterTranspile(`live_loop :t do
+  play (knit :c2, 2, :e1, 1).look(:note)
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      // The :note arg must reach look — else it reads the DEFAULT tick (wrong notes
+      // when the default tick is independently advanced, e.g. square_skit).
+      expect(result.code).toContain('?.at(__b.look("note"))')
+      expect(result.code).not.toContain('?.at(__b.look())')
+    })
   })
 
   // Phase A — error hardening (#185): previously silent passthroughs now


### PR DESCRIPTION
## Problem

The transpiler's ring `.look` handler dropped its argument. `(knit ...).look(:note)` transpiled to:

```js
(__b.knit("c2",2,"e1",1))?.at(__b.look())   // ← :note dropped → reads the DEFAULT tick
```

The sibling `.tick` handler (`TreeSitterTranspiler.ts:1752`) forwards `args`; `.look` (1758) hard-coded `__b.look()`.

## Impact — `square_skit` (the lone genuine SK22 gradeable diverger)

```ruby
tick(:note) if factor? tick, 4
play (knit :c2, 2, :e1, 1, :f3, 1).look(:note), ...
```

`factor? tick, 4` advances the **default** tick every iteration. Because `.look(:note)` read the default tick (not `:note`), the ring index moved every play:
- **web (before):** `36,36,28,53,…` — index advances every play
- **desktop:** `36×8, 28×4, 53×4` — `:note` held while `factor?` is false (advances 1-in-4)

Event-parity: `square` layer "times match but **NOTES differ**".

## Fix

Mirror the `.tick` handler — forward the args:
```js
if (method === 'look') {
  const args = argsNode ? transpileArgList(argsNode, ctx) : ''
  if (args) return `${recStr}?.at(__b.look(${args}))`
  return `${recStr}?.at(__b.look())`
}
```
No-arg `.look` is byte-identical (both existing array-/`times`-look tests still pass); `.look(:foo, 2)` forwards name+offset too.

## Test plan
- **L1:** `1435/1435` vitest + `tsc --noEmit` clean. New transpiler test asserts `(knit …).look(:note)` → `?.at(__b.look("note"))` and *not* the bare `__b.look()`.
- **L3 desktop A/B:** `square_skit` `square` layer `DIVERGE (wrong notes)` → **✓ EVENT-MATCH** (82 onsets, max Δ5ms, notes ✓); note hold-pattern now identical to desktop (`36×16,…`).

## Context
Found during #537 Class-A verification. Class A itself (ambient / lorezzed / orchard_improv) turned out **already EVENT-MATCH** post-#543/#546/#548 — re-verified live this session. `square_skit` was the only remaining genuine gradeable diverger in the SK22 corpus, so this brings the gradeable corpus to full parity (the 2 remaining non-passers are `blimp_zones`/`shufflit`, uncapturable `invalid [heavy]`, excluded from the gate).

closes #552