### PR TITLE
🎛️ fix(scheduler): cross-loop get() reads stale heartbeat when a live_loop is named its set key — closes #588

### DIFF
--- a/src/engine/EventHistory.ts
+++ b/src/engine/EventHistory.ts
@@ -60,6 +60,16 @@ export interface CueEvent {
   idPath: number[]
   /** The payload — cue args (an array) or a `set` value. */
   value: unknown
+  /**
+   * Desktop `CueEvent#priority` (`cueevent.rb:29,67-68`), the equal-`t` tiebreak
+   * BEFORE `idPath`. Normal `cue`/`set` writes use 0; a live_loop's auto-cue
+   * heartbeat uses `-100` (`__live_loop_cue`, core.rb:4504) so it always sorts
+   * BELOW a co-`t` `set`/`cue` — guaranteeing `get`/`sync :foo` resolve to the
+   * user's value, not the heartbeat, even when a live_loop is NAMED `:foo` and
+   * a reader samples at a fractional vt (e.g. inside a `density` block). Defaults
+   * to 0 when omitted (a reader's `ge` probe and pre-priority callers). (#588)
+   */
+  priority?: number
 }
 
 /**
@@ -81,25 +91,37 @@ export function compareIdPath(a: number[], b: number[]): -1 | 0 | 1 {
 
 /**
  * Total order over events — a port of the user-thread-relevant fields of
- * `CueEvent#<=>` (`cueevent.rb:64-74`): `t` first, then `idPath`. `priority`
- * (always 0) and `delta` (GAP D) are omitted. Returns -1 | 0 | 1.
+ * `CueEvent#<=>` (`cueevent.rb:64-74`): `t` first, then `priority`, then
+ * `idPath`. `delta` (GAP D) is omitted. Returns -1 | 0 | 1.
+ *
+ * `priority` (#588) sits BETWEEN `t` and `idPath`, exactly as desktop orders
+ * `time_r < priority < thread_id < delta`. It defaults to 0 when absent — both
+ * for a reader's `ge` probe (a normal thread reads at priority 0) and for any
+ * pre-priority caller. Only the live_loop heartbeat sets it (`-100`), so this is
+ * a no-op for every pair of normal `cue`/`set` events and changes ordering ONLY
+ * where a heartbeat shares a `t` with a `set`/`cue` — making the heartbeat sort
+ * below it (the desktop guarantee that `get :foo` ≠ the `live_loop :foo` beat).
  *
  * The `t` compare is EXACT — desktop compares `time_r` (an exact Rational,
  * `cueevent.rb:28`), so genuinely-simultaneous events (e.g. a synced waiter that
  * INHERITED the cuer's vt, or a top-level fork sharing a bit-exact launch origin)
- * compare equal on `t` and fall through to the idPath tiebreak. The old fireCue
- * `+ 1e-9` epsilon was a web-only float-noise guard that broke the exact
+ * compare equal on `t` and fall through to the priority/idPath tiebreaks. The old
+ * fireCue `+ 1e-9` epsilon was a web-only float-noise guard that broke the exact
  * "last ≤ t" boundary (a write at vt 0.5 must NOT be visible to a get at
  * 0.5 − 1e-9); the faithful order is exact. (Float-accumulation drift between
  * two independently-summed cursors is a known edge desktop sidesteps via
  * Rational — out of scope here.)
  */
 export function compareEvent(
-  a: { t: number; idPath: number[] },
-  b: { t: number; idPath: number[] },
+  a: { t: number; idPath: number[]; priority?: number },
+  b: { t: number; idPath: number[]; priority?: number },
 ): -1 | 0 | 1 {
   if (a.t < b.t) return -1
   if (a.t > b.t) return 1
+  const ap = a.priority ?? 0
+  const bp = b.priority ?? 0
+  if (ap < bp) return -1
+  if (ap > bp) return 1
   return compareIdPath(a.idPath, b.idPath)
 }
 
