### PR TITLE
🧪 chore(tooling): bake the event-parity batch into the sweep pipeline (SP151)

### DIFF
--- a/tools/event-parity-prep.ts
+++ b/tools/event-parity-prep.ts
@@ -1,0 +1,75 @@
+/**
+ * event-parity-prep.ts — build the work manifest for the event-parity sweep
+ * (`event-parity-sweep.sh`). The event-diff dashboard (`build-event-diff.ts`)
+ * reads `.captures/eventparity_*.json`, which are written ONLY by
+ * `event-parity.ts` run per-fixture — the compare sweep never writes them
+ * (SP151). So to truly refresh event-diff you must re-run event-parity over the
+ * whole corpus first. This prep extracts the latest capture per fixture name
+ * and emits, for each, the exact `code` + `duration` it was last captured with
+ * → a temp `.rb` + a TSV manifest the sweep loop consumes.
+ *
+ * The corpus = whatever fixtures already have an `eventparity_*.json` capture
+ * (the same set the dashboard renders). New fixtures enter the corpus the first
+ * time they are event-parity'd directly; this refresh re-captures the existing
+ * set so the dashboard reflects the current engine.
+ *
+ * Output dir: `.captures/.ep-sweep/` (under the gitignored `.captures/`).
+ *   fixtures/<name>.rb   — the source for each fixture
+ *   manifest.tsv         — <name>\t<duration_ms>\t<rb_path>, one per line
+ *
+ * NAME PARSING (SP151 trap): capture files are
+ * `eventparity_<TS>_<name>.json` where the ISO-ish timestamp `<TS>` contains NO
+ * underscores (it uses dashes) but `<name>` MAY contain underscores
+ * (`sw_e2e_05_data_structures`, `10_idm_breakbeat`). So the name is everything
+ * after the SECOND `_`-delimited token. A naive `*_<name>.json` glob
+ * suffix-collides (`idm_breakbeat` would match `10_idm_breakbeat`); the sweep's
+ * resume check uses an exact `eventparity_[^_]+_<name>.json` regex to match.
+ */
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, statSync, rmSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const CAPTURES = resolve(ROOT, '.captures')
+const OUT = resolve(CAPTURES, '.ep-sweep')
+const FIXTURES = resolve(OUT, 'fixtures')
+
+// Fresh fixtures dir each prep so a renamed/removed fixture doesn't linger.
+rmSync(FIXTURES, { recursive: true, force: true })
+mkdirSync(FIXTURES, { recursive: true })
+
+/** Parse `eventparity_<TS>_<name>.json` → name, honoring underscores in name. */
+function parseName(file: string): string | null {
+  if (!file.startsWith('eventparity_') || !file.endsWith('.json')) return null
+  const stem = file.slice('eventparity_'.length, -'.json'.length)
+  const us = stem.indexOf('_') // end of the underscore-free timestamp
+  if (us < 0) return null
+  return stem.slice(us + 1)
+}
+
+const latest: Record<string, { mtime: number; path: string }> = {}
+for (const f of readdirSync(CAPTURES)) {
+  const name = parseName(f)
+  if (!name) continue
+  const p = resolve(CAPTURES, f)
+  const mt = statSync(p).mtimeMs
+  if (!latest[name] || mt > latest[name].mtime) latest[name] = { mtime: mt, path: p }
+}
+
+const rows: string[] = []
+let skipped = 0
+for (const name of Object.keys(latest).sort()) {
+  const d = JSON.parse(readFileSync(latest[name].path, 'utf8'))
+  const code: string = d.code ?? ''
+  const duration: number = d.duration ?? 15000
+  if (!code.trim()) { console.error('SKIP (no code):', name); skipped++; continue }
+  const rb = resolve(FIXTURES, `${name}.rb`)
+  writeFileSync(rb, code)
+  rows.push(`${name}\t${duration}\t${rb}`)
+}
+
+writeFileSync(resolve(OUT, 'manifest.tsv'), rows.join('\n') + '\n')
+const totalSec = rows.reduce((a, r) => a + Number(r.split('\t')[1]) / 1000, 0)
+console.log(`prepared ${rows.length} fixtures (${skipped} skipped) → ${resolve(OUT, 'manifest.tsv')}`)
+console.log(`sum of durations: ${Math.round(totalSec)}s (desktop+web run sequentially → ~2× + analysis)`)

