### PR TITLE
🎚️ fix(engine): warn on no-bang set_volume; correct 6 community fixtures — closes #586

### DIFF
--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -61,6 +61,27 @@ export function detectSp95Limitations(src: string): Sp95Warning[] {
     })
   }
 
+  // `set_volume` (no bang) is NOT a Sonic Pi function — desktop has only
+  // `set_volume!` (mixer.rb / lang.rb `set_volume!`) and RAISES a NoMethodError
+  // on the bangless form, halting the program (silence). Our transpiler strips
+  // the Ruby bang BEFORE matching (`set_volume!` → `set_volume`, line ~1494),
+  // so by the time the call resolves both forms are indistinguishable and the
+  // engine leniently runs the no-bang form too. This source-level lint runs
+  // BEFORE the strip, so it can fire on the no-bang form ONLY — making the
+  // divergence-from-desktop loud rather than silent (#586, loud-not-silent /
+  // SV50). Negative lookahead `(?![!\w])` excludes the valid `set_volume!`
+  // form and longer identifiers (`set_volume_foo`); the `^[^#\n]*` guard skips
+  // comment lines and inline `# … set_volume` comments.
+  if (/^[^#\n]*\bset_volume(?![!\w])/m.test(src)) {
+    warnings.push({
+      pattern: 'set_volume',
+      title: 'set_volume is not a Sonic Pi function',
+      message:
+        'Did you mean `set_volume!`? Running the no-bang `set_volume` as `set_volume!`. ' +
+        'Desktop Sonic Pi has only `set_volume!` (with bang) and errors on `set_volume`.',
+    })
+  }
+
   // `with_tempo` is deprecated since Sonic Pi v2.0 — desktop RAISES a
   // DeprecationError (core.rb:3641-3642). We keep the user's code running by
   // aliasing it to `with_bpm` (transpiler) and surface this warning so the

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -123,4 +123,20 @@ describe('Sp95Lint — deprecation warnings (loud-not-silent, SV50/SV60 channel)
   it('does NOT warn when with_tempo only appears in a comment', () => {
     expect(detectSp95Limitations('play 60 # with_tempo is the old name')).toEqual([])
   })
+
+  it('warns on no-bang set_volume (NoMethodError on desktop — silent) — #586', () => {
+    const w = detectSp95Limitations('set_volume 0.5\nsample :bd_fat')
+    expect(w).toHaveLength(1)
+    expect(w[0].pattern).toBe('set_volume')
+    expect(w[0].message).toMatch(/set_volume!/)
+  })
+
+  it('does NOT warn on the valid set_volume! (with bang) form — #586', () => {
+    expect(detectSp95Limitations('set_volume! 0.5\nsample :bd_fat')).toEqual([])
+  })
+
+  it('does NOT warn on set_volume in a comment, nor on longer identifiers — #586', () => {
+    expect(detectSp95Limitations('play 60 # set_volume vs set_volume!')).toEqual([])
+    expect(detectSp95Limitations('set_volume_target = 0.5')).toEqual([])
+  })
 })


### PR DESCRIPTION
## Problem

Six `tests/book-examples/community/` fixtures (`16_minimal_mixer`, `17_top_arp_bass`, `20_noise_drums_saw`, `23_bass_distortion`, `27_hydra_jam`, `28_snowflight_inspired`) — plus `e2e_10_missing_coverage` — call `set_volume <n>` **without the bang**. Sonic Pi's only mixer-volume function is `set_volume!`; the no-bang form is not a Sonic Pi method → **desktop raises a NoMethodError and runs silent** (peak 0, ungradeable; showed up as INCONCLUSIVE with absurd `l2_mel_db` in the community dashboard).

Our engine **silently accepted** the invalid form: the transpiler strips the Ruby bang *before* matching (`set_volume!` → `set_volume`, `TreeSitterTranspiler` ~L1494), so both forms resolve to the same internal `set_volume` builder and the divergence-from-desktop was invisible. Grounded SP163.

## Fix

**1. Engine leniency → loud, not silent** (`Sp95Lint.ts`). Added a pure source-level lint that fires on the **no-bang form only**: it runs before the bang-strip, so a negative lookahead `(?![!\w])` distinguishes `set_volume` from the valid `set_volume!` (and from longer identifiers like `set_volume_target`), and the `^[^#\n]*` guard skips comments. It routes through the existing `warningHandler` channel — the same loud-not-silent path as `with_tempo`/`with_density` (SV50). Decision: **keep accepting-with-warning** (don't break running code) rather than reject.

`set_volume` (no bang) stays in `DSL_NAMES` — it is the *internal post-strip name* that `set_volume!` resolves to, not a user-facing alias (existence-checked: `DslBuilderContract` comment + git blame `#187`). Removing it would break the valid bang form.

**2. Fixture data.** The 6 community fixtures + `e2e_10_missing_coverage` were corrected to `set_volume!` on disk. ⚠️ `tests/book-examples/` is **gitignored local corpus** (`.gitignore:67`), with no tracked source/generator (the sweep reads the dir directly), so those edits are **not part of this PR's diff** — but they make the fixtures grade against desktop.

## Test plan

- **L1:** `npx tsc --noEmit` clean; `npx vitest run` 1469/1469 (Sp95Lint +4 cases: no-bang warns; `set_volume!` does not; comment + longer-identifier do not).
- **L2 (observe):** `capture.ts` on a no-bang repro emits the warning under `## Engine Warnings`; the `set_volume!` repro emits `(none)`.
- **L3 (observe):** after the fixture fix all 6 produce desktop audio (peak **0.50–1.0**, was **0**). 5/6 grade event-parity **STRUCTURE-MATCH** / Tier-1 audio-match; `16_minimal_mixer` is **STRUCTURE-DIVERGE** (d27/w9) — a separate PRNG / `density([...].choose)` class divergence, **out of #586 scope** (follow-up candidate). `20_noise_drums_saw` initially failed under back-to-back sweep load (SV31 ghost); re-run individually → desktop peak 0.93, STRUCTURE-MATCH d116/w108.

closes #586