@@ -200,8 +222,8 @@ export class EventHistory {
    * list is trimmed: the desktop age trim ({@link trimHistory}) then the
    * `maxPerKey` hard ceiling — both drop the tail (oldest) of the descending list.
    */
-  insert(key: string | symbol, t: number, idPath: number[], value: unknown): void {
-    const ce: CueEvent = { t, idPath, value }
+  insert(key: string | symbol, t: number, idPath: number[], value: unknown, priority = 0): void {
+    const ce: CueEvent = { t, idPath, value, priority }
     const events = this.store.get(key)
     if (!events) {
       this.store.set(key, [ce])

--- a/src/engine/ProgramBuilder.ts
+++ b/src/engine/ProgramBuilder.ts
@@ -73,6 +73,13 @@ export class ProgramBuilder {
   private _currentBuildSeconds: number = 0
   private _currentBeat: number = 0
   private _schedAheadTime: number = 0
+  // #588: ABSOLUTE iteration-start time (task.virtualTime, NOT #364-rebased).
+  // timeStateClock() uses this directly so set/get stamp the shared store in the
+  // scheduler's ABSOLUTE cue/heartbeat frame WITHOUT a subtract-then-add-origin
+  // round-trip (which introduced float noise that occasionally put a set's t an
+  // epsilon BELOW its co-located heartbeat, losing the priority tiebreak).
+  // Defaults to _iterationStartAudioTime when unset (unwired builders, origin 0).
+  private _iterationStartAbsolute: number = 0
   // SP95(d) #393: scheduler access for build-time sync resolution. When set
   // (the audio build path wires it before builderFn), `sync` awaits the
   // scheduler-resolved cue payload mid-build instead of pushing a runtime
@@ -462,12 +469,17 @@ export class ProgramBuilder {
    *    body still overrides per-step.
    * (#226)
    */
-  setIterationContext(audioTime: number, beat: number, schedAhead: number, bpm?: number): void {
+  setIterationContext(audioTime: number, beat: number, schedAhead: number, bpm?: number, absoluteStartTime?: number): void {
     this._iterationStartAudioTime = audioTime
     this._currentBeat = beat
     this._currentBuildSeconds = 0
     this._schedAheadTime = schedAhead
     if (bpm !== undefined) this._currentBpm = bpm
+    // #588: the UN-rebased iteration start (the scheduler's absolute
+    // task.virtualTime). Used by timeStateClock() so set/get stamp the shared
+    // store in the same ABSOLUTE frame as cue/sync/live_loop heartbeats — passed
+    // directly (not reconstructed from audioTime + origin) to avoid float noise.
+    this._iterationStartAbsolute = absoluteStartTime ?? audioTime
   }
 
   /**
@@ -530,6 +542,22 @@ export class ProgramBuilder {
    */
   current_time(): number {
     return this._iterationStartAudioTime + this._currentBuildSeconds
+  }
+
+  /**
+   * The ABSOLUTE virtual time used to stamp coordination-store writes/reads
+   * (`set`/`get`). #588: `current_time()` is rebased per-Run (#364 — subtract
+   * `_spiderTimeOrigin` for desktop-equivalent user-facing seconds), but the
+   * shared EventHistory ALSO holds `cue`/`sync`/`live_loop`-heartbeat events,
+   * which the scheduler stamps with the ABSOLUTE `task.virtualTime`. A `get :foo`
+   * reads the `/{cue,set,live_loop}/foo` union, so its `set` writes MUST live in
+   * the same frame as those cue/heartbeat entries — otherwise a loop NAMED `:foo`
+   * that also `set :foo`s has its heartbeat (absolute, ~`origin`s ahead) beat the
+   * set in a fractional-vt read. Adding `_spiderTimeOrigin` back undoes the #364
+   * rebase for the STORE only; `current_time()`/`vt()` stay rebased for the user.
+   */
+  private timeStateClock(): number {
+    return this._iterationStartAbsolute + this._currentBuildSeconds
   }
 
   /** Engine's schedule-ahead window in seconds. (#226) */
@@ -1145,14 +1173,14 @@ export class ProgramBuilder {
   set(key: string | symbol, value: unknown): this {
     // GAP A2: tag the write with the owning task's idPath so a same-vt reader
     // resolves it by the (t, idPath) total order (#400).
-    this._timeState?.set(key, value, this.current_time(), this._ownerIdPath)
+    this._timeState?.set(key, value, this.timeStateClock(), this._ownerIdPath)
     // #498: desktop's EventHistory.set runs @event_matchers.match after the
     // insert (event_history.rb:204), so a `set` wakes an already-parked `sync`,
     // not just the set-before-sync case the history-first scan covers. The eager
     // write above already landed `value` in the shared store; notifySet only runs
     // the match. Audio path only (the scheduler is the sole waiter holder); the
     // capture / query builders never wire it, so an S3 sync there can't be woken.
-    this._syncScheduler?.notifySet?.(String(key), this.current_time(), this._ownerIdPath, value)
+    this._syncScheduler?.notifySet?.(String(key), this.timeStateClock(), this._ownerIdPath, value)
     this.steps.push({ tag: 'set', key, value })
     return this
   }
@@ -1177,7 +1205,7 @@ export class ProgramBuilder {
       if (!this._timeState) return null
       // GAP A2: read at the owning task's idPath so the (t, idPath) tiebreak
       // resolves a same-vt cross-loop write by writer-idPath ≤ reader-idPath (#400).
-      return this._timeState.get(key, this.current_time(), this._ownerIdPath) ?? null
+      return this._timeState.get(key, this.timeStateClock(), this._ownerIdPath) ?? null
     }
     return new Proxy(read, {
       apply(_target, _thisArg, args) {

--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -1079,6 +1079,13 @@ export class SonicPiEngine {
             this.loopBeats.get(name) ?? 0,
             this.schedAheadTime,
             task.bpm,
+            // #588: pass the ABSOLUTE (un-rebased) iteration start so the builder
+            // stamps set/get STORE writes (timeStateClock) in the scheduler's
+            // absolute cue/heartbeat frame — even though current_time() stays
+            // per-Run rebased. Passed directly (not origin + audioTime) so a set
+            // co-located with a same-iteration live_loop heartbeat shares its exact
+            // t and the heartbeat's priority -100 loses the tie (get returns the set).
+            task.virtualTime,
           )
           // Enter per-loop scope so variable writes are isolated.
           // Track build-phase nesting depth so any `live_loop` call that
@@ -1139,6 +1146,22 @@ export class SonicPiEngine {
             this.loopDelayed.add(name)
             if (delayBeats > 0) builder.sleep(delayBeats)
           }
+          // Auto-cue the loop name at the START of each iteration (#588).
+          // In Sonic Pi, `live_loop :foo` auto-cues `:foo` each iteration so that
+          // `live_loop :bar, sync: :foo` can synchronize to it (core.rb:2308 —
+          // `__live_loop_cue name` runs BEFORE the body `send(ll_name, res)`).
+          // Firing it HERE — before builderFn, at task.virtualTime = the iteration
+          // start — co-locates the heartbeat's vt with this iteration's eager
+          // `b.set` writes (same task cursor). Combined with its priority -100
+          // (fireCue), a co-`t` `set :foo` always wins `get`/`sync :foo`, so a
+          // loop NAMED `:foo` that also `set :foo`s reads its own value, not the
+          // heartbeat `{args:[],bpm}`. (Was fired AFTER runProgram — at the loop's
+          // run-ahead vt, ~schedAhead seconds past the set's frame — so the
+          // heartbeat could lead the set and win a fractional-vt read, e.g. inside
+          // a `density` block. #588 / SV62 family.)
+          // GAP M1c: heartbeat writes the `/live_loop/foo` root; a `sync :foo`
+          // reads the `/{cue,set,live_loop}/foo` union and still matches.
+          scheduler.fireCue(name, name, [], 'live_loop')
           try {
             // SP95(d) #393: await so an S3 body can suspend on a scheduler-resolved
             // sync mid-build. For today's synchronous S1/S2 bodies this `await` is
@@ -1179,13 +1202,11 @@ export class SonicPiEngine {
             onVolumeChange: setVolumeShared,
             onRecordingEvent: recordingHandler,
           })
-
-          // Auto-cue the loop name after each iteration.
-          // In Sonic Pi, `live_loop :foo` auto-cues `:foo` on each iteration
-          // so that `live_loop :bar, sync: :foo` can synchronize to it.
-          // GAP M1c: heartbeat writes the `/live_loop/foo` root; a `sync :foo`
-          // reads the `/{cue,set,live_loop}/foo` union and still matches.
-          scheduler.fireCue(name, name, [], 'live_loop')
+          // (#588) The live_loop heartbeat is now auto-cued at the START of this
+          // iteration — before builderFn, above — matching desktop's
+          // `__live_loop_cue` order and co-locating its vt with the eager `b.set`
+          // writes. It is NO LONGER fired here (post-runProgram), where the loop's
+          // run-ahead cursor put it ahead of the set's frame.
         }
 
         // SP72: when this registration fires from inside a parent builderFn

--- a/src/engine/VirtualTimeScheduler.ts
+++ b/src/engine/VirtualTimeScheduler.ts
@@ -513,11 +513,17 @@ export class VirtualTimeScheduler {
     // `/{cue,set,live_loop}/foo`, so it matches whichever root the writer used.
     const firedPath = toWritePath(name, op)
 
-    // Record the cue in the (t, idPath)-ordered history so a late or
+    // Record the cue in the (t, priority, idPath)-ordered history so a late or
     // forked-sibling syncer resolves it correctly (replaces the single-entry
     // cueMap). Value carries the cuer's BPM for sync_bpm waiters (#236).
+    // #588: a live_loop heartbeat is registered at priority -100 (desktop
+    // `__live_loop_cue`, core.rb:4504) so it sorts BELOW a co-`t` `set`/`cue`.
+    // Without this, `get :foo` inside a loop NAMED `:foo` (sampling at a
+    // fractional vt, e.g. in a `density` block) can resolve to the heartbeat
+    // `{args:[],bpm}` instead of the user's `set :foo, value`.
     const value = { args, bpm: cueBpm }
-    this.cueHistory.insert(firedPath, cueVirtualTime, cueIdPath, value)
+    const priority = op === 'live_loop' ? -100 : 0
+    this.cueHistory.insert(firedPath, cueVirtualTime, cueIdPath, value, priority)
 
     // Emit cue event for UI (CueLog panel)
     this.emitEvent({

--- a/src/engine/__tests__/EventHistory.test.ts
+++ b/src/engine/__tests__/EventHistory.test.ts
@@ -45,6 +45,35 @@ describe('compareEvent (cueevent.rb:64-74 — t then idPath)', () => {
     expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5, idPath: [0] })).toBe(0)
     expect(compareEvent({ t: 0.5, idPath: [0] }, { t: 0.5 + 1e-12, idPath: [0] })).toBe(-1)
   })
+  it('#588 — orders by priority BETWEEN t and idPath (heartbeat -100 < set 0)', () => {
+    // Same t + same idPath: the live_loop heartbeat (priority -100) sorts BELOW a
+    // set/cue (priority 0), matching desktop cueevent.rb:67-68.
+    expect(compareEvent({ t: 1, idPath: [0], priority: -100 }, { t: 1, idPath: [0], priority: 0 })).toBe(-1)
+    expect(compareEvent({ t: 1, idPath: [0], priority: 0 }, { t: 1, idPath: [0], priority: -100 })).toBe(1)
+    // priority defaults to 0 when omitted (reader ge probe / pre-priority callers).
+    expect(compareEvent({ t: 1, idPath: [0] }, { t: 1, idPath: [0], priority: -100 })).toBe(1)
+    // t still dominates priority (a later heartbeat outranks an earlier set).
+    expect(compareEvent({ t: 2, idPath: [0], priority: -100 }, { t: 1, idPath: [0], priority: 0 })).toBe(1)
+  })
+})
+
+describe('EventHistory #588 — a co-t live_loop heartbeat must NOT win get over a set', () => {
+  it('getMostRecent returns the set value, not the lower-priority heartbeat, at equal t', () => {
+    const h = new EventHistory()
+    // A loop NAMED :mixer that also `set :mixer` — heartbeat and set land on the
+    // union read at the SAME t, same writer idPath. The set (priority 0) must win.
+    h.insert('/live_loop/mixer', 1, [0, 0], { args: [], bpm: 45 }, -100)
+    h.insert('/set/mixer', 1, [0, 0], [0, 2, 1], 0)
+    // The union read `get :mixer` scans /{cue,set,live_loop}/mixer.
+    const hit = h.getMostRecent('/{cue,set,live_loop}/mixer', 5, [0, 0])
+    expect(hit!.value).toEqual([0, 2, 1])
+  })
+  it('the heartbeat still wins when it is the ONLY event (sync :loop heartbeat intact)', () => {
+    const h = new EventHistory()
+    h.insert('/live_loop/mixer', 1, [0, 0], { args: [], bpm: 45 }, -100)
+    const hit = h.getMostRecent('/{cue,set,live_loop}/mixer', 5, [0, 0])
+    expect(hit!.value).toEqual({ args: [], bpm: 45 })
+  })
 })
 
 describe('EventHistory.insert — descending (t, idPath) order', () => {

--- a/src/engine/__tests__/SonicPiEngineTimeState.test.ts
+++ b/src/engine/__tests__/SonicPiEngineTimeState.test.ts
@@ -93,6 +93,38 @@ describe('Time State — engine-level cross-loop set/get (SV47 / #350)', () => {
     engine.dispose()
   })
 
+  it('#588 — a loop NAMED its own set key reads its set value, NOT the auto-cue heartbeat', async () => {
+    // A live_loop :mixer auto-cues `:mixer` each iteration (the heartbeat that
+    // `sync :mixer` waits on). It ALSO `set :mixer`s. Both land on the
+    // /{cue,set,live_loop}/mixer read union; the heartbeat's priority -100 must
+    // lose to the set so a cross-loop `get(:mixer)` reads the array. Before the
+    // fix the heartbeat (fired post-iteration, later vt + no priority) won, so
+    // `get(:mixer)[0]` was undefined and the gated play never fired.
+    const engine = new SonicPiEngine()
+    await engine.init()
+    const events: SoundEvent[] = []
+    engine.components.streaming!.eventStream.on((e) => events.push(e))
+    await engine.evaluate(`
+      use_bpm 120
+      set :mixer, [1]
+      live_loop :mixer do
+        set :mixer, [1]
+        sleep 1
+      end
+      live_loop :reader do
+        play 72 if get(:mixer)[0] == 1
+        sleep 1
+      end
+    `)
+    engine.play()
+    await drive(engine, 5, 5)
+    const played = midiNotes(events, 'reader')
+    // get(:mixer) resolves to [1] (not the heartbeat {args,bpm}) → the gate fires.
+    expect(played.length).toBeGreaterThanOrEqual(2)
+    expect(played.every((n) => n === 72)).toBe(true)
+    engine.dispose()
+  })
+
   it('(e) reversed: player declared BEFORE director — reads desktop {52,57} (GAP A2 / #400)', async () => {
     // DESKTOP-PARITY gate (was a documented divergence; SV47 Slice 3 / #400).
     // Source order now matters via the (t, idPath) total order: player declared


### PR DESCRIPTION
## Problem

A `live_loop :foo` auto-cues `:foo` every iteration (the heartbeat `sync :foo` waits on). When the loop also `set :foo`s and another loop reads `get(:foo)`, the **heartbeat could win** the `/{cue,set,live_loop}/foo` union read — so `get(:foo)` returned `{args:[],bpm}` instead of the user's array, and array-index gates (`if get(:foo)[i] == 1`) silently failed.

In **`16_minimal_mixer`** this dropped the `bd_fat` kick + saw bass layers: event-parity **STRUCTURE-DIVERGE d27/w9** (web fired only `beep`). Found in the #586 post-fix L3 sweep.

## Root cause — two grounded desktop-parity gaps

1. **Missing `priority`.** Desktop `CueEvent#<=>` orders `(time, priority, thread_id, delta)` (`cueevent.rb:64-74`); `__live_loop_cue` registers the heartbeat at **priority -100** (`core.rb:4504`) so it always sorts *below* a co-`t` `set`/`cue`. Our `compareEvent` was `(t, idPath)` only.
2. **Frame mismatch.** `set`/`get` stamped the shared store at `current_time()` — the **per-Run rebased** frame (#364, `task.virtualTime − spiderTimeOrigin`) — while `cue`/`sync`/heartbeat use the **absolute** `task.virtualTime`. The two frames (~`origin`≈1.6s apart) coexisted in the **one** union store, so a rebased `get` read the absolute heartbeat (~1.6s ahead) once the reader vt passed `origin`.

## Fix

- `EventHistory`: add `priority` to `CueEvent`; `compareEvent` compares it **after `t`, before `idPath`** (faithful to desktop). `fireCue` passes `-100` for `op:'live_loop'`, `0` otherwise.
- `ProgramBuilder`: `set`/`get`/`notifySet` stamp the store at the **absolute** iteration start (`timeStateClock = _iterationStartAbsolute + buildSeconds`, passed directly to avoid a subtract-then-add-origin float round-trip). `current_time()`/`vt()` stay rebased for the user (#364 intact).
- `SonicPiEngine`: the heartbeat is auto-cued at the iteration **START** (before `builderFn` — matching `core.rb:2308`) so its vt co-locates with the iteration's eager `set` writes, and priority -100 resolves the tie in the set's favour.

## Test plan

- **L1:** `tsc` clean; `vitest` **1470/1470** (+4: priority tiebreak in `compareEvent` + `getMostRecent`; engine — a loop named its own set key reads the set, not the heartbeat). All sync/cue/director-player/GapM tests unchanged.
- **L3 (browser, origin≠0):**
  - flip repro: `get(:mixer)` → `[0,1,0]`×30 then `[0,2,1]`×20, **zero** cue-object reads (was flipping to `{args,bpm}`).
  - `director`/`player` sync-then-get → `55,59` — desktop **#350 parity preserved** (the absolute-frame store didn't break sync-then-get).
  - `16_minimal_mixer`: **STRUCTURE-DIVERGE d27/w9 → STRUCTURE-MATCH d27/w26** (`basic_mono_player` 0→11 — kick layer recovered).

closes #588