### PR TITLE
🎚️ fix(engine): warn on no-bang set_mixer_control / reset_mixer — closes #594

### DIFF
--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -37,6 +37,24 @@ export interface Sp95Warning {
 }
 
 /**
+ * DSL functions that exist on desktop Sonic Pi ONLY in their bang form. A
+ * bangless call raises a NoMethodError on desktop — the thread dies and every
+ * line after it is silent. Our transpiler strips the Ruby bang BEFORE the call
+ * resolves (`set_mixer_control!` → `set_mixer_control`, ~line 1492) and
+ * `DslNames.ts` lists the no-bang internal names, so the engine leniently runs
+ * the bangless form too — working web audio, silent death on desktop. This
+ * allowlist drives a source-level lint (run PRE-transpile, so it can still see
+ * the bang) that makes the divergence loud instead of silent (#586/#594,
+ * loud-not-silent / SV50).
+ *
+ * `set_volume` is the third member of this class (#586) but its detector lives
+ * in PR #587; fold it into this list (and drop #587's inline block) once that
+ * lands. Grounded: `sound.rb:1007` `reset_mixer!()`, `sound.rb:1027`
+ * `set_mixer_control!(opts)`, `sound.rb:2076` `set_volume!`.
+ */
+const BANG_ONLY_DSL: ReadonlyArray<string> = ['set_mixer_control', 'reset_mixer']
+
+/**
  * Run all build-time DSL lints over the given Ruby source. The SP95 detectors
  * are retired (see module header); this is the retained integration point for
  * non-fatal build-time warnings (the channel a future lint slots into). Pure.
@@ -74,6 +92,24 @@ export function detectSp95Limitations(src: string): Sp95Warning[] {
         '`with_tempo` is deprecated since Sonic Pi v2.0 — use `use_bpm` or `with_bpm`. ' +
         'Running it as `with_bpm`. Desktop Sonic Pi raises an error on `with_tempo`.',
     })
+  }
+
+  // Bang-only DSL functions (#594) — see BANG_ONLY_DSL. Each fires on the
+  // no-bang form ONLY: the negative lookahead `(?![!\w])` excludes the valid
+  // bang form (`set_mixer_control!`) and longer identifiers; the `^[^#\n]*`
+  // guard matches a call position only (skips comment lines and inline
+  // `# … reset_mixer` comments). Keep-accept-with-warning (SV50).
+  for (const name of BANG_ONLY_DSL) {
+    const re = new RegExp(`^[^#\\n]*\\b${name}(?![!\\w])`, 'm')
+    if (re.test(src)) {
+      warnings.push({
+        pattern: name,
+        title: `${name} is not a Sonic Pi function`,
+        message:
+          `Did you mean \`${name}!\`? Running the no-bang \`${name}\` as \`${name}!\`. ` +
+          `Desktop Sonic Pi has only \`${name}!\` (with bang) and errors on \`${name}\`.`,
+      })
+    }
   }
 
   return warnings

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -124,3 +124,29 @@ describe('Sp95Lint — deprecation warnings (loud-not-silent, SV50/SV60 channel)
     expect(detectSp95Limitations('play 60 # with_tempo is the old name')).toEqual([])
   })
 })
+
+describe('Sp95Lint — bang-only DSL functions (loud-not-silent, SV50) — #594', () => {
+  it('warns on no-bang set_mixer_control (NoMethodError on desktop — silent)', () => {
+    const w = detectSp95Limitations('set_mixer_control lpf: 30\nsleep 1')
+    expect(w).toHaveLength(1)
+    expect(w[0].pattern).toBe('set_mixer_control')
+    expect(w[0].message).toMatch(/set_mixer_control!/)
+  })
+
+  it('warns on no-bang reset_mixer (NoMethodError on desktop — silent)', () => {
+    const w = detectSp95Limitations('reset_mixer\nplay 60')
+    expect(w).toHaveLength(1)
+    expect(w[0].pattern).toBe('reset_mixer')
+    expect(w[0].message).toMatch(/reset_mixer!/)
+  })
+
+  it('does NOT warn on the valid bang forms', () => {
+    expect(detectSp95Limitations('set_mixer_control! lpf: 30')).toEqual([])
+    expect(detectSp95Limitations('reset_mixer!')).toEqual([])
+  })
+
+  it('does NOT warn on comments nor longer identifiers', () => {
+    expect(detectSp95Limitations('play 60 # set_mixer_control vs reset_mixer')).toEqual([])
+    expect(detectSp95Limitations('reset_mixers = 1\nset_mixer_controls = 2')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem
`set_mixer_control!` and `reset_mixer!` are **bang-only** in desktop Sonic Pi (`sound.rb:1027` `set_mixer_control!(opts)`, `sound.rb:1007` `reset_mixer!()` — doc names `:set_mixer_control!`/`:reset_mixer!`). A bangless `set_mixer_control lpf: 30` / `reset_mixer` raises a NoMethodError on desktop → the thread dies → silence.

Our engine accepts **both** forms: the transpiler strips the Ruby bang (`TreeSitterTranspiler.ts:1492`) and `DslNames.ts:156` lists the no-bang internal names, so a bangless call resolves to the same builder step. The user gets working web audio but silent death on desktop — a hidden cross-platform divergence, the same class as #586 (no-bang `set_volume`). Latent: no corpus fixture currently triggers it, but the divergence is real.

## Fix
Generalize the #586 no-bang detector into a list-driven `BANG_ONLY_DSL` allowlist in `Sp95Lint.detectSp95Limitations` covering `set_mixer_control` and `reset_mixer`. The source-level regex `^[^#\n]*\bNAME(?![!\w])` fires on the **no-bang form only** — it runs PRE-transpile so it still sees the bang; the negative lookahead excludes the valid bang form and longer identifiers (`reset_mixers`); `^[^#\n]*` skips comment lines. Keep-accept-with-warning (SV50, loud-not-silent), routed through the existing `warningHandler` channel (no wiring change).

`set_volume` is the third member of this class (#586); fold it into this list and drop #587's inline block once #587 lands.

## Test plan
- **L1:** `tsc --noEmit` clean; `vitest` 1470 passed (+4 Sp95Lint cases — no-bang fires, bang clean, comments/longer-idents ignored).
- **L2:** direct detector observation — no-bang `set_mixer_control`/`reset_mixer` emit both warnings with correct guidance text; valid bang forms emit `[]`. Call site `SonicPiEngine.ts:513` runs the detector PRE-transpile through `warningHandler` (same proven path as `with_density`/`with_tempo`).

Build-time lint only — no audio output changes (L3 N/A).

closes #594