### PR TITLE
🎚️ fix(audio): mixer gain-staging siblings — reset_mixer state-desync (#582), set_mixer_control slides (#581), setVolume contract (#583)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -2525,12 +2525,16 @@ export class SonicPiEngine {
   }
 
   /**
-   * Set master volume. Range: 0 (silent) to 1 (full).
-   * Safe to call before `init()` — applied when the audio bridge is ready.
+   * Set master volume. Range 0–5 where **1.0 = unity** (matches the `set_volume!`
+   * DSL); the UI slider's 0–1 is a subset (1 = full). Values >1 boost and are
+   * tamed by the mixer limiter. Clamped here to [0,5] so the public contract is
+   * self-documenting and a future caller can't silently re-introduce the #579
+   * `/5` mis-map. Safe to call before `init()` — applied when the bridge is ready.
    */
   setVolume(volume: number): void {
-    this.pendingVolume = volume
-    this.bridge?.setMasterVolume(volume)
+    const clamped = Math.max(0, Math.min(5, volume))
+    this.pendingVolume = clamped
+    this.bridge?.setMasterVolume(clamped)
   }
 
   /** Set mixer amp (0.5–6 typical). Live — propagates to scsynth /n_set

--- a/src/engine/SuperSonicBridge.ts
+++ b/src/engine/SuperSonicBridge.ts
@@ -431,15 +431,22 @@ export class SuperSonicBridge {
   /**
    * Set arbitrary mixer params (Tier C PR #3 #255 — set_mixer_control! DSL).
    * The allowlist matches the sonic-pi-mixer synthdef's parameter vocabulary
-   * (pre_amp/amp/hpf/lpf and four bypass flags). Param names not in this
-   * set are silently dropped by scsynth, so we filter + surface a console
-   * warning instead — making the parameter-name boundary loud rather than
-   * quiet. Returns the names actually applied for telemetry / test assertion.
+   * (pre_amp/amp/hpf/lpf, their *_slide glide times, and four bypass flags).
+   * Param names not in this set are silently dropped by scsynth, so we filter
+   * + surface a console warning instead — making the parameter-name boundary
+   * loud rather than quiet. Returns the names actually applied for telemetry.
    */
   setMixerControl(opts: Record<string, number>): string[] {
     if (!this.sonic) return []
     const ALLOWED = new Set([
       'pre_amp', 'amp', 'hpf', 'lpf',
+      // *_slide glide-time params — paired 1:1 with the four control params.
+      // Desktop's canonical example is `set_mixer_control! lpf: 30, lpf_slide:
+      // 16` (sound.rb:1035); the sonic-pi-mixer synthdef declares these
+      // (synthinfo.rb:5637-5660, default 0.02). Without them a mixer sweep
+      // snaps instead of gliding (#581). force_mono/invert_stereo are separate
+      // mixer features — deferred.
+      'pre_amp_slide', 'amp_slide', 'hpf_slide', 'lpf_slide',
       'hpf_bypass', 'lpf_bypass', 'limiter_bypass', 'leak_dc_bypass',
     ])
     const applied: string[] = []
@@ -459,18 +466,34 @@ export class SuperSonicBridge {
    * Reset mixer to MIXER config defaults (Tier C PR #3 #255 — reset_mixer! DSL).
    * Mirrors the initialization sequence in connect() so a sweep can be
    * undone in one call.
+   *
+   * Resets the CACHED gain state (currentMasterVolume / currentMixerPreAmp /
+   * currentMixerAmp) as well as the wire, and sends a COMPOSED pre_amp
+   * (mirroring connect() :301 and setMixerPreAmp :426). Without this, the wire
+   * was reset but the cached fields stayed stale, so a later UI pre-amp slider
+   * drag (setMixerPreAmp) or a mixer re-init re-multiplied by the stale
+   * master volume (#582). Slides are reset to 0 so the reset SNAPS rather than
+   * gliding over any slide armed via set_mixer_control! (#581).
    */
   resetMixer(): void {
     if (!this.sonic) return
+    this.currentMasterVolume = 1
+    this.currentMixerPreAmp = MIXER.PRE_AMP
+    this.currentMixerAmp = MIXER.AMP
     this.sonic.send('/n_set', this.mixerNodeId,
-      'amp', MIXER.AMP,
-      'pre_amp', MIXER.PRE_AMP,
+      'amp', this.currentMixerAmp,
+      'pre_amp', this.currentMasterVolume * this.currentMixerPreAmp,
       'hpf', MIXER.HPF,
       'lpf', MIXER.LPF,
       'limiter_bypass', MIXER.LIMITER_BYPASS,
       'hpf_bypass', 0,
       'lpf_bypass', 0,
       'leak_dc_bypass', 0,
+      // Clear any slide armed by set_mixer_control! so the reset is instant.
+      'pre_amp_slide', 0,
+      'amp_slide', 0,
+      'hpf_slide', 0,
+      'lpf_slide', 0,
     )
   }
 

--- a/src/engine/__tests__/SuperSonicBridge.test.ts
+++ b/src/engine/__tests__/SuperSonicBridge.test.ts
@@ -413,7 +413,7 @@ describe('SuperSonicBridge', () => {
     expect(applied).toEqual(['hpf'])
   })
 
-  it('resetMixer /n_sets all five MIXER defaults plus three bypass clears', async () => {
+  it('resetMixer /n_sets all MIXER defaults, bypass clears, and slide clears (#582)', async () => {
     const { mockSonic, sent } = createMockSuperSonic()
     ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
     const bridge = new SuperSonicBridge()
@@ -424,13 +424,54 @@ describe('SuperSonicBridge', () => {
 
     const sets = sent.filter(m => m.address === '/n_set')
     expect(sets.length).toBe(1)
-    // All eight params packed into one /n_set call.
+    // All params packed into one /n_set call: 5 values + 3 bypass clears +
+    // 4 slide clears (#582 — slides reset to 0 so the reset snaps).
     const args = sets[0].args as Array<string | number>
     const paramNames = args.filter((_, i) => i > 0 && i % 2 === 1)
     expect(paramNames).toEqual([
       'amp', 'pre_amp', 'hpf', 'lpf', 'limiter_bypass',
       'hpf_bypass', 'lpf_bypass', 'leak_dc_bypass',
+      'pre_amp_slide', 'amp_slide', 'hpf_slide', 'lpf_slide',
     ])
+  })
+
+  // #581 — set_mixer_control! must accept *_slide glide times, else a sweep
+  // (`set_mixer_control! lpf: 30, lpf_slide: 16`) snaps instead of gliding.
+  it('setMixerControl accepts *_slide params (#581)', async () => {
+    const { mockSonic, sent } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+    sent.length = 0
+
+    const applied = bridge.setMixerControl({ lpf: 30, lpf_slide: 16, pre_amp_slide: 0.5 })
+    expect(applied).toEqual(['lpf', 'lpf_slide', 'pre_amp_slide'])
+    const sets = sent.filter(m => m.address === '/n_set')
+    expect(sets.map(s => s.args[1])).toEqual(['lpf', 'lpf_slide', 'pre_amp_slide'])
+  })
+
+  // #582 — resetMixer must reset the CACHED gain state, not just the wire.
+  // Otherwise a UI pre-amp slider drag (setMixerPreAmp) after set_volume! +
+  // reset_mixer! re-multiplies by the stale currentMasterVolume.
+  it('resetMixer clears stale master volume so a later setMixerPreAmp is not re-attenuated (#582)', async () => {
+    const { mockSonic, sent } = createMockSuperSonic()
+    ;(globalThis as Record<string, unknown>).SuperSonic = vi.fn(() => mockSonic)
+    const bridge = new SuperSonicBridge()
+    await bridge.init()
+
+    const lastPreAmp = (): number => {
+      const calls = sent.filter((c) => c.address === '/n_set' && c.args.includes('pre_amp'))
+      const args = calls[calls.length - 1].args
+      return args[args.indexOf('pre_amp') + 1] as number
+    }
+
+    bridge.setMasterVolume(0.5)          // currentMasterVolume = 0.5
+    bridge.resetMixer()                  // must reset currentMasterVolume → 1
+    expect(lastPreAmp()).toBeCloseTo(MIXER.PRE_AMP, 6) // composed 1 × baseline, not 0.5×
+
+    // The UI pre-amp slider now lands at its raw value, not 0.5× of it.
+    bridge.setMixerPreAmp(0.5)
+    expect(lastPreAmp()).toBeCloseTo(0.5, 6) // 1 × 0.5, NOT stale 0.5 × 0.5 = 0.25
   })
 
   it('getScsynthInfo returns a config dict with sample-rate-derived fields', async () => {


### PR DESCRIPTION
Post-#579 audit of the gain-staging family surfaced three sibling bugs at the same mixer boundary. The #577/#579 fixes themselves audited clean; these are their neighbors.

## #582 — `reset_mixer!` cached-state desync (MED)
`resetMixer` wrote default `pre_amp`/`amp` to the wire but never reset the cached `currentMasterVolume`/`currentMixerPreAmp`/`currentMixerAmp` fields. So after `set_volume! v; reset_mixer!`, a later UI pre-amp slider drag (`setMixerPreAmp`, `App.ts:248`) or a mixer re-init re-multiplied by the **stale** master volume (e.g. slider→0.5 landed at `0.5×0.5=0.25`).
**Fix:** reset the cached fields, send a **composed** `pre_amp = currentMasterVolume × currentMixerPreAmp` (mirroring `connect()`/`setMixerPreAmp`), and clear `*_slide`→0 so the reset snaps.

## #581 — `set_mixer_control!` dropped `*_slide` params (MED)
The allowlist omitted `pre_amp_slide`/`amp_slide`/`hpf_slide`/`lpf_slide`, so `set_mixer_control! lpf: 30, lpf_slide: 16` (desktop's canonical example, `sound.rb:1035`) snapped instead of gliding.
**Fix:** add the four `*_slide` params to the allowlist (`force_mono`/`invert_stereo` deferred).

## #583 — `setVolume` contract drift (LOW, hardening)
The public API still documented "0–1" while its receiver is now 0–5/1=unity (post-#579), with no clamp of its own.
**Fix:** update the doc and clamp `[0,5]` here so a future caller can't silently re-introduce the #579 `/5` mis-map.

## Test plan
**L1:** tsc clean; vitest 1468/1468 (+2 — `setMixerControl accepts *_slide`, `resetMixer clears stale master volume`; updated the `resetMixer` defaults test for the slide clears).

**L3 (observed):**
- **#581** web A/B: `lpf_slide: 6` → high-freq energy (>1.5kHz) **glides** 29%→25%→16%→5.6%→2.4% over ~6s; no-slide **snaps** to 2.5% from t0. Confirms the slide now reaches scsynth.
- **#582**: unit test asserts the wire `pre_amp` (`setMasterVolume(0.5)`→`resetMixer`→`setMixerPreAmp(0.5)` = 0.5, not stale 0.25). The audible path is the host UI slider (not `.rb`-reachable), so the OSC-wire assertion is the right evidence level.

## Bonus — SP160 re-verification
Re-ran the desktop `set_volume!` recording A/B that grounded #579. The earlier "desktop WAV unchanged" reading was a **half-booted-desktop artifact**; a fresh capture shows `set_volume! 0.5` reduces the desktop recording to **0.59×** — desktop and web agree under `set_volume!`, so #579 is parity-correct (catalogue rationale corrected).

Closes #581
Closes #582
Closes #583