### PR TITLE
🎛️ fix(audio): flush the slow-path /s_new after the synthdef loads so the first node isn't dropped (#570)

### DIFF
--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -775,9 +775,20 @@ export class SuperSonicBridge {
     // Slow path: load synthdef first (only happens once per synth name). The
     // returned promise still REJECTS on a CDN miss (SV43/SP89), so the caller's
     // .catch can surface it — the pre-reserved `nodeId` doesn't change that.
-    return this.ensureSynthDefLoaded(fullName).then(() =>
-      this.triggerSynthImmediate(fullName, audioTime, params, nodeId)
-    )
+    return this.ensureSynthDefLoaded(fullName).then(() => {
+      const id = this.triggerSynthImmediate(fullName, audioTime, params, nodeId)
+      // #570: the interpreter's synchronous end-of-iteration `flushMessages()`
+      // already ran (on an empty queue) before this async load resolved — the
+      // interpreter dispatches `play` fire-and-forget (dispatchNode, no await).
+      // Without flushing here, the `/s_new` we just queued waits for the NEXT
+      // flush (next iteration / sleep) and is then sent at THAT flush's later
+      // timetag — so the first node is dropped (a one-shot run has no next
+      // flush → never sent → silent). Flush it now, in its own bundle at the
+      // original `audioTime`. The fast path needs no flush: it queues
+      // synchronously, inside the iteration's own flush window.
+      this.flushMessages()
+      return id
+    })
   }
 
   private triggerSynthImmediate(
@@ -1001,7 +1012,13 @@ export class SuperSonicBridge {
     if (!this.loadedSynthDefs.has(playerName)) {
       await this.ensureSynthDefLoaded(playerName)
     }
-    return this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm, nodeId)
+    const id = this.playSampleImmediate(sampleName, bufNum, playerName, audioTime, opts, bpm, nodeId)
+    // #570: same race as triggerSynth's slow path — the interpreter dispatches
+    // `sample` fire-and-forget (dispatchNode), so its synchronous flush already
+    // ran before this async load resolved. Flush the just-queued `/s_new` now,
+    // in its own bundle at the original audioTime, or the first node is dropped.
+    this.flushMessages()
+    return id
   }
 
   /**

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -109,6 +109,39 @@ describe('SuperSonicBridge', () => {
     expect(bundleStr).toContain('sonic-pi-beep')
   })
 
+  it('slow-path triggerSynth (unloaded synthdef) auto-flushes its /s_new — first node not dropped (#570)', async () => {
+    const { mockSonic, bundles } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    // `dsaw` is NOT in COMMON_SYNTHDEFS → slow path (ensureSynthDefLoaded.then).
+    // The interpreter dispatches `play` fire-and-forget, so its synchronous
+    // end-of-iteration flush runs BEFORE this async load resolves. Without the
+    // in-`then` flush (#570), this /s_new would sit unsent until the NEXT flush
+    // (a one-shot run never flushes again → silence). It must auto-flush, so
+    // sendOSC fires with NO explicit flushMessages() call.
+    await bridge.triggerSynth('dsaw', 1.0, { note: 52, amp: 0.5 })
+    expect(mockSonic.sendOSC).toHaveBeenCalledTimes(1)
+    expect(new TextDecoder().decode(bundles[0])).toContain('sonic-pi-dsaw')
+  })
+
+  it('fast-path triggerSynth (preloaded synthdef) does NOT auto-flush — waits for the iteration flush (#570 scope guard)', async () => {
+    const { mockSonic } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    // `beep` IS preloaded → fast path → queues synchronously, sent only on the
+    // interpreter's own flush. The #570 fix must NOT change this (else every
+    // event flushes as its own bundle, breaking same-instant co-bundling that
+    // SP83/#567 rely on).
+    await bridge.triggerSynth('beep', 1.0, { note: 60, amp: 0.5 })
+    expect(mockSonic.sendOSC).not.toHaveBeenCalled()
+  })
+
   it('drops non-finite numeric params before /s_new (#509 — NaN must not reach scsynth)', async () => {
     const { mockSonic, bundles } = createMockSuperSonic()
     ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)


### PR DESCRIPTION
Closes #570. The correctness fix beneath #568 — both lift tron_bike's first cycle independently (defense-in-depth).

## Problem

The **first** `play`/`sample` of an **un-preloaded** synthdef produced no audio — the node was created but silent (a one-shot run was silent entirely, `peak 0.0000`; a loop lost its first cycle). This is the root cause that #568's ComponentScan preload merely *masked* — it still bit any reference the static scan can't see:

```ruby
foo = :dsaw
use_synth foo          # runtime-computed → not scanned → not preloaded → SILENT
play :e3, release: 6
```

## Root cause

`triggerSynth` / `playSampleSlow` take the slow path (`ensureSynthDefLoaded().then(…)`) when the synthdef isn't cached. The interpreter dispatches `play`/`sample` **fire-and-forget** (`dispatchNode`, no await), so its synchronous end-of-iteration `flushMessages()` runs on an empty queue **before** the async load resolves. The `.then` then queues the `/s_new` with no flush behind it → it waits for the **next** flush and is sent at that flush's later timetag (node dropped); a one-shot run has no next flush → never sent. Boundary B2, same fire-after-the-flush-boundary family as #557/#567.

## Fix

In both slow paths, call `flushMessages()` right after the `*Immediate` call queues the `/s_new`, sending it in its own bundle at the original `audioTime`. The **fast path is untouched** — it queues synchronously inside the iteration's own flush window, preserving the same-instant co-bundling that SP83/#567 rely on (covered by a new scope-guard test).

## Test plan

- **L1:** `tsc` clean · `vitest` **1448/1448** (+2 bridge tests: slow-path auto-flush + fast-path *no* auto-flush guard).
- **L3 (real pipeline + desktop A/B):**
  - `foo=:dsaw; use_synth foo; play :e3`: peak **0.0000 → 0.17**
  - dynamic `sample s`: silent → audible
  - `with_synth :dsaw` (slow path on this branch, no ComponentScan preload): **7.20s → 0.00s**
  - full `13_tron_bike.rb`: web first-audio **7.70s → 0.20s**, Tier-1 **EVENT-MATCH** preserved
  - flat fast-path baseline: unchanged (0.00s)

## Relationship to #568 / PR #571

Complementary, non-conflicting (different files): #568 preloads `with_synth` synths (perf — avoids first-use latency, SP84); this fixes the slow path itself (correctness — covers dynamic names). Either one alone lifts tron_bike's first cycle.