### PR TITLE
🧪 chore(tooling): mark counter non-gradeable — desktop thread-race non-determinism (#562)

### DIFF
--- a/tools/__tests__/non-gradeable.test.ts
+++ b/tools/__tests__/non-gradeable.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { NON_GRADEABLE, isNonGradeable, nonGradeableReason } from '../lib/non-gradeable.ts'
 
 describe('non-gradeable fixtures (#549)', () => {
-  it('flags the two known desktop-side non-gradeable fixtures', () => {
+  it('flags the known desktop-side non-gradeable fixtures (both sub-classes)', () => {
+    // Sub-class A — desktop-sparse (#549).
     expect(isNonGradeable('iso_density')).toBe(true)
     expect(isNonGradeable('e2e_08_math_misc')).toBe(true)
+    // Sub-class B — desktop-non-deterministic (counter: racing live_loops).
+    expect(isNonGradeable('counter')).toBe(true)
   })
 
   it('does NOT flag a normal gradeable fixture', () => {
@@ -23,6 +26,7 @@ describe('non-gradeable fixtures (#549)', () => {
   it('nonGradeableReason returns the reason for listed fixtures, null otherwise', () => {
     expect(nonGradeableReason('iso_density')).toContain('non-looping')
     expect(nonGradeableReason('e2e_08_math_misc')).toContain('halts early')
+    expect(nonGradeableReason('counter')).toContain('DIFFERS run-to-run')
     expect(nonGradeableReason('cloud_beat')).toBeNull()
   })
 

--- a/tools/lib/non-gradeable.ts
+++ b/tools/lib/non-gradeable.ts
@@ -1,21 +1,37 @@
 /**
  * non-gradeable.ts — the single source of truth for fixtures that CANNOT be
  * graded by desktop↔web `/s_new` event-parity, because the DESKTOP REFERENCE
- * side produces ~no usable events (#549). The web output is correct; there is
- * simply nothing trustworthy to diff against.
+ * side is not a usable target. The web output is correct; there is simply
+ * nothing trustworthy to diff against.
  *
- * This is DISTINCT from a `DESKTOP-EMPTY` verdict. DESKTOP-EMPTY means desktop
- * produced zero voice events in THIS run — which is usually a transient
- * scsynth/harness failure worth investigating (so it stays surfaced). The
- * entries below are KNOWN-STRUCTURAL desktop-side limits that recur on every
- * run, so counting them as divergences (or even as "empty, check scsynth") is
- * an over-report (the SP139 class — the dashboard claiming a web bug where the
- * web engine is correct).
+ * Two grounded sub-classes earn a place here:
+ *
+ *   (A) DESKTOP-SPARSE (#549) — desktop produces ~no usable voice events on
+ *       every run (the run finishes before the dumpOSC window, or a fixture
+ *       helper raises and halts it early). iso_density, e2e_08_math_misc.
+ *
+ *   (B) DESKTOP-NON-DETERMINISTIC (#560-adjacent, counter) — desktop produces
+ *       events, but they are NOT REPRODUCIBLE: the fixture races two real
+ *       desktop threads, so the same code yields a DIFFERENT note sequence on
+ *       each desktop run. There is no stable reference to match, and web's
+ *       deterministic VirtualTimeScheduler output is the CORRECT behaviour by
+ *       design — replicating OS-thread jitter would be a regression of the
+ *       project's central determinism guarantee. Proven by capturing desktop
+ *       twice and observing the sequences differ while web is bit-identical.
+ *
+ * This is DISTINCT from a transient `DESKTOP-EMPTY` verdict (zero voice events
+ * in THIS run only — usually a scsynth/harness hiccup worth investigating, so
+ * it stays surfaced). The entries below are KNOWN-STRUCTURAL desktop-side
+ * limits that recur on every run, so counting them as divergences (or even as
+ * "empty, check scsynth") is an over-report (the SP139 class — the dashboard
+ * claiming a web bug where the web engine is correct).
  *
  * Keep this list EXPLICIT and reasoned. Never replace it with a heuristic like
- * "desktop produced far fewer events than web" — that would silently swallow a
- * genuine web over-production regression. A fixture earns a place here only
- * after a grounded desktop A/B observation shows the desktop side is the limit.
+ * "desktop produced far fewer events than web" or "desktop run-to-run differs"
+ * — either would silently swallow a genuine web regression. A fixture earns a
+ * place here only after a grounded desktop A/B observation shows the desktop
+ * side is the limit (sub-class A: re-capture shows ~0 events; sub-class B:
+ * two desktop runs produce different sequences while web is identical).
  */
 
 export interface NonGradeableEntry {
@@ -40,6 +56,20 @@ export const NON_GRADEABLE: Record<string, NonGradeableEntry> = {
       'play_chord soup) ending in `stop`. Desktop halts early (~2 events) when a ' +
       'helper not present on this Sonic Pi version raises; web runs the full ~18. ' +
       'Web is correct — the divergence is the desktop fixture, not the engine.',
+  },
+  counter: {
+    reason:
+      'Sub-class B (DESKTOP-NON-DETERMINISTIC). Cross-loop shared var: a :writer ' +
+      'live_loop increments `counter` and a :reader live_loop plays `60 + counter`, ' +
+      'both on the same beat. On desktop the two are REAL threads that race within ' +
+      'each beat, so the reader samples `counter` after a non-deterministic number ' +
+      'of writer increments — the note sequence DIFFERS run-to-run (observed at ' +
+      'use_bpm 60: run1 …66,68,68,69,70… vs run2 …66,67,68,70,71…; far larger jitter ' +
+      'at use_bpm 600). Web\'s VirtualTimeScheduler runs both loops in deterministic ' +
+      'lockstep (writer-first) → clean +1 per read, bit-identical run-to-run. Both ' +
+      'sides agree on the writer-first deterministic part; desktop only diverges ' +
+      'where its threads jitter. There is no stable desktop target to match, and ' +
+      'web determinism is the intended behaviour — not a bug to fix.',
   },
 }
 


### PR DESCRIPTION
## What

Resolves the lone remaining "gradeable" SEQUENCE-DIVERGE in the SK22 event-parity sweep — `counter` — by classifying it as **NON-GRADEABLE (sub-class B: desktop-non-deterministic)**, not by changing the engine. Web is correct.

## Why (observed, not inferred)

The fixture races a `:writer` live_loop (increments a shared `counter`) against a `:reader` live_loop (`play 60 + counter`) on the same beat. On desktop these are **real threads** → the reader samples `counter` after a non-deterministic number of writer increments.

Decisive test — capture desktop **twice** at `use_bpm 60`:
- DESKTOP run1: `…66,68,68,69,70…`
- DESKTOP run2: `…66,67,68,70,71…` ← **differs**
- WEB run1 == run2: `61,62,…,75` ← **identical**

Desktop has no stable target; web's `VirtualTimeScheduler` lockstep determinism is the **intended** behaviour (the engine's core thesis). `#548`/SV70 shared-var propagation works — both engines increment; only cross-loop **read timing** diverges, which is inherently racy on desktop.

## Change

- `tools/lib/non-gradeable.ts`: add `counter`; broaden the doc to name two grounded sub-classes — **A (desktop-sparse**, iso_density/e2e_08) and **B (desktop-non-deterministic**, counter). The dashboard's `effectiveVerdict` already maps listed names to NON-GRADEABLE → the next sweep stops over-reporting it (SP139 class).
- `tools/__tests__/non-gradeable.test.ts`: +assertions for `counter`.
- Logic-only; dashboards are regenerated by the full sweep, not committed here.

L1 green + `tsc` clean. Catalogued as vyapti SV72.

Closes #562