### PR TITLE
🎛️ fix(audio): land same-instant control after /s_new so *_slide glides initialise (#567)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -158,6 +158,11 @@ export class SonicPiEngine {
   private schedAheadTime: number
   /** Maps DSL nodeRef → SuperSonic nodeId for control messages */
   private nodeRefMap = new Map<number, number>()
+  /** SP153/#567: nodeRef → its /s_new audioTime, so a same-instant `control`
+   *  lands its /n_set strictly after the node's creation (else WASM inits a
+   *  *_slide Lag at the control target). Same lifecycle as nodeRefMap —
+   *  bounded (refs reused per iteration) and cleared on stop/hot-swap. */
+  private nodeCreationTime = new Map<number, number>()
   /** Reusable inner FX nodes — persists across loop iterations. See issue #70.
    *  `killTimer` is the pending virtual-time-scheduled kill handle (SV41) that
    *  frees this FX after kill_delay seconds of virtual time if no follow-up
@@ -1162,6 +1167,7 @@ export class SonicPiEngine {
             schedAheadTime: this.schedAheadTime,
             printHandler: this.printHandler ?? undefined,
             nodeRefMap: this.nodeRefMap,
+            nodeCreationTime: this.nodeCreationTime,
             reusableFx: this.reusableFx,
             globalStore: this.globalStore,
             oscHandler: this.oscHandler ?? undefined,
@@ -2184,6 +2190,7 @@ export class SonicPiEngine {
           //     iteration that re-enters their with_fx Step (existing nodeId
           //     reused via persistentFx.has(scopeId) short-circuit).
           this.nodeRefMap.clear()
+          this.nodeCreationTime.clear() // SP153/#567: same lifecycle as nodeRefMap
         }
 
         // Pre-create persistent FX synchronously before reEvaluate. See
@@ -2359,6 +2366,7 @@ export class SonicPiEngine {
       this.bridge.stopAllLiveAudio()
     }
     this.nodeRefMap.clear()
+    this.nodeCreationTime.clear() // SP153/#567: same lifecycle as nodeRefMap
 
     // Dispose scheduler so next evaluate() starts fresh
     this.scheduler?.dispose()

--- a/src/engine/__tests__/ControlRunningSynth.test.ts
+++ b/src/engine/__tests__/ControlRunningSynth.test.ts
@@ -46,9 +46,9 @@ async function drive(engine: SonicPiEngine, targetVt = 4, steps = 8) {
  * for its /s_new. Records every synth id and every sendTimedControl target.
  */
 function createSpyBridge() {
-  const synths: Array<{ id: number; params: Record<string, number> }> = []
+  const synths: Array<{ id: number; params: Record<string, number>; t: number }> = []
   const samples: Array<{ id: number; name: string }> = []
-  const controls: Array<{ nodeId: number; params: (string | number)[] }> = []
+  const controls: Array<{ nodeId: number; params: (string | number)[]; time: number }> = []
   let nextNode = 9000
   let nextBus = 16
   const impl: Record<string, unknown> = {
@@ -58,7 +58,7 @@ function createSpyBridge() {
     reserveNodeId: () => nextNode++,
     async triggerSynth(_name: string, _t: number, params: Record<string, number>, nodeId?: number) {
       const id = nodeId ?? nextNode++
-      synths.push({ id, params: { ...params } })
+      synths.push({ id, params: { ...params }, t: _t })
       return id
     },
     async playSample(name: string, _t: number, _o?: Record<string, number>, _b?: number, nodeId?: number) {
@@ -68,7 +68,7 @@ function createSpyBridge() {
     },
     async ensureSamplePlaybackDuration() { return 1 },
     sendTimedControl(_time: number, nodeId: number, params: (string | number)[]) {
-      controls.push({ nodeId, params })
+      controls.push({ nodeId, params, time: _time })
     },
     freeNode() { /* no-op */ },
     get audioContext() { return null },
@@ -204,6 +204,74 @@ sleep 4`)
     expect(spy.controls.length).toBeGreaterThan(0)
     expect(spy.controls.every((c) => c.nodeId === n62!.id)).toBe(true)
     expect(paramsToObj(spy.controls[0].params).amp).toBe(0.1)
+    engine.dispose()
+  })
+})
+
+describe('control lands after its node creation so *_slide glides initialise (#567)', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).SuperSonic
+  })
+
+  it('a same-instant control (no sleep after play) is timestamped strictly after the /s_new', async () => {
+    // SP153/#567: `p = play …, cutoff_slide: 4; control p, cutoff: 100` with no
+    // sleep between would co-bundle /n_set with /s_new at one timestamp; WASM
+    // scsynth then inits the cutoff Lag at the target (100) and skips the glide.
+    // The interpreter must push the /n_set strictly after the node's creation.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+    const r = await engine.evaluate(`use_synth :dsaw
+live_loop :t do
+  p = play 50, cutoff: 30, cutoff_slide: 4, release: 8
+  control p, cutoff: 100
+  sleep 8
+end`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 8, 8)
+
+    expect(spy.synths.length).toBeGreaterThan(0)
+    expect(spy.controls.length).toBeGreaterThan(0)
+    // Each control must be timestamped strictly after the synth it targets,
+    // so scsynth latches the cutoff Lag at 30 before the control sets 100.
+    for (const c of spy.controls) {
+      const node = spy.synths.find((s) => s.id === c.nodeId)
+      expect(node).toBeDefined()
+      expect(c.time).toBeGreaterThan(node!.t)
+      expect(paramsToObj(c.params).cutoff).toBe(100)
+    }
+    engine.dispose()
+  })
+
+  it('a control after an elapsed sleep is NOT pushed later (no drift on the common case)', async () => {
+    // The guard only fires when control coincides with creation. A control that
+    // follows a sleep already lands well after the /s_new and must keep its
+    // natural timestamp.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const spy = createSpyBridge()
+    ;(engine as unknown as { bridge: unknown }).bridge = spy.bridge
+    const r = await engine.evaluate(`use_synth :dsaw
+live_loop :t do
+  p = play 50, cutoff: 30, cutoff_slide: 4, release: 8
+  sleep 1
+  control p, cutoff: 100
+  sleep 7
+end`)
+    expect(r.error).toBeUndefined()
+    engine.play()
+    await drive(engine, 8, 8)
+
+    expect(spy.controls.length).toBeGreaterThan(0)
+    // The control is a full beat (1s) after the play — its timestamp is the
+    // natural scheduled time, ~1s past creation, NOT a tiny offset nudge.
+    for (const c of spy.controls) {
+      const node = spy.synths.find((s) => s.id === c.nodeId)
+      expect(node).toBeDefined()
+      expect(c.time - node!.t).toBeGreaterThan(0.5)
+    }
     engine.dispose()
   })
 })

--- a/src/engine/__tests__/ControlRunningSynth.test.ts
+++ b/src/engine/__tests__/ControlRunningSynth.test.ts
@@ -48,9 +48,10 @@ async function drive(engine: SonicPiEngine, targetVt = 4, steps = 8) {
 function createSpyBridge() {
   const synths: Array<{ id: number; params: Record<string, number>; t: number }> = []
   const samples: Array<{ id: number; name: string }> = []
-  const controls: Array<{ nodeId: number; params: (string | number)[]; time: number }> = []
+  const controls: Array<{ nodeId: number; params: (string | number)[]; time: number; synthsFlushedBefore: number }> = []
   let nextNode = 9000
   let nextBus = 16
+  let flushedSynthCount = 0
   const impl: Record<string, unknown> = {
     allocateBus: () => nextBus++,
     createFxGroup: () => nextNode++,
@@ -68,8 +69,11 @@ function createSpyBridge() {
     },
     async ensureSamplePlaybackDuration() { return 1 },
     sendTimedControl(_time: number, nodeId: number, params: (string | number)[]) {
-      controls.push({ nodeId, params, time: _time })
+      // Record the snapshot of synths flushed BEFORE this control so a test can
+      // assert the node's /s_new was emitted (separate bundle) first (#567).
+      controls.push({ nodeId, params, time: _time, synthsFlushedBefore: flushedSynthCount })
     },
+    flushMessages() { flushedSynthCount = synths.length },
     freeNode() { /* no-op */ },
     get audioContext() { return null },
   }
@@ -234,12 +238,15 @@ end`)
 
     expect(spy.synths.length).toBeGreaterThan(0)
     expect(spy.controls.length).toBeGreaterThan(0)
-    // Each control must be timestamped strictly after the synth it targets,
-    // so scsynth latches the cutoff Lag at 30 before the control sets 100.
+    // Each control must (a) be timestamped strictly after the synth it targets
+    // AND (b) have had the pending queue flushed first, so the node's /s_new
+    // went out in its OWN bundle before the /n_set — a single shared-timetag
+    // bundle would make WASM scsynth init the Lag at the target (the real bug).
     for (const c of spy.controls) {
       const node = spy.synths.find((s) => s.id === c.nodeId)
       expect(node).toBeDefined()
       expect(c.time).toBeGreaterThan(node!.t)
+      expect(c.synthsFlushedBefore).toBeGreaterThan(0) // /s_new flushed before /n_set
       expect(paramsToObj(c.params).cutoff).toBe(100)
     }
     engine.dispose()

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -414,19 +414,25 @@ export async function runProgram(
         const realNodeId = ctx.nodeRefMap.get(step.nodeRef)
         if (realNodeId && ctx.bridge) {
           const audioTime = task.virtualTime + ctx.schedAheadTime
-          // SP153/#567: if this control targets a node whose `/s_new` was
-          // scheduled at the same (or a later) audioTime — i.e. `control`
-          // follows `play`/`sample` with no `sleep` between — push the `/n_set`
-          // a control-block later. Co-bundling the two at one timestamp makes
-          // SuperSonic's WASM scsynth init a `*_slide` Lag at the control TARGET
-          // instead of the play value, skipping the glide (cutoff_slide etc.).
-          // A control after an elapsed sleep has audioTime > creation, so the
-          // guard is false and the timestamp is untouched (no drift on the
-          // common case). Mirrors desktop, whose `/n_set` lands after `/s_new`.
+          // SP153/#567: a `control` that follows `play`/`sample` with no `sleep`
+          // between (same virtualTime) targets a node whose `/s_new` is still in
+          // this iteration's pending message queue. The bridge flushes the whole
+          // queue as ONE OSC bundle sharing ONE timetag, so `/s_new` and `/n_set`
+          // would execute at the SAME scsynth time — and WASM scsynth then inits a
+          // `*_slide` Lag at the control TARGET, skipping the glide (cutoff_slide).
+          // An OSC bundle has a single timetag, so separating their execution
+          // times requires separate bundles: flush now (emit the node's `/s_new`
+          // at its creation time), then queue the `/n_set` at creation+offset so
+          // it flushes later, in its own bundle, strictly after the node exists.
+          // This mirrors what `sleep` does between play and control (the only
+          // thing that previously rendered the slide correctly). A control after
+          // an elapsed sleep has audioTime > creation → guard false → untouched.
           const created = ctx.nodeCreationTime?.get(step.nodeRef)
-          const ctlTime = created !== undefined && audioTime <= created
-            ? created + CONTROL_AFTER_CREATE_OFFSET
-            : audioTime
+          const coincident = created !== undefined && audioTime <= created
+          if (coincident && typeof ctx.bridge.flushMessages === 'function') {
+            ctx.bridge.flushMessages(created)
+          }
+          const ctlTime = coincident ? created! + CONTROL_AFTER_CREATE_OFFSET : audioTime
           const ctlWarn = ctx.printHandler
             ? (m: string) => ctx.printHandler!(`[Warning] control — ${m}`)
             : undefined

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -63,6 +63,17 @@ export interface AudioContext {
   printHandler?: (msg: string) => void
   nodeRefMap: Map<number, number>
   /**
+   * audioTime at which each nodeRef's `/s_new` was scheduled this iteration.
+   * SP153/#567: a `control` that follows its `play`/`sample` with NO `sleep`
+   * between (same `task.virtualTime`) would otherwise co-bundle its `/n_set`
+   * with the `/s_new` at an identical timestamp — and SuperSonic's WASM scsynth
+   * then initializes a `*_slide` param's `Lag` UGen at the control TARGET rather
+   * than the play value, skipping the glide. We record the creation time here so
+   * the `control` case can land the `/n_set` strictly AFTER it (mirrors desktop,
+   * whose `/n_set` arrives a control-block after the `/s_new`). Lazily created.
+   */
+  nodeCreationTime?: Map<number, number>
+  /**
    * Live inner FX node instances — keyed by "taskId:fxIndex#nodeId".
    * Since #452 a with_fx inside a live_loop creates a FRESH FX node every
    * iteration (matching desktop SP), so several instances of the same loop
@@ -133,6 +144,20 @@ export interface AudioContext {
  * to the legacy async bind (on the producer's resolved id) when the bridge has
  * no `reserveNodeId` (older mock bridges) or the step carries no ref.
  */
+/**
+ * SP153/#567: minimum gap between a node's `/s_new` and a `control`'s `/n_set`
+ * when they would otherwise share a timestamp (control follows play with no
+ * sleep). Must exceed one scsynth control block (64 samples ≈ 1.3ms @48k) and
+ * the AudioWorklet render quantum (128 samples ≈ 2.7ms @48k) so the creation
+ * bundle is fully processed — the `*_slide` Lag latched at the play value —
+ * before the control sets the target. Empirically WASM scsynth needs ~20ms
+ * here (5ms still skipped the Lag; a 20ms gap recovers it fully) — larger than
+ * native's ~10ms, likely a transport/worklet batching window. 25ms clears the
+ * threshold with margin and is far below any audible slide-onset shift (a 25ms
+ * shift on a multi-second glide is imperceptible).
+ */
+const CONTROL_AFTER_CREATE_OFFSET = 0.025
+
 function dispatchNode(
   ctx: AudioContext,
   nodeRef: number | undefined,
@@ -233,6 +258,11 @@ export async function runProgram(
             (nodeId) => bridge.triggerSynth(synth, audioTime, params, nodeId),
             (err) => ctx.printHandler?.(`Synth '${synth}' failed: ${err.message}`),
           )
+          // SP153/#567: remember when this node was created so a same-instant
+          // `control` lands its `/n_set` strictly after the `/s_new`.
+          if (step.nodeRef !== undefined) {
+            (ctx.nodeCreationTime ??= new Map()).set(step.nodeRef, audioTime)
+          }
 
           // Extend enclosing FX scopes' aliveUntil so the FX bus outlives this
           // synth's audible envelope. Mirrors desktop sound.rb:1817-1822
@@ -286,6 +316,10 @@ export async function runProgram(
             (nodeId) => bridge.playSample(step.name, audioTime, sampleOpts, currentBpm, nodeId),
             (err) => ctx.printHandler?.(`Sample '${step.name}' failed: ${err.message}`),
           )
+          // SP153/#567: see play case — same-instant `control` must land after.
+          if (step.nodeRef !== undefined) {
+            (ctx.nodeCreationTime ??= new Map()).set(step.nodeRef, audioTime)
+          }
 
           // Extend enclosing FX scopes' aliveUntil so the FX bus outlives this
           // sample. SP135/#506: a sample's audible end is its BUFFER PLAYOUT
@@ -380,6 +414,19 @@ export async function runProgram(
         const realNodeId = ctx.nodeRefMap.get(step.nodeRef)
         if (realNodeId && ctx.bridge) {
           const audioTime = task.virtualTime + ctx.schedAheadTime
+          // SP153/#567: if this control targets a node whose `/s_new` was
+          // scheduled at the same (or a later) audioTime — i.e. `control`
+          // follows `play`/`sample` with no `sleep` between — push the `/n_set`
+          // a control-block later. Co-bundling the two at one timestamp makes
+          // SuperSonic's WASM scsynth init a `*_slide` Lag at the control TARGET
+          // instead of the play value, skipping the glide (cutoff_slide etc.).
+          // A control after an elapsed sleep has audioTime > creation, so the
+          // guard is false and the timestamp is untouched (no drift on the
+          // common case). Mirrors desktop, whose `/n_set` lands after `/s_new`.
+          const created = ctx.nodeCreationTime?.get(step.nodeRef)
+          const ctlTime = created !== undefined && audioTime <= created
+            ? created + CONTROL_AFTER_CREATE_OFFSET
+            : audioTime
           const ctlWarn = ctx.printHandler
             ? (m: string) => ctx.printHandler!(`[Warning] control — ${m}`)
             : undefined
@@ -388,7 +435,7 @@ export async function runProgram(
           for (const [k, v] of Object.entries(normalized)) {
             paramList.push(k, v)
           }
-          ctx.bridge.sendTimedControl(audioTime, realNodeId, paramList)
+          ctx.bridge.sendTimedControl(ctlTime, realNodeId, paramList)
         }
         break
       }


### PR DESCRIPTION
Closes #567.

## Problem
A synth whose param is swept via `*_slide` + `control` (e.g. `p = play …, cutoff: 30, cutoff_slide: 4; control p, cutoff: 100`) rendered the **wrong trajectory on web** — the glide was effectively instantaneous. On `tron_bike` this collapsed the bass fundamental (peak freq desktop 92 Hz vs web 374 Hz). Notes/timing matched (EVENT-MATCH); only the rendering diverged.

## Root cause
When `control` follows `play`/`sample` with no `sleep` between, the node's `/s_new` and the `/n_set` are queued in the **same iteration**. `SuperSonicBridge.flushMessages` flushes the whole queue as **one OSC bundle with one NTP timetag** — so both execute at the **same scsynth time**, and WASM scsynth then initialises the `*_slide` `Lag` UGen at the control **target** (100) instead of the play value (30). Nothing to glide from → slide skipped → filter open immediately.

Proven by: an explicit `sleep` before the control (which forces a separate flush) renders the slide correctly.

## Fix
When a control is coincident with its target node's creation:
1. **Flush the queue first** (`bridge.flushMessages(created)`) so the `/s_new` goes out in its **own** bundle at the creation time;
2. queue the `/n_set` at `created + CONTROL_AFTER_CREATE_OFFSET` (25 ms) so it flushes later, in a **separate** bundle, with a strictly-later timetag.

This mirrors exactly what `sleep` does between play and control. Node creation times are tracked in `nodeCreationTime` (an engine field sharing `nodeRefMap`'s lifecycle — cleared on stop/hot-swap). A control after an elapsed sleep already lands after creation → guard false → untouched (no drift on the common case).

⚠️ A timestamp offset **alone** is insufficient (a bundle has one timetag) — it only got web 53→74; the separate flush is what completes it to 93.

## Verification (same-session web-vs-web; desktop too non-deterministic as reference)
- minimal repro web bass% **53 (broken) → 74 (offset only) → 93.0 (flush+offset)**, matching the `sleep` reference 93.3 and desktop 92.8.
- instant control (no slide): web 72.4 ≈ desktop 71.8 — **no regression**.
- L1: `tsc` clean, vitest **1448/1448** (timestamp + flush-order contract test; the decisive oracle was the L3 A/B).

## Notes
- Full `tron_bike` still under-renders due to the **separate** #568 (web drops the first ~cycle for nested `with_synth`/`with_fx` live_loops). The cutoff slide itself is now correct there.
- **Relationship to #557:** that fix made `/n_set` co-bundle with `/s_new` (synchronous node-ref binding) — correct for instant controls, but the precondition for this slide-skip.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (1448/1448)
- [x] L3 A/B: minimal repro reaches the sleep-reference; instant-control no-regression
- [ ] reviewer: full SK22 sweep to confirm no broader regression