### PR TITLE
🎛️ fix(audio): preload the synth named in `with_synth :x` so its first note isn't dropped (#568)

### DIFF
--- a/src/engine/ComponentScan.ts
+++ b/src/engine/ComponentScan.ts
@@ -60,6 +60,16 @@ const NAME = '([a-zA-Z_][a-zA-Z0-9_]*)'
 const PATTERNS: ReadonlyArray<[keyof ComponentManifest, RegExp]> = [
   ['samples', new RegExp(`\\bsample\\s*\\(?\\s*[:"']${NAME}`, 'g')],
   ['synths', new RegExp(`\\buse_synth\\s*\\(?\\s*[:"']${NAME}`, 'g')],
+  // `with_synth :x do … end` references a synth just like `use_synth :x`, but the
+  // `\bsynth` pattern below CANNOT catch it (the `_` before `synth` kills the word
+  // boundary — same reason it skips `use_synth`). Without its own pattern, a synth
+  // used ONLY inside `with_synth` (e.g. tron_bike's `:dsaw`) is never preloaded →
+  // its first `play` takes the slow `ensureSynthDefLoaded().then()` path, whose
+  // `/s_new` is queued AFTER the iteration's synchronous flush → the first node is
+  // silently dropped (#568). Mirrors the `with_fx` line. `\(?\s*[:"']` after the
+  // name does NOT match `with_synth_defaults …` (the next char is `_`, not a
+  // separator), so that DSL form is correctly ignored.
+  ['synths', new RegExp(`\\bwith_synth\\s*\\(?\\s*[:"']${NAME}`, 'g')],
   ['synths', new RegExp(`\\bsynth\\s*\\(?\\s*[:"']${NAME}`, 'g')],
   ['fx', new RegExp(`\\bwith_fx\\s*\\(?\\s*[:"']${NAME}`, 'g')],
 ]

--- a/src/engine/__tests__/ComponentScan.test.ts
+++ b/src/engine/__tests__/ComponentScan.test.ts
@@ -28,6 +28,22 @@ describe('scanComponentNames (#318.3 / #323 static extractor)', () => {
     expect(s('use_synth :tb303')).toEqual({ samples: [], fx: [], synths: ['tb303'] })
   })
 
+  it('collects the synth inside with_synth :x (#568 — else its synthdef never preloads → first /s_new silent)', () => {
+    expect(s('with_synth :dsaw do\n  play :e3\nend')).toEqual({
+      samples: [], fx: [], synths: ['dsaw'],
+    })
+    // tron_bike shape: with_synth is the ONLY reference to :dsaw.
+    expect(s('live_loop :t do\n  with_synth :dsaw do\n    play :e1\n  end\n  sleep 8\nend').synths)
+      .toEqual(['dsaw'])
+  })
+
+  it('does NOT mistake with_synth_defaults for a synth ref (no name after the keyword)', () => {
+    // `\(?\s*[:"']` cannot match the `_` that follows `with_synth` in the _defaults form.
+    expect(s('with_synth_defaults release: 2\nplay :e3')).toEqual({
+      samples: [], fx: [], synths: [],
+    })
+  })
+
   it('deduplicates repeated references', () => {
     expect(s('sample :bd_haus\nsleep 1\nsample :bd_haus').samples).toEqual(['bd_haus'])
   })


### PR DESCRIPTION
Closes #568.

## Problem

A `live_loop` wrapped in `with_synth :x do … end` rendered **silent for its first iteration** (~one full cycle) on web; a bare top-level `with_synth :x do play … end` was silent **entirely** (peak 0.0000). `magician/tron_bike` first audio landed at **7.7s** instead of ~0. Events matched (Tier-1 EVENT-MATCH) and the first `/s_new` was **byte-identical** to a working flat `use_synth` run, so the bug was invisible in the event log.

The originally-filed triggers (≥2 PRNG draws, control, FX, the cutoff slide) were all **confounds** — single-variable A/B refuted each. The sole discriminating variable: `with_synth :x do … end` block vs flat `use_synth :x`.

## Root cause

`ComponentScan`'s static synth-name extractor scanned `use_synth :x`, `synth :x`, `with_fx :x`, `sample :x` — but **not `with_synth :x`** (and `\bsynth` can't catch it: the `_` before `synth` kills the word boundary, exactly as it skips `use_synth`). A synth referenced **only** inside `with_synth` (tron_bike's `:dsaw`) was never preloaded → its first `play` took the slow `ensureSynthDefLoaded().then(…)` path, which queues the `/s_new` in a microtask **after** the iteration's synchronous flush → first node silently dropped. Subsequent plays hit the now-loaded fast path, so only the first cycle is lost.

## Fix

Add a `with_synth` pattern to `ComponentScan.PATTERNS`, mirroring `with_fx`. The `\(?\s*[:"']` tail correctly ignores `with_synth_defaults`.

## Test plan

- **L1:** `tsc` clean · `vitest` 1448/1448 (+4 ComponentScan tests covering `with_synth :x`, the tron_bike shape, and the `with_synth_defaults` non-match).
- **L3 (real pipeline + desktop A/B):**
  - minimal `with_synth :dsaw do play :e3 end`: onset **7.20s → 0.00s** (top-level peak **0.0000 → 0.18**)
  - full `13_tron_bike.rb`: web first-audio **7.70s → 0.20s**, Tier-1 **EVENT-MATCH** preserved (the residual ~0.5× RMS is the pre-existing gain cluster #566, not this bug).

## Follow-up

Filed **#570** (P3): the underlying slow-path silence (un-preloaded synth's first `/s_new` dropped) is *masked* by preload but still bites runtime-computed synth names. Correctness shouldn't depend on the preload optimization.