### PR TITLE
🐛 Hash#length/#size/#count → __spSize (#603, SP169)

### DIFF
--- a/src/engine/Sandbox.ts
+++ b/src/engine/Sandbox.ts
@@ -212,6 +212,20 @@ export function createIsolatedExecutor(
     '  if (typeof a === "number" && typeof b === "string") return b.repeat(Math.max(0, Math.floor(a)));',
     '  return a * b;',
     '}',
+    // Ruby collection size — `.length`/`.size`/`.count` (SP169/#603). The
+    // transpiler lowers a Ruby Hash literal `{a:…}` to a JS OBJECT, which has
+    // no `.length` → `undefined` → NaN → loop crash. Dispatch by receiver type:
+    // Array/String/Ring keep `.length` (numeric); ANY other object is a Hash →
+    // count its pairs via Object.keys (so even a `{length: 5}` hash returns its
+    // pair count, matching Ruby, not the stored value). nil → 0 (Ruby raises,
+    // but silent-safe beats crashing a live loop, cf. __spIsA).
+    'function __spSize(x) {',
+    '  if (x == null) return 0;',
+    '  if (typeof x === "string" || Array.isArray(x)) return x.length;',
+    '  if (__spIsRing(x)) return x.length;',
+    '  if (typeof x === "object") return Object.keys(x).length;',
+    '  return x.length;',
+    '}',
     // Ruby x.kind_of?(Class) / x.is_a?(Class) — dispatch by class name.
     // Class arg comes in as a string (the transpiler JSON-encodes the
     // constant name) so we can match without needing the runtime to have

--- a/src/engine/TreeSitterTranspiler.ts
+++ b/src/engine/TreeSitterTranspiler.ts
@@ -2093,9 +2093,13 @@ function transpileReceiverMethodCall(
     return `Number(${recStr})`
   }
 
-  // .length / .size / .count → .length
+  // .length / .size / .count → __spSize (SP169/#603). A raw `.length` is correct
+  // for Array/Ring/String but `undefined` on a Hash literal (lowered to a JS
+  // object with no `.length`) → NaN → loop crash. __spSize dispatches by receiver
+  // type at runtime. (No-arg form only; `.count(x)`/`.count { }` selective-count
+  // is unchanged — still out of scope, as before this fix.)
   if (method === 'length' || method === 'size' || method === 'count') {
-    return `${recStr}.length`
+    return `__spSize(${recStr})`
   }
 
   // .abs → Math.abs

--- a/src/engine/__tests__/TreeSitterTranspiler.test.ts
+++ b/src/engine/__tests__/TreeSitterTranspiler.test.ts
@@ -43,6 +43,14 @@ function __spMul(a: unknown, b: unknown): unknown {
   if (typeof a === 'number' && __spIsRing(b)) return (b as Ring<any>).repeat(a)
   return (a as number) * (b as number)
 }
+// SP169/#603 — mirror of the Sandbox __spSize helper.
+function __spSize(x: any): number | undefined {
+  if (x == null) return 0
+  if (typeof x === 'string' || Array.isArray(x)) return x.length
+  if (__spIsRing(x)) return (x as Ring<any>).length
+  if (typeof x === 'object') return Object.keys(x).length
+  return x.length
+}
 // Resolve WASM paths for Node.js test environment
 const base = new URL('../../..', import.meta.url).pathname
 const tsWasm = base + 'node_modules/web-tree-sitter/tree-sitter.wasm'
@@ -2689,6 +2697,41 @@ end`)
       // The cue/gate machinery is top-level only (SP118); the inner in_thread
       // keeps the un-gated path.
       expect(r.code).not.toContain('__startGate')
+    })
+  })
+
+  describe('SP169/#603: .length/.size/.count route through __spSize (Hash literals)', () => {
+    it('emits __spSize(...) for .length / .size / .count, not raw .length', () => {
+      for (const m of ['length', 'size', 'count']) {
+        const r = treeSitterTranspile(`x = h.${m}`)
+        expect(r.ok).toBe(true)
+        expect(r.code).toContain('__spSize(h)')
+        // The old raw-.length emission (`h.length`) must be gone.
+        expect(r.code).not.toMatch(/\bh\.length\b/)
+      }
+    })
+
+    it('__spSize counts Hash pairs (the bug: a JS object has no .length)', () => {
+      const hash = { a: 1, b: 2, c: 3 }
+      // Raw .length on the lowered object is undefined → NaN downstream (SP169).
+      expect((hash as any).length).toBeUndefined()
+      expect(__spSize(hash)).toBe(3)
+      // The 39_blues_machine chain: `g_max = g_licks.length - 1` must be finite.
+      expect(__spSize(hash)! - 1).toBe(2)
+    })
+
+    it('__spSize keeps Array / Ring / String semantics (the 3 receiver types that already worked)', () => {
+      expect(__spSize([10, 20, 30])).toBe(3)
+      expect(__spSize(ring(1, 2, 3, 4))).toBe(4)
+      expect(__spSize('hello')).toBe(5)
+    })
+
+    it('__spSize is silent-safe on nil and counts pairs even for a {length:} hash', () => {
+      expect(__spSize(null)).toBe(0)
+      expect(__spSize(undefined)).toBe(0)
+      // A Hash whose key happens to be :length → Ruby #length is the PAIR count,
+      // not the stored value. __spSize routes any non-Array/Ring object to keys.
+      expect(__spSize({ length: 5, other: 1 })).toBe(2)
     })
   })
 })


### PR DESCRIPTION
Closes #603.

## Problem (SP169)

The transpiler lowers a Ruby Hash literal `{ a: …, b: … }` to a JS object, but `Hash#length`/`#size`/`#count` were emitted as raw `${recv}.length` (`TreeSitterTranspiler.ts:2097`). A JS object has no `.length` → `undefined`.

In `39_blues_machine.rb`:
```rb
g_max = g_licks.length - 1        # undefined - 1 = NaN
temp_num = rrand_i(0, g_max)      # rrand_i(0, NaN)
p_lick = g_licks.values[temp_num] # Object.values(g_licks)[NaN] = undefined
l_notes = p_lick[0].map { ... }   # undefined[0] → throws → :ll_licks loop crashes
```
→ web silently **drops the `pluck` layer** (STRUCTURE-DIVERGE d220/w199, "Web DROPPED pluck×17"). The handler was correct for 3 of 4 receiver types (Array/Ring/String have `.length`); the Hash case was the blind spot.

## Fix

A runtime helper `__spSize(x)` in the Sandbox preamble (alongside `__spAdd`/`__spMul`) dispatches by receiver type:
- Array / String / Ring → `.length` (unchanged)
- **any other object → `Object.keys(x).length`** — a Hash. Even a `{ length: 5 }` hash returns its *pair count* (Ruby semantics), not the stored value.
- `nil` → `0` (silent-safe; Ruby would raise, but crashing a live loop is worse — cf. `__spIsA`).

The transpiler emits `__spSize(recv)` for the no-arg `.length`/`.size`/`.count` family. Selective `.count(x)` / `.count { }` is unchanged — out of scope, as before this fix.

`g_licks` is the only Hash literal in the corpus (so #39 is the sole trigger today), but the fix is general.

## Test plan

- **L1:** `tsc` clean; `vitest` **1496 → 1500** (+4 cases: emits `__spSize` not raw `.length`; counts Hash pairs; preserves Array/Ring/String; nil + `{length:}` edge).
- **L3 (web capture, `39_blues_machine`):** `sonic-pi-pluck` `/s_new` **0 → 6** in the window; the `:ll_licks` loop cues and runs, no NaN/crash. The web layer-drop is eliminated; full d≈w STRUCTURE-MATCH expected on the next resweep (desktop unchanged).

Catalogue: hetvabhasa SP169 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)