### PR TITLE
🎚️ fix(audio): set_volume! over-attenuated web ~50× (÷5 mis-map + double-apply) (#579)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -677,7 +677,11 @@ export class SonicPiEngine {
       let currentVolume = 1
       const set_volume = (vol: number) => {
         currentVolume = Math.max(0, Math.min(5, vol))
-        this.bridge?.setMasterVolume(currentVolume / 5) // normalize 0-5 → 0-1
+        // Pass the 0-5 value straight through: setMasterVolume treats 1.0 as
+        // unity (no-op) and scales the mixer pre_amp by it. The old `/5` mapped
+        // unity to 0.2 and (with the bridge double-apply) collapsed audio to
+        // near-silence (#579).
+        this.bridge?.setMasterVolume(currentVolume)
       }
       // Used by AudioInterpreter's setVolume step — same body as set_volume,
       // but exposed as a stable reference so the interpreter can update the

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -385,18 +385,26 @@ export class SuperSonicBridge {
     return null
   }
 
-  /** Set master volume (0-1). Controls both scsynth mixer pre_amp and Web Audio gain. */
+  /**
+   * Set master volume. Range mirrors desktop `set_volume!`: 0–5 where **1.0 =
+   * unity** (the no-op baseline), not 1/5 of max. The UI slider's 0–1 range is
+   * a subset (1 = full). Boost (>1) is allowed up to 5 and is tamed by the
+   * mixer's `Limiter.ar(0.99)`, exactly as desktop does.
+   *
+   * Drives a SINGLE gain stage — the scsynth mixer `pre_amp` (the documented
+   * primary volume control, upstream of the limiter and the recording tap).
+   * It deliberately does NOT also scale the Web Audio `masterGainNode`: that
+   * node is UI-feedback-only and stays at unity. Driving both multiplied the
+   * value (≈v²) and collapsed the output to near-silence (#579).
+   */
   setMasterVolume(volume: number): void {
-    const clamped = Math.max(0, Math.min(1, volume))
+    const clamped = Math.max(0, Math.min(5, volume))
     this.currentMasterVolume = clamped
     // pre_amp on the wire = master volume × user-pref pre_amp baseline.
-    // The pref baseline lets users dial in headroom independent of volume.
+    // The pref baseline lets users dial in headroom independent of volume;
+    // volume 1.0 leaves it at the baseline (unity / no-op).
     const scaledPreAmp = clamped * this.currentMixerPreAmp
     this.sonic?.send('/n_set', this.mixerNodeId, 'pre_amp', scaledPreAmp)
-    // Web Audio gain for UI slider feedback (not the primary volume control)
-    if (this.masterGainNode) {
-      this.masterGainNode.gain.setTargetAtTime(clamped, this.masterGainNode.context.currentTime, 0.02)
-    }
   }
 
   /** Set mixer amp (final gain stage). Live — sends /n_set immediately if

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SuperSonicBridge } from '../SuperSonicBridge'
+import { MIXER } from '../config'
 
 /** Extract the OSC address string from a raw OSC bundle (starts after 16-byte header + 4-byte size). */
 function extractBundleAddress(bundle: Uint8Array): string {
@@ -88,6 +89,47 @@ describe('SuperSonicBridge', () => {
     expect(mockSonic.loadSynthDef).toHaveBeenCalledWith('sonic-pi-mixer')
     expect(mockSonic.sync).toHaveBeenCalled()
     expect(mockSonic.node.connect).toHaveBeenCalled()
+  })
+
+  // #579 — set_volume! over-attenuated web ~50×. Two compounding bugs:
+  // (1) the engine divided the 0-5 value by 5 (unity 1.0 → 0.2); (2) this
+  // method scaled BOTH scsynth pre_amp AND the Web Audio masterGainNode by the
+  // value, multiplying them (≈v²). The fix: 1.0 = unity, drive ONE stage
+  // (scsynth pre_amp), leave masterGainNode at unity.
+  it('setMasterVolume drives ONLY scsynth pre_amp, 1.0 = unity, no masterGain double-apply (#579)', async () => {
+    const { mockSonic, sent } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    // masterGainNode is the single GainNode created during init.
+    const gainNode = mockSonic.audioContext.createGain.mock.results[0].value
+
+    const lastPreAmp = (): number => {
+      const calls = sent.filter((c) => c.address === '/n_set' && c.args.includes('pre_amp'))
+      const args = calls[calls.length - 1].args
+      return args[args.indexOf('pre_amp') + 1] as number
+    }
+
+    // 1.0 = unity → pre_amp stays at the baseline (no-op).
+    bridge.setMasterVolume(1.0)
+    expect(lastPreAmp()).toBeCloseTo(MIXER.PRE_AMP, 6)
+
+    // 0.5 = half → pre_amp halved (NOT squared / collapsed).
+    bridge.setMasterVolume(0.5)
+    expect(lastPreAmp()).toBeCloseTo(MIXER.PRE_AMP * 0.5, 6)
+
+    // Boost (>1) is allowed up to 5 — a boost, not the old ÷5 attenuation.
+    bridge.setMasterVolume(2)
+    expect(lastPreAmp()).toBeCloseTo(MIXER.PRE_AMP * 2, 6)
+    bridge.setMasterVolume(10)
+    expect(lastPreAmp()).toBeCloseTo(MIXER.PRE_AMP * 5, 6) // clamped to 5
+
+    // The Web Audio masterGainNode must stay at unity — never driven by volume
+    // (it is UI-feedback-only). Driving it too caused the ≈v² collapse.
+    expect(gainNode.gain.setTargetAtTime).not.toHaveBeenCalled()
+    expect(gainNode.gain.value).toBe(1)
   })
 
   it('triggerSynth queues message, flushMessages sends bundle', async () => {

--- a/src/engine/interpreters/AudioInterpreter.ts
+++ b/src/engine/interpreters/AudioInterpreter.ts
@@ -712,7 +712,9 @@ export async function runProgram(
         if (ctx.onVolumeChange) {
           ctx.onVolumeChange(vol)
         } else {
-          ctx.bridge?.setMasterVolume(vol / 5)
+          // Fallback when the engine didn't wire onVolumeChange: 1.0 = unity,
+          // pass the 0-5 value through (no `/5` — see #579).
+          ctx.bridge?.setMasterVolume(vol)
         }
         break
       }


### PR DESCRIPTION
## Problem

Any track that calls `set_volume!` was **near-silent on web**. `set_volume! 1.0` (which should be unity / a no-op) dropped web output to **~0.06×**; `set_volume! 0.5` to **~0.015×** (the value was also effectively squared). `set_volume! 2` — a *boost* — was wrongly attenuated too (`2/5` → ~0.16× baseline). Desktop is unaffected. Closes #579.

Found while diagnosing `33_dub_reverb` (web RMS 0.04× of desktop despite event-parity STRUCTURE-MATCH).

### Two compounding bugs
1. **`SonicPiEngine.ts` `set_volume`** divided the 0–5 value by 5, so Sonic Pi's unity (`1.0`) mapped to `setMasterVolume(0.2)` — it treated `5` as "full".
2. **`SuperSonicBridge.setMasterVolume`** drove **both** the scsynth mixer `pre_amp` (`v × currentMixerPreAmp`) **and** the Web Audio `masterGainNode.gain`, multiplying them (≈`v²`).

## Fix

- **`1.0` = unity.** Drop the `÷5` in `set_volume` (and the `AudioInterpreter` `setVolume` fallback) — pass the 0–5 value straight through.
- **`setMasterVolume` drives ONE gain stage** — the scsynth mixer `pre_amp` (the documented primary control, upstream of the limiter and the recording tap). The Web Audio `masterGainNode` stays at unity (UI-feedback-only).
- **Clamp widened to `[0,5]`** so boost (`>1`) works, tamed by `Limiter.ar(0.99)` exactly as desktop does.

### Desktop ground truth
On desktop, `set_volume! 0.5` leaves the *recorded* WAV unchanged (volume stage sits after the recording tap; range 0–5, `1` = unity). Web honors `set_volume!` linearly in its capture (our tap is downstream of `pre_amp`), which is the more useful live-coding behavior; the resulting global gain offset vs desktop is Tier-3 and absorbed by the dashboard RMS-norm.

## Test plan

**L1** — `tsc` clean; `vitest` 1462/1462 (+1 test: `setMasterVolume drives ONLY scsynth pre_amp, 1.0 = unity, no masterGain double-apply`).

**L3 (audio observation)** — web RMS, baseline `bd_plain` (no `set_volume`) = 0.02240:
| case | before | after |
|---|---|---|
| `set_volume! 1.0` (unity) | 0.06× | **1.08× baseline** ✓ |
| `set_volume! 0.5` (half) | 0.015× | **0.55× baseline** ✓ |
| `33_dub_reverb` (web/desktop) | 0.04× (near-silent) | **1.80×** (audible, event-parity STRUCTURE-MATCH d57/w56) ✓ |