--- a/tools/event-parity-sweep-run.sh
+++ b/tools/event-parity-sweep-run.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Standalone supervisor for the event-parity pool: re-launch event-parity-sweep.sh
+# until every fixture settles (surviving the ~12-17-fixture signal-kill), then
+# rebuild the event-diff dashboard. Use this to refresh event-diff WITHOUT
+# re-running the expensive compare sweep (compare WAVs are unrelated to
+# event-parity captures — SP151).
+#
+#   FRESH_EP=1 bash tools/event-parity-sweep-run.sh   # new run (re-prep manifest)
+#   bash tools/event-parity-sweep-run.sh              # resume after a death
+#
+# The full compare+event sweep wires this same pool into full-sweep-run.sh, so
+# you normally only need THIS script for an event-diff-only refresh.
+
+REPO=/Users/mrityunjaybhardwaj/Documents/projects/sonicPiWeb
+cd "$REPO"
+WORK="$REPO/.captures/.ep-sweep"
+EPOCH_ID_FILE="$WORK/.epoch.id"
+LOG="$REPO/.captures/event-parity-sweep.log"
+MAX_PASSES="${MAX_PASSES:-40}"
+mkdir -p "$WORK"
+
+if [ "${FRESH_EP:-0}" = "1" ] || [ ! -f "$EPOCH_ID_FILE" ]; then
+  RUN_EPOCH=$(date +%s)
+  rm -f "$EPOCH_ID_FILE"          # force event-parity-sweep.sh to re-prep + stamp
+  : > "$LOG"
+  echo "EP-SWEEP START (fresh, epoch=$RUN_EPOCH) $(date)" | tee -a "$LOG"
+else
+  RUN_EPOCH=$(cat "$EPOCH_ID_FILE")
+  echo "EP-SWEEP RESUME (epoch=$RUN_EPOCH) $(date)" | tee -a "$LOG"
+fi
+
+pass=0 settled=0 total=0
+while [ "$pass" -lt "$MAX_PASSES" ]; do
+  pass=$((pass + 1))
+  echo "EP-PASS #$pass $(date)" | tee -a "$LOG"
+  EP_RUN_EPOCH="$RUN_EPOCH" bash tools/event-parity-sweep.sh 2>&1 | tee -a "$LOG"
+  line=$(grep "POOL-SETTLED event-parity " "$LOG" | tail -1)
+  settled=$(echo "$line" | awk '{print $3}')
+  total=$(echo "$line" | awk '{print $4}')
+  if [ -n "$settled" ] && [ -n "$total" ] && [ "$settled" -ge "$total" ]; then
+    echo "EP-SWEEP DONE ($settled/$total) after $pass passes $(date)" | tee -a "$LOG"
+    break
+  fi
+  echo "EP-SWEEP INCOMPLETE (${settled:-?}/${total:-?}) — relaunch" | tee -a "$LOG"
+done
+
+if [ -z "$settled" ] || [ -z "$total" ] || [ "$settled" -lt "$total" ]; then
+  echo "EP-SWEEP GAVEUP after $MAX_PASSES passes (${settled:-?}/${total:-?}) $(date)" | tee -a "$LOG"
+fi
+
+echo "▶ rebuilding event-diff dashboard…" | tee -a "$LOG"
+npx tsx tools/build-event-diff.ts 2>&1 | tee -a "$LOG"
+echo "EP-SWEEP+DASHBOARD DONE $(date)" | tee -a "$LOG"

