### PR TITLE
🎚️ fix(transpiler): N.times enumerator form (`N.times.map { }`) emits valid JS (#573)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -1704,6 +1704,20 @@ function transpileReceiverMethodCall(
     return `{ const ${nTmp} = ${recStr}; for (let ${varName} = 0; ${varName} < ${nTmp}; ${varName}++) {\n${ctx.indent}  __b.__checkBudget__()\n${bodyStr}\n${ctx.indent}} }`
   }
 
+  // N.times used as an ENUMERATOR — NO block of any kind: `8.times.map { }`,
+  // `4.times.to_a`, `3.times.map { }.ring`. Ruby's `N.times` yields 0..N-1, so as
+  // a bare receiver it is an Enumerator that chained `.map`/`.each`/`.to_a`/`.ring`
+  // operate on. WITHOUT this it fell through to the generic receiver-call handler
+  // → `recStr.times()` = `8.times()`, which is INVALID JS (`8.` parses as a float
+  // literal → "Invalid or unexpected token") → the whole program is REJECTED
+  // (ok:false, SV19) → silence (#573, bhairav_tabla). The BLOCK forms
+  // (`N.times do…end` above, and `N.times { }` braces) are handled as for-loops;
+  // only the no-block enumerator form reaches here. Emit the 0..N-1 index array.
+  if (method === 'times' && !blockNode &&
+      !fullNode?.namedChildren?.some((c: any) => c.type === 'block')) {
+    return `Array.from({ length: ${recStr} }, (_, __i) => __i)`
+  }
+
   // .each do |item| ... end  /  .each do |a, b| ... end (destructure)
   // Multi-arg block over a tuple-yielding iterator (e.g. arr.zip(b).each do |a, b|)
   // emits JS array destructure: for (const [a, b] of iter).

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -90,6 +90,42 @@ end`)
     })
   })
 
+  describe('#573: N.times as an enumerator (no block) is valid JS', () => {
+    it('`N.times.map { }` emits an index array, NOT invalid `N.times()`', () => {
+      const result = treeSitterTranspile('a = 8.times.map { |i| i * 2 }')
+      expect(result.ok).toBe(true)
+      // 8.times() (the bug) is invalid JS — `8.` is a float literal. Must be an array.
+      expect(result.code).not.toMatch(/\b8\.times\(/)
+      expect(result.code).toContain('Array.from({ length: 8 }')
+      expect(result.code).toContain('.map(')
+    })
+
+    it('`N.times.to_a` and `N.times.map { }.ring` transpile ok', () => {
+      expect(treeSitterTranspile('r = 4.times.to_a').ok).toBe(true)
+      expect(treeSitterTranspile('x = 3.times.map { |i| i }.ring').ok).toBe(true)
+    })
+
+    it('block forms are unchanged (still a for-loop)', () => {
+      const brace = treeSitterTranspile('8.times { play 60 }')
+      const doEnd = treeSitterTranspile('8.times do\n  play 60\nend')
+      expect(brace.ok).toBe(true)
+      expect(doEnd.ok).toBe(true)
+      expect(brace.code).toMatch(/for \(let _i = 0; _i < __times_\d+; _i\+\+\)/)
+      expect(doEnd.code).toMatch(/for \(let _i = 0; _i < __times_\d+; _i\+\+\)/)
+    })
+
+    it('the bhairav_tabla shape (`8.times.map { … }.ring` inside define) no longer rejects the program', () => {
+      const result = treeSitterTranspile(`define :pat do
+  8.times.map { tablas.choose }.ring
+end
+live_loop :t do
+  p = pat
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+    })
+  })
+
   describe('Task 1: Setup & Prototype', () => {
     it('parses and transpiles a basic live_loop', () => {
       const ruby = `live_loop :drums do


### PR DESCRIPTION
Closes #573.

## Problem

`N.times` as an **enumerator** (no block on `times`, chained with `.map`/`.to_a`/`.each`/…) transpiled to `N.times()` — **invalid JS** (`8.` is a float literal → "Invalid or unexpected token"). The transpiler self-validates, so this set `ok:false` → the engine **rejected the entire program** (SV19) → total silence even for unrelated loops in the same file.

Found via community sweep triage: `24_bhairav_tabla.rb` was fully silent (peak 0.000) — its `define :tabla_pattern do 8.times.map { tablas.choose }.ring end` poisoned the whole file.

## Fix

`transpileReceiverMethodCall` handled `times` only **with** a block. Added the no-block enumerator case: emit `Array.from({ length: N }, (_, __i) => __i)` so chained `.map`/`.to_a`/`.ring` work. Block forms (`N.times do…end` / `N.times { }`) are unchanged.

## Test plan

- **L1:** `tsc` clean · `vitest` **1450/1450** (+4 transpiler tests: enumerator forms transpile `ok:true`, block forms still emit for-loops, the bhairav shape no longer rejects).
- **L3:** `24_bhairav_tabla.rb` peak **0.000 → 0.40**, onset 0.00s; the drone loop now sounds (program no longer rejected).

## Follow-up

`bhairav_tabla` still under-produces its two `define`-driven loops (`p = tabla_pattern`; tabla + pluck loops emit nothing). That's a **separate** bug — a bare call to a `define`d method on an assignment RHS isn't invoked (the `isStatement` gate at `TreeSitterTranspiler.ts:583`) — filed as a follow-up. This PR is the prerequisite (the program is no longer rejected outright).