### PR TITLE
🎲 fix(scheduler): inline bare loop continues the top-level RNG stream, not a replay — closes #593

### DIFF
--- a/src/engine/SonicPiEngine.ts
+++ b/src/engine/SonicPiEngine.ts
@@ -188,6 +188,25 @@ export class SonicPiEngine {
    * one stream). Cleared/derived on the same lifecycle as loopTicks.
    */
   private loopRngState = new Map<string, { seed: number; idx: number; source: RandSource }>()
+  /**
+   * #593/SV75: the most recently registered `__inline` construct in the current
+   * evaluate's registration pass (reset to null before each `sandbox.execute`).
+   * Inline constructs (`__run_once`, a top-level bare `loop`) all model desktop's
+   * SINGLE continuous main-thread stream. The FIRST one snapshots topLevelBuilder;
+   * each LATER one must continue the SAME stream AFTER the earlier one's draws —
+   * see `inlineRngInheritFrom`.
+   */
+  private lastInlineConstruct: string | null = null
+  /**
+   * #593/SV75: a deferred-seed link `loopName → previous-inline-construct`. A
+   * later inline construct does NOT snapshot topLevelBuilder at registration
+   * (that state is unchanged by the earlier construct's separate per-build
+   * builder, so it would REPLAY those draws). Instead it inherits the previous
+   * inline construct's POST-build rng state at its FIRST build (once only),
+   * relying on the SV70/SV21/SP165 build-order guarantee. Cleared with
+   * loopRngState on a fresh Run.
+   */
+  private inlineRngInheritFrom = new Map<string, string>()
   /** Per-loop tick counters — persisted across iterations so ring.tick() advances correctly */
   private loopTicks = new Map<string, Map<string, number>>()
   /** Per-loop beat counter — persisted across iterations so current_beat keeps growing (#226) */
@@ -613,6 +632,7 @@ export class SonicPiEngine {
 
         this.loopBuilders.clear()
         this.loopRngState.clear()
+        this.inlineRngInheritFrom.clear() // #593: deferred inline-seed links
       }
 
       // Transpile: Ruby DSL → JS builder chain (TreeSitter only).
