### PR TITLE
⬆️ chore(ci): bump actions/checkout + setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
ci.yml still pinned `actions/checkout@v4` + `actions/setup-node@v4` while `deploy.yml` and `publish.yml` already use `@v6`. Bump both in ci.yml to match — no behavior change (same node 20, npm cache). The CI run on this PR exercises the v6 actions directly, so a green check is the validation.

Supersedes the dependabot PRs **#172** (setup-node) and **#173** (checkout, already closed).

> Note: the npm-group dependabot PR **#399** is being held — it bumps `web-tree-sitter` 0.24.3→0.26.9, which relocates the wasm file and breaks the transpiler test harness / postinstall / the CDN pin (needs a coordinated upgrade, like the vite 8 / vitest 4 majors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)