### PR TITLE
🎚️ fix(dsl): line() defaults to endpoint-exclusive, matching desktop (#554)

### DIFF
--- a/src/engine/Ring.ts
+++ b/src/engine/Ring.ts
@@ -317,14 +317,20 @@ export function halves(start: number, num_halves: number = 1): Ring<number> {
 }
 
 /**
- * Line: generate a line of N values between start and end.
- * line(60, 72, 5) → Ring([60, 63, 66, 69, 72])
+ * Line: ring of `steps` evenly-spaced values from start towards finish.
+ * Endpoint-EXCLUSIVE by default (matches desktop Sonic Pi `line`, core.rb:1901):
+ *   line(60, 72, steps: 4)                  → Ring([60, 63, 66, 69])   (step (finish-start)/steps)
+ *   line(60, 72, steps: 4, inclusive: true) → Ring([60, 64, 68, 72])   (step (finish-start)/(steps-1))
  */
 export function line(start: number, finish: number, stepsOrOpts: number | { steps?: number; inclusive?: boolean } = 4): Ring<number> {
   const steps = typeof stepsOrOpts === 'number' ? stepsOrOpts : (stepsOrOpts.steps ?? 4)
+  const inclusive = typeof stepsOrOpts === 'number' ? false : (stepsOrOpts.inclusive === true)
+  // Desktop returns an empty ring when start == finish (core.rb:1904).
+  if (start === finish) return new Ring<number>([])
+  const denom = inclusive ? steps - 1 : steps
   const result: number[] = []
   for (let i = 0; i < steps; i++) {
-    result.push(steps === 1 ? start : start + (finish - start) * (i / (steps - 1)))
+    result.push(start + (finish - start) * (i / denom))
   }
   return new Ring(result)
 }

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { SeededRandom } from '../SeededRandom'
-import { Ring, ring, ramp, stretch, doubles, halves, Ramp } from '../Ring'
+import { Ring, ring, ramp, stretch, doubles, halves, Ramp, line } from '../Ring'
 import { spread } from '../EuclideanRhythm'
 import { noteToMidi, midiToFreq, noteToFreq, noteInfo } from '../NoteToFreq'
 import { MidiBridge } from '../MidiBridge'
@@ -108,6 +108,39 @@ describe('Ring', () => {
   it('is iterable', () => {
     const r = ring(1, 2, 3)
     expect([...r]).toEqual([1, 2, 3])
+  })
+
+  // #554 — desktop Sonic Pi core.rb:1901-1916 parity. Previously `line` defaulted
+  // to the INCLUSIVE formula (/(steps-1), reaching `finish`); desktop's default is
+  // endpoint-EXCLUSIVE (/steps). This produced wrong notes in e2e_05 (line.tick).
+  describe('line (#554 desktop parity)', () => {
+    it('default is endpoint-exclusive: line(60,72,steps:4) → [60,63,66,69]', () => {
+      expect(line(60, 72, { steps: 4 }).toArray()).toEqual([60, 63, 66, 69])
+    })
+
+    it('doc example: line(0,4,steps:4) → [0,1,2,3]', () => {
+      expect(line(0, 4, { steps: 4 }).toArray()).toEqual([0, 1, 2, 3])
+    })
+
+    it('descending: line(5,0,steps:5) → [5,4,3,2,1]', () => {
+      expect(line(5, 0, { steps: 5 }).toArray()).toEqual([5, 4, 3, 2, 1])
+    })
+
+    it('inclusive: true reaches finish: line(60,72,steps:4,inclusive:true) → [60,64,68,72]', () => {
+      expect(line(60, 72, { steps: 4, inclusive: true }).toArray()).toEqual([60, 64, 68, 72])
+    })
+
+    it('inclusive doc example: line(0,3,inclusive:true) → [0,1,2,3]', () => {
+      expect(line(0, 3, { inclusive: true }).toArray()).toEqual([0, 1, 2, 3])
+    })
+
+    it('start == finish returns empty ring (core.rb:1904)', () => {
+      expect(line(60, 60, { steps: 4 }).toArray()).toEqual([])
+    })
+
+    it('numeric positional steps still works (exclusive): line(60,72,4) → [60,63,66,69]', () => {
+      expect(line(60, 72, 4).toArray()).toEqual([60, 63, 66, 69])
+    })
   })
 
   // #354 — desktop Sonic Pi core.rb:796-805 parity. Previously mirror/reflect


### PR DESCRIPTION
Closes #554.

## Problem

`Ring.ts` `line()` used the **inclusive** formula `i/(steps-1)` (reaching `finish`) as its default and ignored the `inclusive:` opt. Desktop Sonic Pi's `line` (`core.rb:1901-1916`) is endpoint-**exclusive** by default (`i/steps`) and only reaches `finish` with `inclusive: true`.

So `line(60, 72, steps: 4)` returned `[60, 64, 68, 72]` instead of desktop's `[60, 63, 66, 69]` — wrong notes wherever `line().tick` is played (surfaced in `e2e_05_data_structures`).

## Fix

- Default to `/steps` (exclusive), matching desktop.
- Honor `inclusive: true` → `/(steps-1)`.
- Return an empty ring when `start == finish` (`core.rb:1904`).

Doc-example parity (`core.rb:1928-1930`):
- `line(0, 4, steps: 4)` → `[0, 1, 2, 3]`
- `line(5, 0, steps: 5)` → `[5, 4, 3, 2, 1]`
- `line(0, 3, inclusive: true)` → `[0, 1, 2, 3]`

## Test plan

- [x] tsc clean, **1442/1442** vitest pass (+7 new `line` tests in DSLHelpers).
- [x] L3 A/B vs running desktop: `line(60,72,steps:4)` repro → **EVENT-MATCH** (notes ✓, Δ 0ms).
- [x] L3 A/B `e2e_05`: beep note prefix now matches **all 18** desktop events (was 14).

## Note

The residual `e2e_05` count gap (desktop 18 vs web 41) is a **desktop-side halt** on `line 60, 72, 1` (a positional-arg quirk desktop rejects — the fixture's "was NaN bug" case). Our engine is more lenient/complete there; that is out of scope for this fix.