--- a/tools/event-parity-sweep.sh
+++ b/tools/event-parity-sweep.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Re-capture every fixture in the event-diff corpus through event-parity.ts so
+# the event-diff dashboard (build-event-diff.ts) reflects the CURRENT engine.
+# This is the missing pool the compare sweep never ran: build-event-diff reads
+# `.captures/eventparity_*.json` (written ONLY by event-parity.ts), NOT the
+# compare sweep's `compare_*.md` (SP151). Run it alongside the compare pools and
+# event-diff refreshes with the rest.
+#
+# RESUMABLE / IDEMPOTENT, same contract as official-book-sweep.sh: the headed-
+# Chromium capture loop is signal-killed after ~12-17 fixtures, so this
+# processes a small BATCH per invocation, prints POOL-SETTLED, and a supervisor
+# (full-sweep-run.sh's run_pool, or event-parity-sweep-run.sh) re-launches it
+# until every fixture settles. NO `set -e`.
+#
+# A fixture is SETTLED when EITHER:
+#   - it has a fresh eventparity_<TS>_<name>.json newer than this run's epoch, OR
+#   - it has been attempted EP_MAX_ATTEMPTS times (a reliable killer gives up).
+#
+# On the FIRST invocation of a fresh run (stored epoch id != EP_RUN_EPOCH) it
+# rebuilds the work manifest via event-parity-prep.ts (latest capture per name
+# → temp .rb + duration). Resume invocations reuse the manifest + epoch so prior
+# passes' captures keep counting as settled.
+#
+# Env: EP_RUN_EPOCH (supervisor sets; default now) · EP_MAX_ATTEMPTS (3)
+#      EP_TIMEOUT_SEC (140) · EP_RESTART_INTERVAL (6) · EP_BATCH (8)
+
+REPO=/Users/mrityunjaybhardwaj/Documents/projects/sonicPiWeb
+cd "$REPO"
+WORK="$REPO/.captures/.ep-sweep"
+MANIFEST="$WORK/manifest.tsv"
+EPOCH_ID_FILE="$WORK/.epoch.id"
+EPOCH_FILE="$WORK/.epoch"          # mtime = run start; fresh captures are -newer
+STATE_DIR="$WORK/state"
+MAX_ATTEMPTS="${EP_MAX_ATTEMPTS:-3}"
+TIMEOUT_SEC="${EP_TIMEOUT_SEC:-140}"
+RESTART_INTERVAL="${EP_RESTART_INTERVAL:-6}"
+BATCH="${EP_BATCH:-8}"
+RUN_EPOCH="${EP_RUN_EPOCH:-$(date +%s)}"
+
+mkdir -p "$WORK" "$STATE_DIR"
+
+restart_sonic_pi() {
+  echo "  ↻ restarting Sonic Pi.app (SP60 mitigation)..."
+  pkill -f "Sonic Pi.app" 2>/dev/null || true
+  sleep 1.5
+  open -a "Sonic Pi"
+  for _ in {1..30}; do
+    sleep 0.5
+    if pgrep -f "scsynth -u" >/dev/null 2>&1; then
+      sleep 2.5
+      echo "  ↻ ready"; return 0
+    fi
+  done
+  echo "  ✗ Sonic Pi.app failed to relaunch"; return 1
+}
+
+cleanup_capture_orphans() {
+  pkill -f "ms-playwright" 2>/dev/null || true
+  pkill -f "node .*tsx.*tools/event-parity.ts" 2>/dev/null || true
+  pkill -f "node .*tsx.*tools/capture" 2>/dev/null || true
+}
+
+# (Re)build the manifest + stamp the epoch ONLY when the run epoch changes (new
+# run) or the manifest is missing — so resume passes keep the same epoch and
+# earlier captures stay "fresh this run".
+STORED=$(cat "$EPOCH_ID_FILE" 2>/dev/null || echo "")
+if [ "$STORED" != "$RUN_EPOCH" ] || [ ! -f "$MANIFEST" ]; then
+  echo "▶ preparing event-parity manifest (epoch $RUN_EPOCH)…"
+  rm -rf "$STATE_DIR"; mkdir -p "$STATE_DIR"
+  npx tsx tools/event-parity-prep.ts || { echo "  ✗ prep failed"; echo "POOL-SETTLED event-parity 0 1"; exit 1; }
+  echo "$RUN_EPOCH" > "$EPOCH_ID_FILE"
+  touch "$EPOCH_FILE"
+fi
+
+# Exact-name fresh-capture check (SP151): `[^_]+` matches the underscore-free
+# timestamp, so `idm_breakbeat` does NOT match `10_idm_breakbeat`'s file.
+fresh_exists() {
+  local name="$1"
+  find "$REPO/.captures" -maxdepth 1 -name "eventparity_*_${name}.json" -newer "$EPOCH_FILE" 2>/dev/null \
+    | grep -Eq "/eventparity_[^_]+_${name}\.json$"
+}
+attempts_of() { local f="$STATE_DIR/$1.attempts"; [ -f "$f" ] && cat "$f" || echo 0; }
+bump_attempts() { local f="$STATE_DIR/$1.attempts"; echo $(( $(attempts_of "$1") + 1 )) > "$f"; }
+is_settled() {
+  local name="$1"
+  fresh_exists "$name" && return 0
+  [ "$(attempts_of "$name")" -ge "$MAX_ATTEMPTS" ] && return 0
+  return 1
+}
+
+n_total=$(grep -c . "$MANIFEST" 2>/dev/null || echo 0)
+echo "▶ Event-parity sweep (resumable): $n_total fixtures, ${TIMEOUT_SEC}s timeout, max ${MAX_ATTEMPTS} attempts, RUN_EPOCH=$RUN_EPOCH"
+
+idx=0; processed=0
+while IFS=$'\t' read -r name dur rb; do
+  [ -z "$name" ] && continue
+  idx=$((idx + 1))
+
+  is_settled "$name" && continue
+
+  if [ "$processed" -ge "$BATCH" ]; then
+    echo "  ⏸ batch limit ($BATCH) reached — exit cleanly, supervisor re-launches"
+    break
+  fi
+  processed=$((processed + 1))
+
+  if [ $idx -gt 1 ] && [ $((idx % RESTART_INTERVAL)) -eq 1 ]; then
+    restart_sonic_pi
+  fi
+  att=$(( $(attempts_of "$name") + 1 ))
+  echo ""
+  echo "[$idx/$n_total] $name (attempt $att/$MAX_ATTEMPTS, dur=${dur}ms)"
+  bump_attempts "$name"
+
+  npx tsx tools/event-parity.ts --file "$rb" --name "$name" --duration "$dur" \
+    > /tmp/ep_sweep.log 2>&1 </dev/null &
+  cpid=$!
+  waited=0
+  while kill -0 "$cpid" 2>/dev/null; do
+    sleep 3; waited=$((waited + 3))
+    if [ "$waited" -ge "$TIMEOUT_SEC" ]; then
+      echo "  ⏱ TIMEOUT ${TIMEOUT_SEC}s — killing event-parity subtree for $name"
+      pkill -P "$cpid" 2>/dev/null || true
+      kill -9 "$cpid" 2>/dev/null || true
+      break
+    fi
+  done
+  wait "$cpid" 2>/dev/null || true
+  tail -4 /tmp/ep_sweep.log 2>/dev/null
+  cleanup_capture_orphans
+
+  if fresh_exists "$name"; then
+    echo "  ✓ fresh eventparity capture for $name"
+  else
+    echo "  ✗ no fresh capture for $name (attempt $att)"
+    restart_sonic_pi || true
+  fi
+done < "$MANIFEST"
+
+# Settled tally — supervisor parses this to decide whether to re-launch.
+n_settled=0
+while IFS=$'\t' read -r name dur rb; do
+  [ -z "$name" ] && continue
+  is_settled "$name" && n_settled=$((n_settled + 1))
+done < "$MANIFEST"
+echo ""
+echo "=== event-parity pass complete ==="
+echo "POOL-SETTLED event-parity $n_settled $n_total"

