### PR TITLE
🎚️ fix(audio): unify node-ref binding via dispatchNode — sample control + fx-drift (#559, #560)

### DIFF
--- a/src/engine/Program.ts
+++ b/src/engine/Program.ts
@@ -12,8 +12,18 @@ export type Step =
        *  `note` is NaN because a string like "not a note" failed to resolve.
        *  Lets the dispatch-time guard name the bad input instead of silently
        *  sounding the middle-C fallback. */
-      noteName?: string }
-  | { tag: 'sample'; name: string; opts: Record<string, number>; srcLine?: number }
+      noteName?: string;
+      /** #557/#559/#560: BUILD-TIME node ref (= ProgramBuilder `_lastRef` at the
+       *  time this play was built). `control p` / `kill p` carry the same ref
+       *  via their own `nodeRef`; the interpreter binds `nodeRefMap[nodeRef]` to
+       *  this play's live scsynth node so a same-instant control resolves it.
+       *  Build-time (not interpret-time-minted) so it shares ONE ref namespace
+       *  with `fx` — no play-vs-fx counter drift (#560). */
+      nodeRef?: number }
+  | { tag: 'sample'; name: string; opts: Record<string, number>; srcLine?: number;
+      /** #559: build-time node ref for `control`/`kill` of a running sample —
+       *  same mechanism as `play` above. */
+      nodeRef?: number }
   | { tag: 'sleep'; beats: number }
   | { tag: 'useSynth'; name: string }
   | { tag: 'useBpm'; bpm: number }

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -230,6 +230,7 @@ export class ProgramBuilder {
       opts: cleanOpts,
       synth: synth ?? this.currentSynth,
       srcLine,
+      nodeRef: this._lastRef,
       ...(noteName !== undefined ? { noteName } : {}),
     })
   }
@@ -268,7 +269,11 @@ export class ProgramBuilder {
     const cleanOpts = { ...this._sampleDefaults, ...opts } as Record<string, number>
     delete (cleanOpts as Record<string, unknown>)._srcLine
     if (!this._argBpmScaling) cleanOpts._argBpmScaling = 0
-    this.steps.push({ tag: 'sample', name, opts: cleanOpts, srcLine })
+    // #559: mint a node ref so `s = sample …; control s, rate: 2` / `kill s`
+    // can target the running sample node — symmetric with `play` above. The
+    // transpiler captures `s = __b.lastRef` for `s = sample …`.
+    this._lastRef = this.nextRef++
+    this.steps.push({ tag: 'sample', name, opts: cleanOpts, srcLine, nodeRef: this._lastRef })
     return this
   }
 

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -874,7 +874,8 @@ export class SuperSonicBridge {
     sampleName: string,
     audioTime: number,
     opts?: Record<string, number>,
-    bpm?: number
+    bpm?: number,
+    nodeId?: number,
   ): Promise<number> {
     if (!this.sonic) throw new Error('SuperSonic not initialized')
 
@@ -887,13 +888,13 @@ export class SuperSonicBridge {
     if (bufNum !== undefined && numChans !== undefined) {
       const playerName = selectSamplePlayer(opts, numChans)
       if (this.loadedSynthDefs.has(playerName)) {
-        return Promise.resolve(this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm))
+        return Promise.resolve(this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm, nodeId))
       }
     }
 
     // Slow path: load sample + decode channel count + load synthdef first
     // (only happens once per sample name / player synthdef).