@@ -944,8 +964,26 @@ export class SonicPiEngine {
           // main thread's own stream, and (worse) consumed a gen_idx that the real
           // sibling loops then skipped — desyncing every default-seed piece.
           if (isInline) {
-            const st = topLevelBuilder.getRandomState()
-            this.loopRngState.set(name, { seed: st.seed, idx: st.idx, source: st.source })
+            if (this.lastInlineConstruct === null) {
+              // First inline construct of this evaluate (`__run_once`, or a lone
+              // top-level bare `loop`): continue the top-level stream from its
+              // eager-draw state. Snapshot topLevelBuilder now.
+              const st = topLevelBuilder.getRandomState()
+              this.loopRngState.set(name, { seed: st.seed, idx: st.idx, source: st.source })
+            } else {
+              // #593/SV75: a LATER inline construct (a bare `loop` after
+              // __run_once's bare draws) must continue the SAME main-thread
+              // stream AFTER those draws. topLevelBuilder is NOT advanced by
+              // __run_once's separate per-build builder, so re-snapshotting it
+              // here would REPLAY __run_once's draws. Defer: inherit the previous
+              // inline construct's POST-build rng state at this loop's first build
+              // (asyncFn below). The SV70/SV21/SP165 build order guarantees
+              // __run_once builds and saves its rng before this loop's first
+              // build — the same ordering that lets the loop body read bare
+              // top-level vars like `play c`.
+              this.inlineRngInheritFrom.set(name, this.lastInlineConstruct)
+            }
+            this.lastInlineConstruct = name
           } else {
             const childSeed = topLevelBuilder.deriveChildSeed()
             this.loopRngState.set(name, {
@@ -1030,6 +1068,18 @@ export class SonicPiEngine {
             }
           }
 
+          // #593/SV75: a deferred inline construct inherits the previous inline
+          // construct's POST-build rng state at its FIRST build (once only). By
+          // now __run_once has built and saved its rng (line ~1200), so this
+          // continues the single main-thread stream AFTER the bare-code draws
+          // instead of replaying them. The `!has(name)` guard makes it once-only
+          // (subsequent iterations use this loop's own persisted, advanced state)
+          // and a no-op on hot-swap (a running loop keeps its stream).
+          const inheritFrom = this.inlineRngInheritFrom.get(name)
+          if (inheritFrom && !this.loopRngState.has(name)) {
+            const prev = this.loopRngState.get(inheritFrom)
+            if (prev) this.loopRngState.set(name, { seed: prev.seed, idx: prev.idx, source: prev.source })
+          }
           // EPIC #531 Phase 3: restore this loop's persistent random stream so it
           // advances CONTINUOUSLY across iterations (desktop live_loop = one
           // thread, one stream — no per-iteration re-seed). Saved back after the
@@ -1141,11 +1191,23 @@ export class SonicPiEngine {
           }
           try {
             // SP95(d) #393: await so an S3 body can suspend on a scheduler-resolved
-            // sync mid-build. For today's synchronous S1/S2 bodies this `await` is
-            // identity (await on a non-thenable void). The single-field
-            // currentBuildBuilder above stays safe until sync actually awaits — the
-            // re-entrancy hardening is tracked in #395.
-            await builderFn(builder)
+            // sync mid-build. Calling the (async) builderFn runs a synchronous
+            // S1/S2 body to COMPLETION before it returns the promise — only an
+            // actual `sync` inside suspends. The single-field currentBuildBuilder
+            // above stays safe until sync actually awaits — the re-entrancy
+            // hardening is tracked in #395.
+            const buildResult = builderFn(builder)
+            // #593/SV75: publish an inline construct's post-draw rng state
+            // SYNCHRONOUSLY — before the `await` below yields a microtask. The
+            // scheduler may run a LATER inline construct's FIRST build during that
+            // yield; that successor inherits this rng (inlineRngInheritFrom) and
+            // must see the CONTINUED main-thread stream, not the pre-build
+            // snapshot. Without this early publish the save below lands one
+            // microtask too late and the successor replays these draws (the #593
+            // bug). The unconditional save after the try still handles
+            // across-iteration continuity.
+            if (isInline) this.loopRngState.set(name, builder.getRandomState())
+            await buildResult
           } finally {
             this.currentBuildBuilder = prevBuildBuilder
             this.currentBuildTaskVt = prevBuildTaskVt
@@ -2081,6 +2143,11 @@ export class SonicPiEngine {
           this.fxScopeChains.clear()
           this.fxScopeRefs.clear() // #511: rebuilt by the new program's with_fx blocks
         }
+        // #593/SV75: reset the inline-construct chain tail before this
+        // evaluate's registration pass — the first inline construct registered
+        // (below, via wrappedLiveLoop) snapshots topLevelBuilder, later ones
+        // defer-inherit. Reset per evaluate so a hot-swap re-derives correctly.
+        this.lastInlineConstruct = null
         await sandbox.execute(...dslValues)
       } finally {
         this.inTopLevelEval = prevInTopLevelEval

--- a/src/engine/Sp95Lint.ts
+++ b/src/engine/Sp95Lint.ts
@@ -37,6 +37,24 @@ export interface Sp95Warning {
 }
 
 /**
+ * DSL functions that exist on desktop Sonic Pi ONLY in their bang form. A
+ * bangless call raises a NoMethodError on desktop — the thread dies and every
+ * line after it is silent. Our transpiler strips the Ruby bang BEFORE the call
+ * resolves (`set_mixer_control!` → `set_mixer_control`, ~line 1492) and
+ * `DslNames.ts` lists the no-bang internal names, so the engine leniently runs
+ * the bangless form too — working web audio, silent death on desktop. This
+ * allowlist drives a source-level lint (run PRE-transpile, so it can still see
+ * the bang) that makes the divergence loud instead of silent (#586/#594,
+ * loud-not-silent / SV50).
+ *
+ * `set_volume` is the third member of this class (#586) but its detector lives
+ * in PR #587; fold it into this list (and drop #587's inline block) once that
+ * lands. Grounded: `sound.rb:1007` `reset_mixer!()`, `sound.rb:1027`
+ * `set_mixer_control!(opts)`, `sound.rb:2076` `set_volume!`.
+ */
+const BANG_ONLY_DSL: ReadonlyArray<string> = ['set_mixer_control', 'reset_mixer']
+
+/**
  * Run all build-time DSL lints over the given Ruby source. The SP95 detectors
  * are retired (see module header); this is the retained integration point for
  * non-fatal build-time warnings (the channel a future lint slots into). Pure.
@@ -74,6 +92,24 @@ export function detectSp95Limitations(src: string): Sp95Warning[] {
         '`with_tempo` is deprecated since Sonic Pi v2.0 — use `use_bpm` or `with_bpm`. ' +
         'Running it as `with_bpm`. Desktop Sonic Pi raises an error on `with_tempo`.',
     })
+  }
+
+  // Bang-only DSL functions (#594) — see BANG_ONLY_DSL. Each fires on the
+  // no-bang form ONLY: the negative lookahead `(?![!\w])` excludes the valid
+  // bang form (`set_mixer_control!`) and longer identifiers; the `^[^#\n]*`
+  // guard matches a call position only (skips comment lines and inline
+  // `# … reset_mixer` comments). Keep-accept-with-warning (SV50).
+  for (const name of BANG_ONLY_DSL) {
+    const re = new RegExp(`^[^#\\n]*\\b${name}(?![!\\w])`, 'm')
+    if (re.test(src)) {
+      warnings.push({
+        pattern: name,
+        title: `${name} is not a Sonic Pi function`,
+        message:
+          `Did you mean \`${name}!\`? Running the no-bang \`${name}\` as \`${name}!\`. ` +
+          `Desktop Sonic Pi has only \`${name}!\` (with bang) and errors on \`${name}\`.`,
+      })
+    }
   }
 
   return warnings

--- a/src/engine/__tests__/InlineLoopRngContinuity.test.ts
+++ b/src/engine/__tests__/InlineLoopRngContinuity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { SonicPiEngine } from '../SonicPiEngine'
+
+// #593 / SV75: a top-level bare `loop` is `__inline` — it models desktop's
+// single continuous main-thread spider stream. Its RNG must CONTINUE the stream
+// after the bare-code draws that precede it (run inside `__run_once`), not
+// snapshot the top-level state at registration and REPLAY those draws.
+//
+// Oracle (desktop-independent): the engine's OWN continuous-stream semantics. A
+// pure-bare `puts rand ×N` advances one stream → [v0, v1, v2, ...]. Splitting
+// the same draws into bare-prefix + inline loop must reproduce the SAME stream:
+// the loop's first `rand` continues at the index AFTER the prefix draws.
+
+async function flush(n = 8): Promise<void> {
+  for (let i = 0; i < n; i++) await new Promise((r) => setTimeout(r, 0))
+}
+type Sched = { tick: (t: number) => void }
+
+/** Drive code through the full engine pipeline, capturing numeric `puts` lines. */
+async function runAndCapture(code: string, iterations = 8): Promise<string[]> {
+  const engine = new SonicPiEngine()
+  await engine.init()
+  const printed: string[] = []
+  engine.setPrintHandler((m) => printed.push(m))
+  await engine.evaluate(code)
+  const scheduler = (engine as unknown as { scheduler: Sched }).scheduler
+  engine.play()
+  for (let i = 0; i < iterations; i++) {
+    scheduler.tick(20)
+    await flush()
+  }
+  engine.dispose()
+  return printed
+}
+
+describe('#593 — inline bare loop continues the top-level RNG stream (SV75)', () => {
+  it("the loop's first rand continues AFTER the bare-prefix draws (not a replay)", async () => {
+    // Reference: one continuous main-thread stream of 4 draws (all in __run_once).
+    const ref = await runAndCapture(`use_random_seed 0
+puts rand
+puts rand
+puts rand
+puts rand`)
+    expect(ref.length).toBeGreaterThanOrEqual(4)
+    const [v0, , v2] = ref
+
+    // Target: two draws in bare code (→ __run_once), then the inline loop draws.
+    // The loop's FIRST rand must equal v2 (continuation), NOT v0 (replay of the
+    // bare-prefix stream from index 0).
+    const got = await runAndCapture(`use_random_seed 0
+a = rand
+b = rand
+loop do
+  puts rand
+  sleep 1
+end`)
+    expect(got.length).toBeGreaterThanOrEqual(2)
+    expect(got[0]).toBe(v2)
+    expect(got[0]).not.toBe(v0)
+    // And it keeps continuing: second loop draw is the next stream value.
+    expect(got[1]).toBe(ref[3])
+  })
+
+  it('a true fork (in_thread) keeps its derived child stream — SV69/#531-P3 intact', async () => {
+    // Regression guard: the deferred inline seeding must not touch forked-loop
+    // child-seed derivation. Determinism across two identical runs.
+    const code = `use_random_seed 0
+a = rand
+in_thread do
+  loop do
+    puts rand
+    sleep 1
+  end
+end
+loop do
+  sleep 1
+end`
+    const a = await runAndCapture(code)
+    const b = await runAndCapture(code)
+    expect(a.length).toBeGreaterThanOrEqual(1)
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+})

--- a/src/engine/__tests__/Sp95Lint.test.ts
+++ b/src/engine/__tests__/Sp95Lint.test.ts
@@ -124,3 +124,29 @@ describe('Sp95Lint — deprecation warnings (loud-not-silent, SV50/SV60 channel)
     expect(detectSp95Limitations('play 60 # with_tempo is the old name')).toEqual([])
   })
 })
+
+describe('Sp95Lint — bang-only DSL functions (loud-not-silent, SV50) — #594', () => {
+  it('warns on no-bang set_mixer_control (NoMethodError on desktop — silent)', () => {
+    const w = detectSp95Limitations('set_mixer_control lpf: 30\nsleep 1')
+    expect(w).toHaveLength(1)
+    expect(w[0].pattern).toBe('set_mixer_control')
+    expect(w[0].message).toMatch(/set_mixer_control!/)
+  })
+
+  it('warns on no-bang reset_mixer (NoMethodError on desktop — silent)', () => {
+    const w = detectSp95Limitations('reset_mixer\nplay 60')
+    expect(w).toHaveLength(1)
+    expect(w[0].pattern).toBe('reset_mixer')
+    expect(w[0].message).toMatch(/reset_mixer!/)
+  })
+
+  it('does NOT warn on the valid bang forms', () => {
+    expect(detectSp95Limitations('set_mixer_control! lpf: 30')).toEqual([])
+    expect(detectSp95Limitations('reset_mixer!')).toEqual([])
+  })
+
+  it('does NOT warn on comments nor longer identifiers', () => {
+    expect(detectSp95Limitations('play 60 # set_mixer_control vs reset_mixer')).toEqual([])
+    expect(detectSp95Limitations('reset_mixers = 1\nset_mixer_controls = 2')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem
A top-level bare `loop` is `__inline` — it models desktop's **single continuous main-thread spider stream** and must continue that stream AFTER the bare-code draws preceding it (which run inside `__run_once`). But the engine seeded every inline construct by snapshotting `topLevelBuilder.getRandomState()` at **eager registration**.

`__run_once`'s bare draws run later, at vt 0, on its OWN per-build builder — they never advance `topLevelBuilder` — so a following bare `loop` snapshotted the **same pre-draw index** and **replayed** `__run_once`'s draws. Its `choose`/`rand` note + timing sequence diverged from desktop's stream (SV75).

Surfaced by #591/PR #592 on `40_choose_generator` (the loop's tri onset/note sequence DIVERGE while the `in_thread` fork matched). Invisible before #591 (the loop played beep). A true fork (`live_loop`/`in_thread`) was already correct — it `deriveChildSeed()`s its own stream (SV69/#531-P3); only `__inline` was wrong.

## Fix
Chain inline constructs. The **first** inline construct of an evaluate keeps the topLevelBuilder snapshot; each **later** inline construct defers its seed and inherits the **previous inline construct's post-build rng state** at its first build (SV70/SV21/SP165 build order — the same ordering that lets the loop body read bare top-level vars like `play c`).

To make that ordering reachable, an inline construct now publishes its post-draw rng state **synchronously** right after its (synchronous S1/S2) builderFn, **before the `await` yields a microtask** — otherwise the successor's first build (run during that yield) read the predecessor's state one microtask too late and still replayed. The `await`-split is **provably identical** for non-inline builds (only the gated inline early-save is added). Forked-loop child-seed derivation is untouched.

Root cause traced via instrumented build/save logging (`artifacts/investigations/exp-593-*.md`): the predecessor's `builderFn` completes before the successor's (so `play c` works), but the rng SAVE landed one microtask late.

## Test plan
- **L1:** `tsc --noEmit` clean; `vitest` **1472** (+2). New `InlineLoopRngContinuity.test.ts`: the inline loop's first `rand` continues at stream idx 2 (`0.4642…`) instead of replaying idx 0 (`0.7500…`); a true `in_thread` fork stays deterministic (SV69 intact). No regression across scheduler/sync/nested/in_thread suites.
- **L3:** `compare-desktop-vs-web 40_choose_generator` → **Tier-1 ✓ PITCH-MATCH (notes identical over 11)**, tempo desktop 0.500s · web 0.500s. Post-fix web `/s_new` note sequence differs from the stale pre-fix replay sequence (fix is active). Remaining beep-vs-tri timbre / 0.5× gain is #592 (synth, independent of the stream; Tier-2/3 never overrides Tier-1).

closes #593