--- a/tools/full-sweep-run.sh
+++ b/tools/full-sweep-run.sh
@@ -53,8 +53,23 @@ run_pool() {
   return 1
 }
 
+# Pools 1-3 feed the COMPARE dashboards (examples-sweep / book / gate) via
+# compare_*.md. Pool 4 (event-parity) feeds the EVENT-DIFF dashboard via
+# eventparity_*.json — a SEPARATE capture source the compare pools never write
+# (SP151). Without it, rebuilding build-event-diff "after a sweep" just
+# re-renders STALE captures and mislabels them fresh. Running it here keeps
+# event-diff in step with the compare dashboards. It re-prep's its work manifest
+# from the latest captures per fixture on the first pass of each fresh run.
 run_pool "official-book" tools/official-book-sweep.sh OB_RUN_EPOCH
 run_pool "e2e"           tools/e2e-sweep.sh           E2E_RUN_EPOCH
 run_pool "community"     tools/community-sweep.sh     COMMUNITY_RUN_EPOCH
+run_pool "event-parity"  tools/event-parity-sweep.sh  EP_RUN_EPOCH
+
+# Rebuild the event-diff dashboard from the now-fresh eventparity captures. This
+# is the one that was silently stale before pool 4 existed (the compare
+# dashboards — examples-sweep / gate — are still rebuilt as a separate step,
+# unchanged). Safe to re-run: it only reads .captures and writes test_results.
+echo "REBUILD event-diff $(date)" | tee -a "$LOG"
+npx tsx tools/build-event-diff.ts 2>&1 | tee -a "$LOG"
 
 echo "FULL-SWEEP DONE $(date)" | tee -a "$LOG"