-    return this.playSampleSlow(sampleName, audioTime, opts, bpm)
+    return this.playSampleSlow(sampleName, audioTime, opts, bpm, nodeId)
   }
 
   private playSampleImmediate(
@@ -903,8 +904,12 @@ export class SuperSonicBridge {
     audioTime: number,
     opts?: Record<string, number>,
     bpm?: number,
+    preReservedNodeId?: number,
   ): number {
-    const nodeId = this.sonic!.nextNodeId()
+    // #559: use the caller's pre-reserved id when given so `control s`/`kill s`
+    // (bound into nodeRefMap synchronously by the interpreter) targets exactly
+    // this sample's node — mirrors triggerSynth (#557).
+    const nodeId = preReservedNodeId ?? this.sonic!.nextNodeId()
     const duration = this.sampleDurations.get(sampleName) ?? null
     const translated = translateSampleOpts(opts, bpm ?? 60, duration)
     const sampleWarn = this.warnHandler
@@ -979,6 +984,7 @@ export class SuperSonicBridge {
     audioTime: number,
     opts?: Record<string, number>,
     bpm?: number,
+    nodeId?: number,
   ): Promise<number> {
     // Load the buffer and decode its channel count before selecting the
     // player — mirrors Desktop SP, which knows buf_info.num_chans before
@@ -995,7 +1001,7 @@ export class SuperSonicBridge {
     if (!this.loadedSynthDefs.has(playerName)) {
       await this.ensureSynthDefLoaded(playerName)
     }
-    return this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm)
+    return this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm, nodeId)
   }
 
   /**

--- a/src/engine/__tests__/ControlRunningSynth.test.ts
+++ b/src/engine/__tests__/ControlRunningSynth.test.ts
@@ -47,6 +47,7 @@ async function drive(engine: SonicPiEngine, targetVt = 4, steps = 8) {
  */
 function createSpyBridge() {
   const synths: Array<{ id: number; params: Record<string, number> }> = []
+  const samples: Array<{ id: number; name: string }> = []
   const controls: Array<{ nodeId: number; params: (string | number)[] }> = []
   let nextNode = 9000
   let nextBus = 16
@@ -60,7 +61,11 @@ function createSpyBridge() {
       synths.push({ id, params: { ...params } })
       return id
     },
-    async playSample() { return nextNode++ },
+    async playSample(name: string, _t: number, _o?: Record<string, number>, _b?: number, nodeId?: number) {
+      const id = nodeId ?? nextNode++
+      samples.push({ id, name })
+      return id
+    },
     async ensureSamplePlaybackDuration() { return 1 },
     sendTimedControl(_time: number, nodeId: number, params: (string | number)[]) {
       controls.push({ nodeId, params })
@@ -74,7 +79,7 @@ function createSpyBridge() {
       return () => undefined
     },
   })
-  return { bridge: proxy, synths, controls }
+  return { bridge: proxy, synths, samples, controls }
 }
 
 function paramsToObj(params: (string | number)[]): Record<string, number> {
@@ -142,6 +147,63 @@ sleep 7`)
     expect(spy.controls.length).toBeGreaterThan(0)
     expect(spy.controls.every((c) => c.nodeId === spy.synths[0].id)).toBe(true)
     expect(paramsToObj(spy.controls[0].params).divisor).toBe(30)
+    engine.dispose()
+  })
+
+  it('control of a running SAMPLE targets the live sample node (#559)', async () => {
+    // `s = sample …; control s, rate: 2` must reach the sample's scsynth node.
+    // Pre-fix: `ProgramBuilder.sample` never set `_lastRef` and the sample
+    // dispatch never bound `nodeRefMap` → control(s) resolved nothing → dropped.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+    const r = await engine.evaluate(`live_loop :s do
+  s = sample :loop_amen, rate: 1, sustain: 4
+  control s, rate: 2
+  sleep 1
+end`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 4, 8)
+
+    expect(spy.samples.length).toBeGreaterThan(1)
+    expect(spy.controls.length).toBeGreaterThan(0)
+    // Every control targets a node that is actually a sample this run.
+    const sampleIds = new Set(spy.samples.map((s) => s.id))
+    for (const c of spy.controls) {
+      expect(sampleIds.has(c.nodeId)).toBe(true)
+      expect(paramsToObj(c.params).rate).toBe(2)
+    }
+    engine.dispose()
+  })
+
+  it('control p resolves when a with_fx precedes the controlled play (#560)', async () => {
+    // Pre-fix: the builder counted `with_fx` in its ref namespace but the
+    // interpreter's play-only counter did not → `control p` after a fx
+    // resolved a non-existent ref → DROPPED. Build-time refs (one namespace
+    // shared with fx) fix the drift.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+    const r = await engine.evaluate(`play 60
+with_fx :reverb do
+  play 70
+end
+p = play 62, sustain: 4
+control p, amp: 0.1
+sleep 4`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 4, 8)
+
+    // Three synths (60, 70-inside-fx, 62); the control targets the n62 play.
+    const n62 = spy.synths.find((s) => s.params.note === 62)
+    expect(n62).toBeDefined()
+    expect(spy.controls.length).toBeGreaterThan(0)
+    expect(spy.controls.every((c) => c.nodeId === n62!.id)).toBe(true)
+    expect(paramsToObj(spy.controls[0].params).amp).toBe(0.1)
     engine.dispose()
   })
 })

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -118,6 +118,43 @@ export interface AudioContext {
 }
 
 /**
+ * Dispatch a controllable LEAF VOICE (synth or sample) and bind its node ref
+ * into `nodeRefMap` SYNCHRONOUSLY, so a same-instant `control`/`kill` (no
+ * intervening sleep — e.g. fm_noise's `p = play …; control p, …`) resolves THIS
+ * dispatch's live scsynth node. Shared by `case 'play'` and `case 'sample'`
+ * (#557/#559); the two FX paths bind their own refs differently (bus+group
+ * routing nodes) and are intentionally NOT folded in here.
+ *
+ * `nodeRef` is the BUILD-TIME ref the ProgramBuilder stamped on the step (one
+ * ref namespace with `fx`, so no play-vs-fx counter drift — #560). Reserve the
+ * scsynth id up front (a free counter increment), write the map before the next
+ * step runs, then fire `produce` with that id. `produce` still loads its
+ * synthdef/sample async and still REJECTS on a CDN miss (SV43/SP89). Falls back
+ * to the legacy async bind (on the producer's resolved id) when the bridge has
+ * no `reserveNodeId` (older mock bridges) or the step carries no ref.
+ */
+function dispatchNode(
+  ctx: AudioContext,
+  nodeRef: number | undefined,
+  produce: (nodeId?: number) => Promise<number>,
+  onError: (err: Error) => void,
+): void {
+  const bridge = ctx.bridge
+  let preReservedNodeId: number | undefined
+  if (nodeRef !== undefined && bridge && typeof bridge.reserveNodeId === 'function') {
+    preReservedNodeId = bridge.reserveNodeId()
+    ctx.nodeRefMap.set(nodeRef, preReservedNodeId)
+  }
+  produce(preReservedNodeId)
+    .then(realNodeId => {
+      if (preReservedNodeId === undefined && nodeRef !== undefined) {
+        ctx.nodeRefMap.set(nodeRef, realNodeId)
+      }
+    })
+    .catch(onError)
+}
+
+/**
  * Run a Program's steps for one loop iteration.
  * Called by the scheduler's loop runner.
  *
@@ -134,7 +171,6 @@ export async function runProgram(
   if (!fxCounter) fxCounter = { value: 0 }
   let currentSynth = 'beep'
   let currentBpm = ctx.scheduler.getTask(ctx.taskId)?.bpm ?? 60
-  let nextNodeRef = 1
 
   for (const step of program) {
     const task = ctx.scheduler.getTask(ctx.taskId)
@@ -164,7 +200,6 @@ export async function runProgram(
 
         const audioTime = task.virtualTime + ctx.schedAheadTime
         const synth = resolveSynthName(step.synth ?? currentSynth)
-        const nodeRef = nextNodeRef++
 
         if (ctx.bridge) {
           // Auto-start mic input on the FIRST dispatch of sound_in per run (#152).
@@ -187,31 +222,17 @@ export async function runProgram(
             : undefined
           const params = normalizePlayParams(synth, step.opts, currentBpm, playWarn)
           params.out_bus = task.outBus
-          // #557: bind nodeRefMap SYNCHRONOUSLY so a same-iteration `control`
-          // (no intervening sleep — e.g. fm_noise's `p = play …; control p,
-          // divisor: …`) resolves THIS synth's live node. Previously the map
-          // was populated by the async `.then` on triggerSynth — a microtask
-          // that runs only AFTER the iteration's synchronous steps complete.
-          // So `control` read either an empty map (iteration 1 → /n_set
-          // dropped) or the PREVIOUS iteration's already-freed node (iteration
-          // N → /n_set to a dead node). Both made `control` of a running synth
-          // inaudible on web while desktop applied it (#557 / exp-019). Reserve
-          // the id up front (a free counter increment) and hand it to
-          // triggerSynth, which still loads the synthdef async and still
-          // REJECTS on a CDN miss (SV43/SP89). The `reserveNodeId` guard keeps
-          // older mock bridges (no such method) on the legacy async-bind path.
-          let preReservedNodeId: number | undefined
-          if (typeof ctx.bridge.reserveNodeId === 'function') {
-            preReservedNodeId = ctx.bridge.reserveNodeId()
-            ctx.nodeRefMap.set(nodeRef, preReservedNodeId)
-          }
-          ctx.bridge.triggerSynth(synth, audioTime, params, preReservedNodeId)
-            .then(realNodeId => {
-              if (preReservedNodeId === undefined) ctx.nodeRefMap.set(nodeRef, realNodeId)
-            })
-            .catch((err: Error) => {
-              ctx.printHandler?.(`Synth '${synth}' failed: ${err.message}`)
-            })
+          // #557: bind nodeRefMap SYNCHRONOUSLY (via dispatchNode) so a
+          // same-iteration `control p` / `kill p` (no intervening sleep — e.g.
+          // fm_noise's `p = play …; control p, divisor: …`) resolves THIS
+          // synth's live node, not the previous iteration's freed one.
+          const bridge = ctx.bridge
+          dispatchNode(
+            ctx,
+            step.nodeRef,
+            (nodeId) => bridge.triggerSynth(synth, audioTime, params, nodeId),
+            (err) => ctx.printHandler?.(`Synth '${synth}' failed: ${err.message}`),
+          )
 
           // Extend enclosing FX scopes' aliveUntil so the FX bus outlives this
           // synth's audible envelope. Mirrors desktop sound.rb:1817-1822
@@ -255,10 +276,16 @@ export async function runProgram(
           const sampleOpts = task.outBus !== 0
             ? { ...step.opts, out_bus: task.outBus }
             : step.opts
-          ctx.bridge.playSample(step.name, audioTime, sampleOpts, currentBpm)
-            .catch((err: Error) => {
-              ctx.printHandler?.(`Sample '${step.name}' failed: ${err.message}`)
-            })
+          // #559: bind nodeRefMap SYNCHRONOUSLY (via dispatchNode) so a
+          // same-iteration `control s` / `kill s` on a running sample resolves
+          // THIS sample's live node — symmetric with `play` (#557).
+          const bridge = ctx.bridge
+          dispatchNode(
+            ctx,
+            step.nodeRef,
+            (nodeId) => bridge.playSample(step.name, audioTime, sampleOpts, currentBpm, nodeId),
+            (err) => ctx.printHandler?.(`Sample '${step.name}' failed: ${err.message}`),
+          )
 
           // Extend enclosing FX scopes' aliveUntil so the FX bus outlives this
           // sample. SP135/#506: a sample's audible end is its BUFFER PLAYOUT


### PR DESCRIPTION
Supersedes #561 (auto-closed when its stacked base branch `fix/557-…` was deleted on #558 merge). Rebased onto main — now a single clean commit.

## Problem
The "bind a controllable node's ref before a same-instant `control`/`kill` reads it" concern was implemented at four sites with four mechanisms; two were broken:
- **#559** — `control`/`kill` of a running **sample** was dropped (`ProgramBuilder.sample` never set `_lastRef`; the sample dispatch never bound `nodeRefMap`).
- **#560** — `control p` dropped when a `with_fx` preceded the controlled play (builder counted fx in `nextRef`, the interpreter's play-only `nextNodeRef` did not → ref-namespace drift; observed `controls: []`).

## Fix
- One `dispatchNode()` helper in `AudioInterpreter` for the two leaf-voice binders (synth + sample): reserve id → sync-bind `nodeRefMap` → fire producer.
- Ref assignment moved to **build time**: `ProgramBuilder` stamps `nodeRef` on the play/sample step from the same `nextRef` namespace `fx` uses; interpreter binds `nodeRefMap[step.nodeRef]`; the dual `nextNodeRef` counter is deleted (kills #560 drift).
- `ProgramBuilder.sample` mints a ref; `playSample` takes an optional pre-reserved `nodeId`. FX paths (routing nodes) intentionally not folded.

## Test plan
- L1 **1439/1439** + `tsc` clean; spy-bridge tests for #559 (control→live sample node, `rate:2`) and #560 (control p resolves past the fx).
- L2 OSC: sample `/n_set`→live node; play-after-fx `/n_set 11007`→correct n62 (was dropped).
- L3 audio: sample-control span **3.50s vs 7.08s** uncontrolled; #557 synth control unchanged at cosine 0.2214.

Closes #559
Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)