### PR TITLE
🎲 fix(dsl): spread matches desktop Bjorklund — closes #597 (SP167)

### DIFF
--- a/src/engine/EuclideanRhythm.ts
+++ b/src/engine/EuclideanRhythm.ts
@@ -19,32 +19,37 @@ export function spread(hits: number, total: number, rotation: number = 0): Ring<
   return new Ring(pattern)
 }
 
+/**
+ * Exact port of desktop Sonic Pi's Euclidean distribution (core.rb:1700-1714,
+ * `redistribute` + `spread`). NOT a generic Bjorklund: desktop's `redistribute`
+ * uses `vNew.unshift(a1 + a2)` (PREPEND), which produces a different placement
+ * than the textbook "head/tail merge" Bjorklund for the dense `spread(s-1, s)`
+ * family — desktop puts the lone rest at index 1 (`X.XXX…`) where a textbook
+ * Bjorklund puts it last (`XXX…X.`). That single-position difference desynced the
+ * PRNG stream in dense random blocks: a `play … if spread(rrand_i, n).look` guard
+ * fired on desktop but not on web (or vice versa), so the conditional `rand` draw
+ * count diverged and every later draw shifted (#597 / SP167). Matching desktop's
+ * algorithm exactly guarantees per-index parity across ALL (hits, total).
+ */
+function redistribute(v1: boolean[][], v2: boolean[][]): [boolean[][], boolean[][]] {
+  const vNew: boolean[][] = []
+  // shift consumes from the front; operate on copies so callers' arrays stand.
+  const a = v1.slice()
+  const b = v2.slice()
+  while (a.length > 0 && b.length > 0) {
+    const a1 = a.shift()!
+    const a2 = b.shift()!
+    vNew.unshift([...a1, ...a2])
+  }
+  return a.length > 0 ? [vNew, a] : [vNew, b]
+}
+
 function bjorklund(hits: number, total: number): boolean[] {
-  let groups: boolean[][] = []
-
-  for (let i = 0; i < total; i++) {
-    groups.push([i < hits])
+  let v1: boolean[][] = Array.from({ length: hits }, () => [true])
+  let v2: boolean[][] = Array.from({ length: total - hits }, () => [false])
+  ;[v1, v2] = redistribute(v1, v2)
+  while (v2.length > 1) {
+    ;[v1, v2] = redistribute(v1, v2)
   }
-
-  let tail = total - hits
-
-  while (tail > 1) {
-    const head = groups.length - tail
-    const min = Math.min(head, tail)
-
-    const newGroups: boolean[][] = []
-    for (let i = 0; i < min; i++) {
-      newGroups.push([...groups[i], ...groups[head + i]])
-    }
-
-    // Remaining groups
-    const remaining = head > tail
-      ? groups.slice(min, head)
-      : groups.slice(head + min)
-
-    groups = [...newGroups, ...remaining]
-    tail = remaining.length
-  }
-
-  return groups.flat()
+  return [...v1, ...v2].flat()
 }

--- a/src/engine/__tests__/DSLHelpers.test.ts
+++ b/src/engine/__tests__/DSLHelpers.test.ts
@@ -706,6 +706,21 @@ describe('spread (Euclidean rhythm)', () => {
     expect(spread(4, 4).toArray()).toEqual([true, true, true, true])
   })
 
+  it('spread(s-1, s) places the lone rest at index 1, matching desktop (#597)', () => {
+    // Desktop core.rb `redistribute` (unshift/prepend) puts the single rest at
+    // index 1 — `X.XXX…` — NOT at the end (`XXX…X.` of a textbook Bjorklund).
+    // The wrong placement desynced the PRNG stream when a conditional draw was
+    // guarded by `spread(rrand_i, n).look` (#597 / SP167).
+    expect(spread(15, 16).toArray()).toEqual([
+      true, false, true, true, true, true, true, true,
+      true, true, true, true, true, true, true, true,
+    ])
+    expect(spread(2, 3).toArray()).toEqual([true, false, true])
+    expect(spread(7, 8).toArray()).toEqual([
+      true, false, true, true, true, true, true, true,
+    ])
+  })
+
   it('spread with rotation shifts the pattern', () => {
     const base = spread(3, 8).toArray()
     const rotated = spread(3, 8, 1).toArray()


### PR DESCRIPTION
## Problem
`spread(hits, total)` used a textbook head/tail-merge Bjorklund that diverges from desktop Sonic Pi for the **`spread(s-1, s)` family** (exactly one rest): we put the lone rest at the **last** index (`XXX…X.`), desktop puts it at **index 1** (`X.XXX…`). **30/560** (hits,size) combinations differed — all that one family.

In dense random blocks a guard like `play … if spread(rrand_i, n).look` then evaluated **true on desktop but false on web** (or vice versa) at the look index, so the *conditional* `rand` draw (`rdist`/etc.) executed on only one side. That's a **1-draw PRNG count desync** that permanently shifts every later draw → the intermittent "dense random block" divergence in #597 (SP167).

### Root cause (observed, not inferred)
`43_exploring_tb303` a1 `/s_new` stream is byte-identical through voice **#71**, then `rrand_i(14,15)`→**15** → `spread(15,16)`: desktop reads `true` (fires `play` → draws `rdist(1)`, emits a noise), web reads `false` (suppresses) → desktop emits an extra noise at #72, web jumps to the next iteration, and all later draws stay diverged.

## Fix
Rewrite the internal generator as an **exact port of desktop's `redistribute`** (`ref/sources/desktop-sp/core.rb:1700-1714`) — the `vNew.unshift(a1 + a2)` *prepend* merge that produces desktop's placement. Now **0/560 differ** vs desktop across size 1..32. Canonical examples (`spread 3,8` / `5,8`) and the rotation arg are unchanged; `.rotate(n)` is a separate `Ring#rotate` path and untouched.

## Test plan
- **L1:** `tsc --noEmit` clean; `vitest run` **1490 → 1491** (added a `spread(s-1, s)` desktop-parity regression test in `DSLHelpers.test.ts`).
- **L3 (audio/event parity):** `43_exploring_tb303` a1 `/s_new` stream `firstDivergence = -1` (full desktop parity, was voice #72) → `compare-desktop-vs-web` **onset-seq MATCH**.
- `16_minimal_mixer`: `spread(6,7)` now correct (count w26 → **w27 = d27**). Its remaining transient onset jitter **re-syncs** (`..XXXX.....XX..` map), so it is categorically a separate **cross-loop `get(:mixer)` timing** class (SP164), not a draw-count desync — filed separately, out of #597 scope.

closes #597