### PR DESCRIPTION
## Problem

The parity dashboards split across two capture sources that look interchangeable but aren't:
- `full-sweep-run.sh` runs only `compare-desktop-vs-web.ts` → `compare_*.md` → feeds **examples-sweep / gate**.
- `build-event-diff.ts` reads `eventparity_*.json`, written **only** by `event-parity.ts` per-fixture — the compare sweep never writes them (SP151).

So "rebuild build-event-diff after a sweep" just re-renders whatever event-parity captures already exist (often pre-merge), **mislabelling stale data as fresh** (the SP139 hazard). The genuine refresh was done with throwaway `/private/tmp` scripts each time.

## Fix

A 4th, in-repo, resumable pool that re-captures every fixture through `event-parity.ts`, so event-diff refreshes alongside the compare dashboards:

- **`tools/event-parity-prep.ts`** — builds the work manifest: latest capture per fixture name → temp `.rb` + the exact `duration` it was last captured with. Parses `eventparity_<TS>_<name>.json` honoring underscores in `<name>` (the timestamp is underscore-free).
- **`tools/event-parity-sweep.sh`** — resumable pool matching the `run_pool` contract (one `BATCH` per invocation, prints `POOL-SETTLED event-parity <s> <t>`), re-prep's on a fresh epoch, survives the ~12-17-fixture signal-kill. Mirrors `official-book-sweep.sh`.
- **`tools/event-parity-sweep-run.sh`** — standalone supervisor to refresh event-diff **alone** (relaunch until settled → `build-event-diff`) without the expensive compare sweep.
- **`full-sweep-run.sh`** — wires the event-parity pool in after the 3 compare pools and rebuilds `build-event-diff` at the end.

### SP151 collision fix
The resume "already captured?" check uses an **exact** `eventparity_[^_]+_<name>.json` regex (the `[^_]+` matches the underscore-free timestamp), so `idm_breakbeat` no longer matches `10_idm_breakbeat`'s capture (nor `ambient` vs `sw_ambient`) — the suffix-collision the throwaway script had.

## Verification (by running — matching the existing pool-script convention; pool scripts aren't unit-tested)
- `prep` emits **144 distinct fixtures**, both `idm_breakbeat` and `10_idm_breakbeat` as separate rows.
- Synthetic `fresh_exists` test: the exact-name regex correctly rejects the `10_idm_breakbeat`→`idm_breakbeat` and `sw_ambient`→`ambient` collisions.
- Live **2-fixture batch**: captures → detects fresh → settles → `POOL-SETTLED event-parity 2 144`.
- Same-epoch **resume**: skips the 2 settled (no re-prep), advances to the next 2 → `4 144`.
- `tsc --noEmit` + `bash -n` on all scripts clean.

Closes the SP151 "pipeline gap to close". No engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)