### PR TITLE
🎚️ fix(audio): control of a running synth applies on web (#557)

### DIFF
--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -745,10 +745,23 @@ export class SuperSonicBridge {
    * The await in ensureSynthDefLoaded creates a microtask yield even on cache hit,
    * which at 43 events/sec causes significant event loop contention. See #71.
    */
+  /**
+   * Reserve the next scsynth node id WITHOUT queuing anything. The caller binds
+   * its ref→nodeId map synchronously and passes the same id back into
+   * `triggerSynth` (#557). Node ids are just a monotonic counter, so reserving
+   * one up front is free and lets a same-instant `control` (no intervening
+   * sleep) resolve THIS synth's node before the async synthdef load resolves.
+   */
+  reserveNodeId(): number {
+    if (!this.sonic) throw new Error('SuperSonic not initialized')
+    return this.sonic.nextNodeId()
+  }
+
   triggerSynth(
     synthName: string,
     audioTime: number,
-    params: Record<string, number>
+    params: Record<string, number>,
+    nodeId?: number,
   ): Promise<number> {
     if (!this.sonic) throw new Error('SuperSonic not initialized')
 
@@ -756,12 +769,14 @@ export class SuperSonicBridge {
 
     // Fast path: synthdef already loaded — skip async entirely
     if (this.loadedSynthDefs.has(fullName)) {
-      return Promise.resolve(this.triggerSynthImmediate(fullName, audioTime, params))
+      return Promise.resolve(this.triggerSynthImmediate(fullName, audioTime, params, nodeId))
     }
 
-    // Slow path: load synthdef first (only happens once per synth name)
+    // Slow path: load synthdef first (only happens once per synth name). The
+    // returned promise still REJECTS on a CDN miss (SV43/SP89), so the caller's
+    // .catch can surface it — the pre-reserved `nodeId` doesn't change that.
     return this.ensureSynthDefLoaded(fullName).then(() =>
-      this.triggerSynthImmediate(fullName, audioTime, params)
+      this.triggerSynthImmediate(fullName, audioTime, params, nodeId)
     )
   }
 
@@ -769,8 +784,11 @@ export class SuperSonicBridge {
     fullName: string,
     audioTime: number,
     params: Record<string, number>,
+    preReservedNodeId?: number,
   ): number {
-    const nodeId = this.sonic!.nextNodeId()
+    // Use the caller's pre-reserved id when given (#557) so the /s_new targets
+    // exactly the node the interpreter already bound into nodeRefMap.
+    const nodeId = preReservedNodeId ?? this.sonic!.nextNodeId()
     const paramList: (string | number)[] = []
     this.pushFiniteParams(paramList, params, `synth ${fullName.replace('sonic-pi-', ':')}`)
     this.queueMessage(audioTime, '/s_new', [fullName, nodeId, 0, 100, ...paramList])

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -632,8 +632,14 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       const lhsStr = transpileNode(lhs, ctx)
       const rhsStr = transpileNode(rhs, ctx)
 
-      // If RHS is __b.play or __b.sample, capture lastRef
-      if (ctx.insideLoop && /^__b\.(play|sample)\(/.test(rhsStr)) {
+      // If RHS is __b.play or __b.sample, capture lastRef so a later
+      // `control p, …` / `kill p` resolves the synth's node ref. Applies at
+      // top level too, not just inside loops (#557): `p = play …; control p`
+      // at the top level is valid Sonic Pi — gating this on `insideLoop` left
+      // `p` bound to the builder object, so `control(p)` never resolved in
+      // nodeRefMap and was silently dropped. The regex matches only a direct
+      // play/sample call as the whole RHS, so chained/compound RHS is untouched.
+      if (/^__b\.(play|sample)\(/.test(rhsStr)) {
         return `${rhsStr}; ${lhsStr} = __b.lastRef`
       }
 

--- a/src/engine/__tests__/ControlRunningSynth.test.ts
+++ b/src/engine/__tests__/ControlRunningSynth.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #557 — `control p, …` on a RUNNING SYNTH node (not an FX node) must reach
+ * scsynth and target THIS iteration's live synth.
+ *
+ * Symptom (found via fm_noise, which "sounds like a static piano, not FM" on
+ * web — user's ears): a `control p, divisor: X` change to a running :fm synth
+ * is inaudible on web while desktop applies it (exp-019: web with-ctrl vs
+ * no-ctrl spectral cosine 0.97 = IGNORED; desktop 0.14 = applied).
+ *
+ * Root cause (proven via the live OSC log, not this harness — see below): the
+ * play case bound nodeRefMap via the ASYNC `.then` on triggerSynth, a microtask
+ * that runs only AFTER the iteration's synchronous steps. So a same-iteration
+ * `control` (fm_noise has NO sleep between play and control) read either an
+ * empty map (iteration 1 → /n_set dropped) or the PREVIOUS iteration's
+ * already-freed node (iteration N → /n_set to a dead node). Real web OSC log:
+ *   [t:2.97] /s_new sonic-pi-fm 11003 …   (iter 1 synth)
+ *   [t:8.97] /s_new sonic-pi-fm 11004 …   (iter 2 synth)
+ *   [t:8.97] /n_set 11003 {divisor: 30}   ← targets 11003 (freed), not 11004
+ * Fix: reserve the node id synchronously (bridge.reserveNodeId) and bind
+ * nodeRefMap BEFORE the next step runs, so control resolves the live node.
+ *
+ * NB: a fake-scheduler unit test cannot reproduce the browser's exact
+ * microtask timing (the drive loop's awaits flush the .then early), so the
+ * DECISIVE regression evidence is the Level-2 OSC capture + Level-3 audio A/B
+ * (web ctrl vs no-ctrl spectral cosine drops from 1.0000). This test guards the
+ * SYNC-BINDING CONTRACT: with a reserveNodeId-capable bridge, every control
+ * targets a node that was reserved THIS run and carries the controlled value.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+type SchedulerLike = { tick: (t: number) => void }
+
+async function drive(engine: SonicPiEngine, targetVt = 4, steps = 8) {
+  const scheduler = (engine as unknown as { scheduler: SchedulerLike | null }).scheduler
+  if (!scheduler) return
+  for (let i = 1; i <= steps; i++) {
+    scheduler.tick((targetVt * i) / steps)
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+/**
+ * Spy bridge modelling the real SuperSonicBridge's #557 contract: reserveNodeId
+ * hands out the id synchronously and triggerSynth honours that pre-reserved id
+ * for its /s_new. Records every synth id and every sendTimedControl target.
+ */
+function createSpyBridge() {
+  const synths: Array<{ id: number; params: Record<string, number> }> = []
+  const controls: Array<{ nodeId: number; params: (string | number)[] }> = []
+  let nextNode = 9000
+  let nextBus = 16
+  const impl: Record<string, unknown> = {
+    allocateBus: () => nextBus++,
+    createFxGroup: () => nextNode++,
+    async applyFxOrdered() { return nextNode++ },
+    reserveNodeId: () => nextNode++,
+    async triggerSynth(_name: string, _t: number, params: Record<string, number>, nodeId?: number) {
+      const id = nodeId ?? nextNode++
+      synths.push({ id, params: { ...params } })
+      return id
+    },
+    async playSample() { return nextNode++ },
+    async ensureSamplePlaybackDuration() { return 1 },
+    sendTimedControl(_time: number, nodeId: number, params: (string | number)[]) {
+      controls.push({ nodeId, params })
+    },
+    freeNode() { /* no-op */ },
+    get audioContext() { return null },
+  }
+  const proxy = new Proxy(impl, {
+    get(target, prop: string) {
+      if (prop in target) return (target as Record<string, unknown>)[prop]
+      return () => undefined
+    },
+  })
+  return { bridge: proxy, synths, controls }
+}
+
+function paramsToObj(params: (string | number)[]): Record<string, number> {
+  const o: Record<string, number> = {}
+  for (let i = 0; i + 1 < params.length; i += 2) o[String(params[i])] = Number(params[i + 1])
+  return o
+}
+
+describe('control of a running synth targets a live node (#557)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('every /n_set targets a synth reserved this run, carrying the controlled value (fm_noise shape)', async () => {
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+
+    // The transpiler emits `__b.play(...); p = __b.lastRef` for the in-loop
+    // `p = play …`, then `__b.control(p, …)`. Same shape as fm_noise's sci_fi
+    // loop: control immediately after play, NO sleep between.
+    const r = await engine.evaluate(`use_synth :fm
+live_loop :sci_fi do
+  p = play 60, divisor: 1, depth: 2, sustain: 0.4, release: 0.1, amp: 0.7
+  control p, divisor: 30
+  sleep 1
+end`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 4, 8)
+
+    expect(spy.synths.length).toBeGreaterThan(1)
+    expect(spy.controls.length).toBeGreaterThan(0)
+
+    // Every control targets a node that is actually a synth this run (never a
+    // stale id from outside the run), and carries divisor: 30.
+    const synthIds = new Set(spy.synths.map((s) => s.id))
+    for (const c of spy.controls) {
+      expect(synthIds.has(c.nodeId)).toBe(true)
+      expect(paramsToObj(c.params).divisor).toBe(30)
+    }
+    engine.dispose()
+  })
+
+  it('top-level `p = play; control p` also resolves a ref (transpiler lastRef capture)', async () => {
+    // Documents the second, distinct manifestation: at top level (NOT inside a
+    // loop) the transpiler must still capture lastRef so `control p` gets a
+    // numeric ref rather than the builder object (which never resolves in
+    // nodeRefMap → control silently dropped). See TreeSitterTranspiler.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+    const r = await engine.evaluate(`use_synth :fm
+p = play 60, divisor: 1, depth: 2, sustain: 4, release: 0.5, amp: 0.7
+control p, divisor: 30
+sleep 7`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 8, 16)
+
+    expect(spy.synths.length).toBe(1)
+    // The control must reach the one synth that was triggered.
+    expect(spy.controls.length).toBeGreaterThan(0)
+    expect(spy.controls.every((c) => c.nodeId === spy.synths[0].id)).toBe(true)
+    expect(paramsToObj(spy.controls[0].params).divisor).toBe(30)
+    engine.dispose()
+  })
+})

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -187,8 +187,28 @@ export async function runProgram(
             : undefined
           const params = normalizePlayParams(synth, step.opts, currentBpm, playWarn)
           params.out_bus = task.outBus
-          ctx.bridge.triggerSynth(synth, audioTime, params)
-            .then(realNodeId => ctx.nodeRefMap.set(nodeRef, realNodeId))
+          // #557: bind nodeRefMap SYNCHRONOUSLY so a same-iteration `control`
+          // (no intervening sleep — e.g. fm_noise's `p = play …; control p,
+          // divisor: …`) resolves THIS synth's live node. Previously the map
+          // was populated by the async `.then` on triggerSynth — a microtask
+          // that runs only AFTER the iteration's synchronous steps complete.
+          // So `control` read either an empty map (iteration 1 → /n_set
+          // dropped) or the PREVIOUS iteration's already-freed node (iteration
+          // N → /n_set to a dead node). Both made `control` of a running synth
+          // inaudible on web while desktop applied it (#557 / exp-019). Reserve
+          // the id up front (a free counter increment) and hand it to
+          // triggerSynth, which still loads the synthdef async and still
+          // REJECTS on a CDN miss (SV43/SP89). The `reserveNodeId` guard keeps
+          // older mock bridges (no such method) on the legacy async-bind path.
+          let preReservedNodeId: number | undefined
+          if (typeof ctx.bridge.reserveNodeId === 'function') {
+            preReservedNodeId = ctx.bridge.reserveNodeId()
+            ctx.nodeRefMap.set(nodeRef, preReservedNodeId)
+          }
+          ctx.bridge.triggerSynth(synth, audioTime, params, preReservedNodeId)
+            .then(realNodeId => {
+              if (preReservedNodeId === undefined) ctx.nodeRefMap.set(nodeRef, realNodeId)
+            })
             .catch((err: Error) => {
               ctx.printHandler?.(`Synth '${synth}' failed: ${err.message}`)
             })


### PR DESCRIPTION
## Problem

`control p, divisor: X` on a running synth was **inaudible on web** while desktop applied it. Reported by ear: `fm_noise` "sounds like a static piano, not FM" (its character is `control p, divisor: rrand(0.001,50)` every iteration). exp-019 quantified it: web with-ctrl vs no-ctrl spectral cosine **0.97** (ignored) vs desktop **0.14** (applied).

Two distinct root causes, both in the play→control node-ref binding:

1. **In-loop** (fm_noise): the `AudioInterpreter` play case bound `nodeRefMap` via the **async `.then`** on `triggerSynth` — a microtask that runs only *after* the iteration's synchronous steps. A same-iteration `control` (no `sleep` between play and control) therefore read an empty map (iteration 1 → `/n_set` dropped) or the **previous iteration's already-freed node** (iteration N → `/n_set` to a dead node). Live web OSC log proved it:
   ```
   /s_new sonic-pi-fm 11003 @t2.97
   /s_new sonic-pi-fm 11004 @t8.97
   /n_set 11003 @t8.97   ← targets 11003 (freed ~t7.5), not 11004
   ```
2. **Top-level** (fm-glide — exp-019's actual repro): the transpiler captured `lastRef` for `p = play …` only `if (ctx.insideLoop)`. At top level `p` bound the **builder object**, so `control(p)` never resolved in `nodeRefMap` → dropped, **no `/n_set` at all**. exp-019 mis-attributed this to "WASM ignores the `/n_set`" — but fm-glide is top-level, so it was the transpiler drop, not a render bug.

## Fix

Bind `nodeRefMap` **synchronously**:
- `SuperSonicBridge.reserveNodeId()` (node ids are a free counter increment) + an optional pre-reserved `nodeId` on `triggerSynth`. The interpreter reserves the id, binds the map **before the next step runs**, and hands the id to `triggerSynth` — which still loads the synthdef async and still **rejects on a CDN miss** (SV43/SP89 preserved). A `reserveNodeId` guard keeps older mock bridges on the legacy async-bind path.
- Drop the transpiler's `insideLoop` gate so top-level `p = play; control p` captures `lastRef` too (regex still matches only a direct `play`/`sample` RHS).

## Test plan (Lokayata — observed, not inferred)

- **L2 (OSC):** post-fix `/n_set` targets each iteration's own live node co-bundled with its `/s_new` (`11003→11003`, `11004→11004`, …) — verified on the deterministic fixture **and** the real `fm_noise` piece.
- **L3 (audio):** web ctrl-vs-noctrl spectral cosine **1.0000 → 0.2214** (control now audible, matching desktop's 0.14).
- **Desktop parity:** `compare-desktop-vs-web` event-parity **STRUCTURE-MATCH** (2 voices both sides).
- **L1:** full suite **1437/1437** + `tsc --noEmit` clean. New `ControlRunningSynth.test.ts` guards the sync-binding contract for both manifestations.

### Method lesson (captured in hetvabhasa SP152)
A fake-scheduler spy test **passed pre-fix** because the harness's `await setTimeout` between ticks flushed the `.then` microtask — a checkpoint the real synchronous scheduler lacks. Observation (real OSC log) beat inference (green unit test); the decisive oracle for this class is the Level-2 OSC capture + Level-3 audio A/B.

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)