### PR TITLE
🎚️ fix(transpiler): invoke a define'd method in expression position + return its last expression (#575)

### DIFF
--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -178,11 +178,17 @@ export function treeSitterTranspile(ruby: string): TreeSitterTranspileResult {
     errors,
     insideLoop: false,
     definedFunctions: new Set(),
+    localVars: new Set(),
     indent: '',
     inthreadLoopCounter: { n: 0 },
     inthreadGateCounter: { n: 0 },
     fxLoopCounter: { n: 0 },
   }
+
+  // #575/SP157: collect local-variable & parameter names before transpiling, so
+  // a bare define'd-method reference in expression position can be told apart
+  // from a same-named local read (Ruby shadowing).
+  collectLocalVars(tree.rootNode, ctx.localVars!)
 
   const js = transpileNode(tree.rootNode, ctx)
 
@@ -229,6 +235,17 @@ interface TranspileContext {
   errors: string[]
   insideLoop: boolean
   definedFunctions: Set<string>
+  /**
+   * #575/SP157: every name bound as a local variable or parameter anywhere in
+   * the program. Lets a bare identifier that matches a `define`d method be
+   * disambiguated in EXPRESSION position: it is a method call only when the
+   * name is NOT also a local (Ruby locals shadow same-named methods — `pat = 5;
+   * play pat` reads 5 even if `define :pat` exists). Over-approximate &
+   * flow-insensitive (a name assigned anywhere counts as local everywhere): the
+   * SAFE direction, since a false "local" only suppresses a call (reverting to a
+   * read), never turns a local read into a wrong call.
+   */
+  localVars?: Set<string>
   indent: string
   /** Current node's source line (1-based) for _srcLine injection */
   srcLine?: number
@@ -373,6 +390,32 @@ const BUILDER_METHODS = new Set([
 const DEF_PREFIX = '__spdef_'
 function defJsName(name: string): string {
   return DEF_PREFIX + name
+}
+
+/**
+ * #575/SP157: walk the whole tree and collect every name bound as a local
+ * variable (assignment / operator-assignment LHS) or as a block/method
+ * parameter. Used to disambiguate a bare define'd-method reference in
+ * expression position from a same-named local read (Ruby shadowing). Deliberately
+ * over-approximate: collecting a name that is only a parameter default or an
+ * element-assignment index is harmless — it can only suppress a method call
+ * (the safe direction), never produce a wrong call.
+ */
+function collectLocalVars(node: any, out: Set<string>): void {
+  if (!node) return
+  if (node.type === 'assignment' || node.type === 'operator_assignment') {
+    collectIdentifiers(node.namedChildren[0], out)
+  } else if (/parameters$/.test(node.type)) {
+    collectIdentifiers(node, out)
+  }
+  for (const child of node.namedChildren) collectLocalVars(child, out)
+}
+
+/** Add every `identifier` descendant's text to `out` (used by collectLocalVars). */
+function collectIdentifiers(node: any, out: Set<string>): void {
+  if (!node) return
+  if (node.type === 'identifier') { out.add(node.text); return }
+  for (const child of node.namedChildren) collectIdentifiers(child, out)
 }
 
 const TOP_LEVEL_SCOPE = new Set([
@@ -573,14 +616,14 @@ function transpileNode(node: any, ctx: TranspileContext): string {
       if (name === 'true') return 'true'
       if (name === 'false') return 'false'
 
-      // Only transform bare identifiers to calls in statement context
-      const parentType = node.parent?.type
-      const isStatement = parentType === 'body_statement' || parentType === 'program' ||
-                          parentType === 'then' || parentType === 'block_body'
-
       // Bare identifier that matches a user-defined function → call it with __b.
       // Namespaced so a same-named local variable can't shadow the call (#432).
-      if (isStatement && ctx.definedFunctions.has(name)) {
+      // #575/SP157: this fires in EXPRESSION position too (e.g. `p = my_pattern`),
+      // not just statement context — but only when the name is NOT also a local
+      // variable/parameter. Ruby locals shadow same-named methods, so `pat = 5;
+      // play pat` must read the local 5 even when `define :pat` exists. A bare
+      // ref that is a define and NOT a local is always a method call.
+      if (ctx.definedFunctions.has(name) && !ctx.localVars?.has(name)) {
         return `${defJsName(name)}(__b)`
       }
 
@@ -2154,7 +2197,11 @@ function transpileDefine(
     : ''
 
   const bodyCtx: TranspileContext = { ...ctx, insideLoop: true }
-  const bodyStr = transpileBlockBody(blockNode, bodyCtx)
+  // #575/SP157: `return` the last expression (Ruby's implicit return) so a
+  // define called in EXPRESSION position (`p = my_pattern`) yields a value
+  // instead of undefined. Statement-position calls (the historical use) ignore
+  // the return value, so this is backwards-compatible.
+  const bodyStr = transpileReturningBody(blockNode, bodyCtx, ctx.indent)
 
   // For `define`, also call the runtime registrar so the engine persists the
   // function across re-evals (#215). `ndefine` skips this — its semantic is
@@ -3166,6 +3213,33 @@ function transpileBlockBody(blockNode: any, ctx: TranspileContext): string {
   return bodyChildren
     .map((c: any) => ctx.indent + '  ' + transpileNode(c, ctx))
     .join('\n')
+}
+
+/**
+ * #575/SP157: like transpileBlockBody but `return`s the last expression (Ruby's
+ * implicit return). Uses blockBodyChildren so a `body_statement`-wrapped do/end
+ * block is flattened and the true last statement is found. Only a single-line
+ * expression is returned; a multi-line statement block (loop / if / case) has
+ * no JS-expression value and is left as-is — `return for(){}` would be a syntax
+ * error that fails the whole program (SV19).
+ */
+function transpileReturningBody(blockNode: any, ctx: TranspileContext, indent: string): string {
+  const bodyChildren = blockBodyChildren(blockNode)
+  const lastIdx = bodyChildren.length - 1
+  return bodyChildren
+    .map((c: any, i: number) => {
+      const expr = transpileNode(c, ctx)
+      return i === lastIdx && isReturnableExpr(expr)
+        ? `${indent}  return ${expr}`
+        : `${indent}  ${expr}`
+    })
+    .join('\n')
+}
+
+/** A transpiled snippet safe to `return`: a single-line expression, not a multi-line statement block or a leading-keyword statement. */
+function isReturnableExpr(expr: string): boolean {
+  if (/\n/.test(expr)) return false
+  return !/^\s*(for|while|if|switch|const|let|var|return|throw|do|\{)\b/.test(expr)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -1261,6 +1261,79 @@ end`)
       expect(result.code).toContain('define("synths", __spdef_synths)')
     })
 
+    it('#575: a define called in expression position (RHS) is invoked, not left bare', () => {
+      // `p = pat` must CALL the define (and use its return value), not leave a
+      // bare reference. The historic gate only transformed statement-position
+      // calls, so `p = pat` produced `p = pat` (undefined) and the loop was silent.
+      const result = treeSitterTranspile(`define :pat do
+  (ring :a, :b, :c)
+end
+live_loop :l do
+  p = pat
+  play (note p.tick)
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      // RHS is the call, not the bare identifier.
+      expect(result.code).toContain('p = __spdef_pat(__b)')
+      expect(result.code).not.toMatch(/\bp = pat\b/)
+    })
+
+    it('#575: a define body returns its last expression (Ruby implicit return)', () => {
+      // Without an explicit return the function evaluates to undefined, so an
+      // expression-position caller gets nothing.
+      const result = treeSitterTranspile(`define :pat do
+  (ring :a, :b, :c)
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('return (__b.ring("a", "b", "c"))')
+    })
+
+    it('#575: a local variable still shadows a same-named define (locals win)', () => {
+      // Ruby: a bare identifier is a local read when a local of that name
+      // exists, else a method call. `pat = 5; play pat` must read 5 even though
+      // `define :pat` exists — the define must NOT be called here.
+      const result = treeSitterTranspile(`define :pat do
+  1
+end
+live_loop :l do
+  pat = 5
+  play pat
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('pat = 5')
+      // play reads the plain local, not the namespaced define call.
+      expect(result.code).toContain('__b.play(pat,')
+      expect(result.code).not.toContain('__b.play(__spdef_pat(__b)')
+    })
+
+    it('#575: a define call as a method receiver works in expression position', () => {
+      // `melody.tick` (no intermediate local) must call the define then tick it.
+      const result = treeSitterTranspile(`define :melody do
+  (ring 60, 62, 64)
+end
+live_loop :l do
+  play melody.tick
+  sleep 1
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).toContain('__spdef_melody(__b)?.at(__b.tick())')
+    })
+
+    it('#575: a define whose last statement is a loop is NOT illegally returned', () => {
+      // A multi-line statement block has no JS-expression value; prefixing
+      // `return` would be a syntax error that fails the whole program (SV19).
+      const result = treeSitterTranspile(`define :spray do
+  4.times do
+    play 60
+    sleep 0.25
+  end
+end`)
+      expect(result.ok).toBe(true)
+      expect(result.code).not.toMatch(/return\s+(\{|for|while)/)
+    })
+
     it('begin/rescue', () => {
       const result = treeSitterTranspile(`live_loop :t do
   begin


### PR DESCRIPTION
## Problem

A bare call to a user `define`d method was only transpiled to a call in **statement** position. In **expression** position — most commonly an assignment RHS `p = my_pattern` — it was left as a bare identifier (undefined), so the value was never computed and the loop using it produced nothing.

Worse, even a statement-position call returned `undefined`: a define body never `return`ed its last expression (it only ever mattered once defines could be used for their value).

Found via community sweep triage on `24_bhairav_tabla.rb`: web emitted only **4** `/s_new` (the drone loop) vs desktop **~90**. The tabla and `:pluck` loops do `p = tabla_pattern` (a `define`) then `p.tick`, and `p` was `undefined` → every `sample`/`play` skipped (CORS-spammed `samples/undefined.flac`).

## Fix

1. **Disambiguate the bare-identifier→call transform with per-program local-variable tracking** instead of the old `isStatement` gate. A pre-scan (`collectLocalVars`) records every assignment LHS and parameter name; a define is now called in **any** position when the name ∈ `definedFunctions` **AND** is not also a local. This preserves Ruby shadowing — `pat = 5; play pat` reads the local `5` even when `define :pat` exists — and is an over-approximation in the safe direction (a false "local" only suppresses a call, never produces a wrong one).
2. **Emit `return` for a define body's last expression** (Ruby implicit return), via `transpileReturningBody`. Only single-line expressions are returned; a multi-line statement block (loop / `if` / `case`) has no JS-expression value and is left as-is, so `return for(){}` can't fail the whole program (SV19).

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1455 passed** (+5 new transpiler tests: RHS-call, implicit return, shadowing-wins, receiver-call, loop-not-returned)
- **L3 (desktop A/B, `compare-desktop-vs-web.ts`):** `24_bhairav_tabla.rb` web `/s_new` **4 → 87**, event-parity **STRUCTURE-MATCH · onset-seq match** vs desktop 90; `undefined.flac` errors gone; sustained audio across the full run. RMS 0.44× = the known gain cluster (#566), not a bug.

Closes #575