### PR TITLE
🎛️ fix(transpiler): var-dependent use_synth before a loop reaches the loop via a per-loop synth thunk (#591)

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -226,6 +226,14 @@ export class SonicPiEngine {
    */
   private startGated = new Set<string>()
   /**
+   * #591: loops that have already called their first-iteration `__synthThunk`.
+   * Creation-only, like startGated — the thunk picks up the var-dependent synth
+   * __run_once drew after the loop registered; once task.currentSynth holds it,
+   * every later iteration re-seeds from it. Cleared on teardown / per-loop on
+   * removal, alongside startGated.
+   */
+  private stateSnapshotted = new Set<string>()
+  /**
    * Build-phase nesting depth (issue #198). Incremented around each
    * synchronous builderFn invocation. > 0 means we are currently
    * building one live_loop's iteration step array; any `live_loop`
@@ -873,6 +881,13 @@ export class SonicPiEngine {
         // (`live_loop`/`in_thread`/`at`) → idPath `[0, n]`. Explicit marker, not
         // name-sniffing (mirrors `__startGate`; PARITY-GAPS GAP A §2 decision).
         let isInline = false
+        // #591: lazy synth source for a var-dependent / mid-PRNG `use_synth` (e.g.
+        // `choose(synths)`) this loop source-follows. The transpiler draws the synth
+        // ONCE into a `__sy_N` var in __run_once (after this loop registered, so the
+        // eager task.currentSynth is the stale default) and passes a thunk reading
+        // it. Called ONCE at the first iteration build — by then __run_once has run
+        // (SV70/SV21: same ordering that makes `play c` see __run_once's `c`).
+        let synthThunk: (() => string) | null = null
         // SP131/#481: a one-shot top-level in_thread (set by topLevelInThread).
         // Such a thread builds its ENTIRE body in ONE pass, so the build-time
         // `sync` await (which suspends the build until the cue) would batch every
@@ -895,6 +910,8 @@ export class SonicPiEngine {
           delayBeats = typeof builderFnOrOpts.delay === 'number' ? builderFnOrOpts.delay : 0
           startGate = (builderFnOrOpts.__startGate as string) ?? null
           isInline = builderFnOrOpts.__inline === true
+          synthThunk = typeof builderFnOrOpts.__synthThunk === 'function'
+            ? (builderFnOrOpts.__synthThunk as () => string) : null
           oneShotThread = builderFnOrOpts.__oneShotThread === true
           builderFn = maybeFn!
         }
@@ -1020,6 +1037,21 @@ export class SonicPiEngine {
 
           const task = scheduler.getTask(name)
           if (!task) return
+
+          // #591: a var-dependent / mid-PRNG `use_synth` (e.g. `choose(synths)`)
+          // is drawn in __run_once at its source position — AFTER this loop
+          // registered, so the eager `task.currentSynth` snapshot is the stale
+          // default (beep). The thunk reads the `__sy_N` var __run_once drew; by
+          // the first iteration build __run_once has run (SV70/SV21 — the same
+          // ordering that makes `play c` see __run_once's `c`). Call it ONCE and
+          // seed the task; the per-iteration build below
+          // (`builder.use_synth(task.currentSynth)`) then applies it every cycle.
+          // A falsy result (var still unset) leaves the prior default — safe.
+          if (synthThunk && !this.stateSnapshotted.has(name)) {
+            this.stateSnapshotted.add(name)
+            const drawn = synthThunk()
+            if (drawn) task.currentSynth = drawn
+          }
 
           // Persistent top-level FX: create FX nodes on first iteration only.
           // Loops under the same with_fx scope share one FX chain (keyed by scope ID).
@@ -2196,6 +2228,7 @@ export class SonicPiEngine {
           this.loopSynced.delete(name)
           this.loopDelayed.delete(name)
           this.startGated.delete(name)
+          this.stateSnapshotted.delete(name) // #591
         }
 
         // Pause ticking so no old events fire during transition
@@ -2470,6 +2503,7 @@ export class SonicPiEngine {
     this.loopSynced.clear()
     this.loopDelayed.clear()
     this.startGated.clear()
+    this.stateSnapshotted.clear() // #591
     // Time State (set/get) intentionally NOT cleared on Stop. Desktop Sonic
     // Pi creates @event_history once per session (runtime.rb:1450) and never
     // clears it on Stop — `get` is documented "deterministic across Runs".

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -266,6 +266,16 @@ interface TranspileContext {
    * propagate into a block's body (a nested in_thread must not inherit it).
    */
   startGate?: string
+  /**
+   * #591: name of the `__sy_N` draw var for a var-dependent / mid-PRNG `use_synth`
+   * (e.g. `choose(synths)`) that this loop source-follows. The var is drawn ONCE in
+   * `__run_once` at its source position (the value is unknown at the loop's eager
+   * registration); the loop carries a `__synthThunk: () => __sy_N` in its opts that
+   * the engine calls at its FIRST iteration build to seed the loop's synth. A thunk
+   * (not the engine defaultSynth) so two dynamic synths before two loops stay
+   * per-loop correct. Set per-block; never propagates into the body.
+   */
+  synthThunkVar?: string
   /** Hoisted-loop counter for `loop do` inside `with_fx` (issue #426/SP111). */
   fxLoopCounter?: { n: number }
   /**
@@ -1262,9 +1272,24 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
   // (`use_synth choose(...)` → draw once into `__sy_N` in topJS, then
   // `use_synth(__sy_N)`). The var form is what extends the #419/#421 eager-prefix
   // family to dynamic synth args without dropping them (→ stale `:beep`).
-  type TopSynth = { lit: string } | { var: string } | null
+  // #591: a third variant — {dynamicVar} — for a NON-self-contained arg
+  // (var-dependent like `choose(synths)`, or mid-PRNG-sequence) that CANNOT be
+  // hoisted to topJS (its value lives in deferred bareCode, drawn at a precise
+  // seeded position). It is drawn ONCE in __run_once at its source position into a
+  // `__sy_N` var; a following loop reads that var lazily via a per-loop
+  // `__synthThunk` (no eager prefix — the var is undefined at eager-registration
+  // time). This replaces the old `:beep` drop for such args.
+  type TopSynth = { lit: string } | { var: string } | { dynamicVar: string } | null
   let currentTopSynth: TopSynth = null
   const blockSynth = new Map<any, TopSynth>()
+  // #591: maps a var-dependent use_synth CALL node → its generated draw var + arg
+  // node. Rendered in bareCode (__run_once) at source position as a single draw
+  // into the var + a builder-local use_synth (bare-play interleave). The following
+  // loop reads the var via its `__synthThunk` opt at first build.
+  const synthDynamicByNode = new Map<any, { varName: string; argNode: any }>()
+  // #591: loop blocks that source-follow a {dynamicVar} use_synth — they carry a
+  // per-loop `__synthThunk: () => __sy_N` reading the var __run_once drew.
+  const blockStateSnapshot = new Set<any>()
   // #585: non-literal `use_synth` hoists. Each maps the use_synth CALL node to a
   // generated var + its arg node. The var is assigned ONCE in topJS (eager draw,
   // before any loop registers); a loop tagged with {var} emits `use_synth(var)`;
@@ -1316,10 +1341,19 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
           const varName = `__sy_${nonLiteralSynthCounter++}`
           synthHoistByNode.set(child, { varName, argNode })
           currentTopSynth = { var: varName }
+        } else if (argNode) {
+          // #591: var-dependent (`choose(synths)`) or mid-PRNG-sequence arg —
+          // cannot hoist to topJS (the var lives in deferred bareCode; an eager
+          // draw would read undefined or reorder the seeded stream). Draw it in
+          // __run_once at source position into a var; a following loop reads it via
+          // a per-loop `__synthThunk` at first build. Was a silent `:beep` drop
+          // before. The var is only emitted if a following loop actually consumes
+          // it (else the use_synth renders normally).
+          const varName = `__sy_${nonLiteralSynthCounter++}`
+          synthDynamicByNode.set(child, { varName, argNode })
+          currentTopSynth = { dynamicVar: varName }
         } else {
-          // var-dependent / mid-PRNG-sequence arg, or bare `use_synth` — cannot
-          // hoist safely; leave it deferred in bareCode (no eager prefix; the
-          // loop keeps the prior default — unchanged from before #585).
+          // Bare `use_synth` with no arg — nothing to propagate.
           currentTopSynth = null
         }
       }
@@ -1380,6 +1414,21 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
         blockGate.set(child, gate)
         bareCode.push({ __sgMarker: gate })
       }
+      // #591: a top-level `live_loop` / bare `loop` that source-follows a
+      // {dynamicVar} use_synth reads the `__sy_N` var (drawn in __run_once AFTER
+      // this loop registered) via a per-loop `__synthThunk` at its first iteration.
+      // This needs NO cue: __run_once's build runs before the loop's first build at
+      // the same vt (the SV70/SV21 invariant — the loop's body already reads bare
+      // top-level vars __run_once set, e.g. `play c`), so __sy_N is set by then. A
+      // cue CAN'T signal this anyway — __run_once and an __inline loop share idPath
+      // [0], and an equal-(t,idPath) cue does not deliver (cueDelivers strict).
+      // Scoped to live_loop / bare loop (the synth-bearing shapes); in_thread /
+      // with_fx stay on the existing eager path (40_choose_generator's in_thread
+      // plays only samples — no synth dependence — so no regression).
+      const followsDynamicSynth = currentTopSynth !== null && 'dynamicVar' in currentTopSynth
+      if (followsDynamicSynth && (method === 'live_loop' || isBareLoopNode)) {
+        blockStateSnapshot.add(child)
+      }
     } else {
       bareCode.push(child)
       // #448/SP118: arm the gate once a vtime-ADVANCING bare statement appears.
@@ -1431,6 +1480,15 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     topJS.push(`${varName} = ${transpileNode(argNode, ctx)}`)
     synthReuseInBare.set(node, varName)
   }
+  // #591: a {dynamicVar} use_synth is consumed iff a thunk-carrying loop follows
+  // it. Only then do we rewrite its bareCode emission to draw into the var (the
+  // following loop reads it via its `__synthThunk`). An unconsumed dynamic
+  // use_synth (no following loop) renders normally — draws at its source position,
+  // same as before, no propagation needed.
+  const consumedDynamicVars = new Set<string>()
+  for (const [block, tag] of blockSynth) {
+    if (tag && 'dynamicVar' in tag && blockStateSnapshot.has(block)) consumedDynamicVars.add(tag.dynamicVar)
+  }
 
   // Transpile bare code inside an implicit in_thread (runs once, not forever)
   // Desktop SP runs bare code once — thread terminates at end.
@@ -1449,6 +1507,17 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
       // stays correct WITHOUT a second PRNG draw.
       const reuseVar = synthReuseInBare.get(c)
       if (reuseVar) return `  __b.use_synth(${reuseVar})`
+      // #591: a {dynamicVar} use_synth consumed by a following loop — draw the arg
+      // ONCE into the var at this source position (correct seeded position, no
+      // extra draw) and set the builder-local synth (bare-play interleave). The
+      // loop reads this var lazily via its `__synthThunk: () => __sy_N` opt at its
+      // first build — per-loop, so two dynamic synths stay independent (no global
+      // defaultSynth write).
+      const dyn = synthDynamicByNode.get(c)
+      if (dyn && consumedDynamicVars.has(dyn.varName)) {
+        return `  ${dyn.varName} = ${transpileNode(dyn.argNode, bareCtx)}\n` +
+               `  __b.use_synth(${dyn.varName})`
+      }
       return '  ' + transpileNode(c, bareCtx)
     })
     .filter(s => s.trim())
@@ -1488,7 +1557,10 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     const isLoopRegister = m === 'live_loop' || m === 'loop' || m === 'in_thread' || m === 'with_fx'
     const tagged = blockSynth.get(c) ?? null
     let eagerPrefix = ''
-    if (tagged && isLoopRegister) {
+    // #591: {dynamicVar} gets NO eager prefix — its var is drawn in __run_once at
+    // source position (undefined at this eager-registration point); the loop picks
+    // it up via its per-loop `__synthThunk` instead (blockStateSnapshot).
+    if (tagged && isLoopRegister && !('dynamicVar' in tagged)) {
       // {lit} → use_synth("name"); {var} → use_synth(__sy_N) (#585, the var was
       // drawn once in topJS). Dedup by the emitted arg text (defaultSynth persists
       // across registrations, so a run of loops on the same synth emits once).
@@ -1526,10 +1598,15 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
         const gate = blockGate.get(c)
         // GAP A: a hoisted bare `loop do` runs INLINE in the main thread (desktop
         // never forks it) → `__inline: true` ⇒ idPath `[0]`. Merge with the
-        // optional start-gate cue.
-        const optsArg = gate
-          ? `{__startGate: ${JSON.stringify(gate)}, __inline: true}, `
-          : `{__inline: true}, `
+        // optional start-gate cue. #591: `__synthThunk` lazily reads the var a
+        // {dynamicVar} use_synth drew in __run_once (after this loop registered).
+        const dynTag = blockSynth.get(c)
+        const optsBits = ['__inline: true']
+        if (gate) optsBits.unshift(`__startGate: ${JSON.stringify(gate)}`)
+        if (blockStateSnapshot.has(c) && dynTag && 'dynamicVar' in dynTag) {
+          optsBits.push(`__synthThunk: () => ${dynTag.dynamicVar}`)
+        }
+        const optsArg = `{${optsBits.join(', ')}}, `
         return `${eagerPrefix}live_loop("${name}", ${optsArg}async (__b) => {\n${bodyStr}\n${ctx.indent}})`
       }
     }
@@ -1537,7 +1614,12 @@ function transpileProgram(node: any, ctx: TranspileContext): string {
     // ctx so transpileInThread emits `__startGate` in its registration opts. The
     // gate is consumed by THIS construct only — transpileInThread must not leak
     // it into the body (a nested in_thread must not inherit it).
-    const blockCtx: TranspileContext = blockGate.has(c) ? { ...ctx, startGate: blockGate.get(c) } : ctx
+    const dynTagBlk = blockSynth.get(c)
+    const thunkVar = (blockStateSnapshot.has(c) && dynTagBlk && 'dynamicVar' in dynTagBlk)
+      ? dynTagBlk.dynamicVar : undefined
+    const blockCtx: TranspileContext = (blockGate.has(c) || thunkVar)
+      ? { ...ctx, startGate: blockGate.get(c), synthThunkVar: thunkVar }
+      : ctx
     return eagerPrefix + transpileNode(c, blockCtx)
   }).filter(Boolean)
 
@@ -2254,6 +2336,10 @@ function transpileLiveLoop(
   if (syncName) optsParts.push(`sync: "${syncName}"`)
   optsParts.push(...extraOpts)
   if (startGateName !== null) optsParts.push(`__startGate: ${JSON.stringify(startGateName)}`)
+  // #591: lazily read the var a {dynamicVar} use_synth drew in __run_once (its
+  // value is unknown at this loop's eager registration). The engine calls the
+  // thunk at the first iteration build to seed the loop's synth.
+  if (ctx.synthThunkVar) optsParts.push(`__synthThunk: () => ${ctx.synthThunkVar}`)
   const optsArg = optsParts.length > 0 ? `{${optsParts.join(', ')}}, ` : ''
 
   return `live_loop("${name}", ${optsArg}async (__b) => {\n${bodyStr}\n${ctx.indent}})`

--- a/src/engine/__tests__/RealWorldTreeSitter.test.ts
+++ b/src/engine/__tests__/RealWorldTreeSitter.test.ts
@@ -213,13 +213,44 @@ end`
       expect((r.code.match(/choose\(/g) ?? []).length).toBe(1)
     })
 
-    it('var-dependent choose(synths) is NOT hoisted (no undefined-var read, stays deferred)', () => {
+    it('#591 var-dependent choose(synths): drawn once in __run_once, loop reads it via __synthThunk', () => {
       const r = autoTranspileDetailed('synths = [:tri, :saw]\nuse_synth choose(synths)\nloop do\n  play 60\n  sleep 0.5\nend')
       expect(r.hasError).toBe(false)
-      // no eager hoist var — the free var `synths` lives in deferred bareCode
-      expect(r.code).not.toMatch(/__sy_\d+ = /)
-      // the use_synth stays inline in bareCode with its original expression
-      expect(r.code).toMatch(/__b\.use_synth\(__b\.choose\(synths\)\)/)
+      // NOT hoisted to topJS (the free var `synths` lives in deferred bareCode) —
+      // instead drawn at source position INSIDE __run_once into a var
+      expect(r.code).toMatch(/__sy_0 = __b\.choose\(synths\)/)
+      // builder-local set for bare-play interleave (no global defaultSynth write)
+      expect(r.code).toMatch(/__b\.use_synth\(__sy_0\)/)
+      // ONE draw only — no second choose() of synths
+      expect((r.code.match(/__b\.choose\(synths\)/g) ?? []).length).toBe(1)
+      // the loop carries a per-loop thunk reading __sy_0 lazily at first build
+      expect(r.code).toMatch(/__synthThunk: \(\) => __sy_0/)
+    })
+
+    it('#591 mid-PRNG sequence (40_choose_generator shape): synth drawn at its seeded position, no extra draw', () => {
+      // use_random_seed/use_bpm(rrand) hoist to topJS (draw #1 = rrand); the
+      // var-dependent use_synth draws at its source position INSIDE __run_once
+      // (draw #2), preserving the seeded stream; the bare loop reads it via thunk.
+      const r = autoTranspileDetailed(
+        'use_random_seed 0\nuse_bpm rrand(90, 130)\nsynths = [:piano, :saw, :tri]\nuse_synth choose(synths)\nc = choose([:c4, :e4])\nloop do\n  play c\n  sleep 0.5\nend')
+      expect(r.hasError).toBe(false)
+      // synth drawn once in __run_once; the bare loop reads it via __synthThunk
+      expect(r.code).toMatch(/__sy_0 = __b\.choose\(synths\)/)
+      expect(r.code).toMatch(/__synthThunk: \(\) => __sy_0/)
+      // exactly ONE choose(synths) — no eager re-draw that would desync the stream
+      expect((r.code.match(/__b\.choose\(synths\)/g) ?? []).length).toBe(1)
+      // the seed/bpm stay hoisted (topJS) — unchanged
+      expect(r.code).toMatch(/use_random_seed\(0\)/)
+      expect(r.code).toMatch(/use_bpm\(rrand\(90, 130\)\)/)
+    })
+
+    it('#591 var-dependent use_synth before a live_loop also gets a per-loop __synthThunk', () => {
+      // trailing bare `sleep` forces the __run_once wrapper, so the use_synth is
+      // deferred (without it, use_synth runs eagerly at top level — no #591 path).
+      const r = autoTranspileDetailed('opts = [:tri, :saw]\nuse_synth choose(opts)\nlive_loop :m do\n  play 60\n  sleep 0.5\nend\nsleep 0.1')
+      expect(r.hasError).toBe(false)
+      expect(r.code).toMatch(/__sy_0 = __b\.choose\(opts\)/)
+      expect(r.code).toMatch(/live_loop\("m".*__synthThunk: \(\) => __sy_0/)
     })
 
     it('literal use_synth :tri still emits the eager string prefix (unchanged)', () => {


### PR DESCRIPTION
Closes #591. Follow-up to #585 (PR #590) — **stacked on `fix/585-nonliteral-use-synth-prefix`**; merge #590 first (GitHub will retarget this to `main`).

## Problem
A **var-dependent / mid-PRNG** `use_synth` (e.g. `use_synth choose(synths)`) before a top-level loop was **dropped** — the loop registered with the stale default (`:beep`). #585 fixed only **self-contained** non-literal args (hoistable to a single `topJS` draw). A free-var or mid-PRNG arg can't hoist: its value lives in the deferred `__run_once` bareCode, drawn at a precise seeded position, so it was left deferred and the loop never saw the chosen synth.

`40_choose_generator` played `:beep` where desktop plays `:tri`.

## Fix
- **Transpiler**: draw the arg **once** in `__run_once` at its source position into a `__sy_N` var (same single PRNG draw — correct seeded position, **no extra draw**) + a builder-local `use_synth` for bare-play interleave. The following top-level `live_loop` / bare `loop` carries a **per-loop** `__synthThunk: () => __sy_N` in its registration opts.
- **Engine**: call the thunk **once** at the first iteration build to seed `task.currentSynth`; the per-iteration build applies it thereafter.

A thunk (not a global `defaultSynth` write) keeps two dynamic synths before two loops **per-loop correct**. **No cue** is needed — `__run_once`'s build runs before the loop's first build at the same vt (SV70/SV21: the same ordering that makes the loop body read bare top-level vars like `play c`); a cue couldn't signal it anyway (an `__inline` loop shares idPath `[0]` with `__run_once`, and an equal-`(t,idPath)` cue does not deliver). `in_thread`/`with_fx` stay on the existing path.

## Test plan
- **L1**: `tsc` clean; `vitest` **1471** pass (+2 new #591 transpiler tests, 1 #585 test updated for the new behavior).
- **L3** (observe `/s_new`): `40_choose_generator` event-parity **STRUCTURE-DIVERGE → STRUCTURE-MATCH** — the loop dispatches `sonic-pi-tri` (desktop 37 / web 32), `beep` gone, `basic_mono_player` matches. Regression: #585 self-contained still `saw`; literal `use_synth :prophet` still `prophet`.

## Known limitation (pre-existing, not this PR)
The inline bare loop snapshots the top-level RNG **at registration** (before `__run_once`'s bare draws), so its `choose(times)`/note sequence still diverges from desktop's continuous main-thread stream (tri onset/note DIVERGE under the STRUCTURE-MATCH verdict). My changes are build-time + RNG-free and don't touch the loop's RNG snapshot — this divergence predates #591 (it was invisible while the loop played `beep`). Filing as a separate follow-up.