### PR TITLE
🎚️ fix(audio): scale chord/array play amplitude by 1/notes.size, matching desktop (#577)

### DIFF
--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -192,7 +192,20 @@ export class ProgramBuilder {
     // Chord: Ring or array — push one play step per note (all at the same virtual time).
     if (noteVal instanceof Ring || Array.isArray(noteVal)) {
       const notes: number[] = noteVal instanceof Ring ? noteVal.toArray() : noteVal
-      for (const n of notes) this._pushPlayStep(n, opts)
+      // #577: a chord/array is played at 1/notes.size the amplitude so it isn't
+      // N× louder than a single note. Mirrors desktop `sound.rb:3580` trigger_chord
+      // (`args_h[:amp] = (amp || 1.0) / notes.size`). The RESOLVED amp is divided —
+      // explicit opt, else use_synth_defaults, else 1.0 — then applied per note as
+      // an explicit amp (overrides the default re-merged in _pushPlayStep). Divide
+      // by the full array length: rests still count toward the divisor (desktop
+      // divides by notes.size before skipping nils).
+      if (notes.length > 0) {
+        const baseAmp = (opts?.amp as number | undefined)
+          ?? (this._synthDefaults.amp as number | undefined)
+          ?? 1.0
+        const chordOpts = { ...opts, amp: baseAmp / notes.length }
+        for (const n of notes) this._pushPlayStep(n, chordOpts)
+      }
       return this
     }
     this._pushPlayStep(noteVal, opts)

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -583,6 +583,37 @@ describe('Pattern helpers (#211 Tier A)', () => {
     expect(steps.filter(s => s.tag === 'sleep').length).toBe(0)
   })
 
+  it('#577: a chord/array scales amp by 1/notes.size (desktop trigger_chord parity)', () => {
+    const b = new ProgramBuilder()
+    b.play([60, 64, 67], { amp: 0.3 })
+    const plays = b.build().filter(s => s.tag === 'play') as Array<{ opts: Record<string, number> }>
+    expect(plays.length).toBe(3)
+    // amp 0.3 / 3 notes = 0.1 per note (not the full 0.3, which would be 3× too loud)
+    for (const p of plays) expect(p.opts.amp).toBeCloseTo(0.1, 6)
+  })
+
+  it('#577: a chord with no explicit amp divides the default 1.0 across notes', () => {
+    const b = new ProgramBuilder()
+    b.play([60, 64, 67, 72])
+    const plays = b.build().filter(s => s.tag === 'play') as Array<{ opts: Record<string, number> }>
+    for (const p of plays) expect(p.opts.amp).toBeCloseTo(0.25, 6) // 1.0 / 4
+  })
+
+  it('#577: a single-note play is NOT amp-divided', () => {
+    const b = new ProgramBuilder()
+    b.play(60, { amp: 0.3 })
+    const play = b.build().find(s => s.tag === 'play') as { opts: Record<string, number> }
+    expect(play.opts.amp).toBeCloseTo(0.3, 6)
+  })
+
+  it('#577: a chord divides the resolved use_synth_defaults amp', () => {
+    const b = new ProgramBuilder()
+    b.use_synth_defaults({ amp: 0.6 })
+    b.play([60, 64, 67])
+    const plays = b.build().filter(s => s.tag === 'play') as Array<{ opts: Record<string, number> }>
+    for (const p of plays) expect(p.opts.amp).toBeCloseTo(0.2, 6) // 0.6 / 3
+  })
+
   it('play_pattern_timed cycles through times array (sleeps after every note, #404)', () => {
     const b = new ProgramBuilder()
     b.play_pattern_timed([60, 64, 67, 72], [0.25, 0.5])


### PR DESCRIPTION
## Problem

`play chord(:e4, :major)` / `play [60,64,67]` rendered **N× louder** on web than on desktop Sonic Pi (N = note count). Desktop scales a chord's amplitude down by the number of notes; our engine played each array note at the full `amp`.

L3 (`:tri`, `amp: 0.3`, sustained):

| | Desktop RMS | Web RMS | web/desktop |
|---|---|---|---|
| `play chord(:e4,:major)` | 0.0193 | 0.0303 | **1.57×** |
| 3 separate `play` (same notes) | 0.0579 | 0.0303 | 0.52× |

## Root cause (grounded both sides)

- **Desktop** `sound.rb:3580-3581` (`trigger_chord`): `args_h[:amp] = (amp || 1.0) / notes.size` — "Scale down amplitude based on number of notes in chord."
- **Web** `ProgramBuilder.ts:195`: each array note pushed with the full `amp`, no division.

## Fix

In `play`'s array/Ring branch, divide the **resolved** amp (explicit opt → else `use_synth_defaults` → else 1.0) by `notes.length` and apply per note, mirroring desktop. Divide by the full array length so rests still count toward the divisor (desktop divides by `notes.size` before skipping nils). Scalar `play` and sequential `play_pattern` are unaffected; `play_chord` routes through `play()` and is fixed by the same change.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1465 passed** (+5: per-note amp division, default-amp division, single-note untouched, `use_synth_defaults` division)
- **L3 A/B** (`compare-desktop-vs-web.ts`): `play chord(:e4,:major)` web/desktop **1.57× → 0.56×** (web RMS 0.0303 → 0.0101, exactly ÷3), now matching the separate-play control (0.52×) and the engine's ~0.5× baseline (the #566 gain cluster). Separate plays unchanged.

Found while investigating the `orchard_improv` spectrogram — note that orchard itself does **not** use array-play, so its spectral difference is a separate, inherent WASM-vs-native overlapping-retrigger effect, not this bug.

Closes #577