### PR TITLE
🔀 Rename sonicpi.cc → sonicweb.cc + redirect (HOLD until DNS live)

### DIFF
--- a/.release-notes/v1.5.0-beta.3.md
+++ b/.release-notes/v1.5.0-beta.3.md
@@ -93,7 +93,7 @@ npm install @mjayb/sonicpijs        # latest tag now points here
 npm install @mjayb/sonicpijs@beta   # beta tag — same version
 ```
 
-Browser: <https://sonicpi.cc>
+Browser: <https://sonicweb.cc>
 
 See [KNOWN_ISSUES.md](https://github.com/MrityunjayBhardwaj/SonicPi.js/blob/main/KNOWN_ISSUES.md)
 for current beta blockers.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![npm beta](https://img.shields.io/npm/v/@mjayb/sonicpijs/beta?label=npm%20beta&color=orange)](https://www.npmjs.com/package/@mjayb/sonicpijs/v/beta)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
-**[Try it now at sonicpi.cc](https://sonicpi.cc)**
+**[Try it now at sonicweb.cc](https://sonicweb.cc)**
 
 > v1.5 is in **beta** — published under both the `latest` and `beta` npm tags during stabilization. `npm install @mjayb/sonicpijs` gets you the current beta; pin with `@1.5.0-beta.3` for a fixed version.
 
@@ -81,7 +81,7 @@ The bass joins in. Change a number. Hit Run again. The music updates instantly. 
 
 ### Option 1: Just open the website
 
-**[sonicpi.cc](https://sonicpi.cc)** — nothing to install.
+**[sonicweb.cc](https://sonicweb.cc)** — nothing to install.
 
 ### Option 2: Run locally
 
@@ -182,7 +182,7 @@ The 3 non-gradeable fixtures are excluded by design (a counter probe, a density 
 
 Every fixture is browsable in the live **[parity dashboard](https://dashboard-dist-five.vercel.app)** — one overview links the official roster, the differential matrix, per-`/s_new` event-diffs, the launch gate, and the FX A/B inspector, each with desktop ↔ web spectrograms.
 
-Every Ruby snippet on the dashboards is **playable in the browser** — ▶ Run / ■ Stop through the same engine that powers the editor — and carries an **↗ open in sonicpi.cc** link that loads it straight into the live editor. Locally, open `test_results/index.html`, or serve the dashboards with inline audio via `npm run dashboard:serve`.
+Every Ruby snippet on the dashboards is **playable in the browser** — ▶ Run / ■ Stop through the same engine that powers the editor — and carries an **↗ open in sonicweb.cc** link that loads it straight into the live editor. Locally, open `test_results/index.html`, or serve the dashboards with inline audio via `npm run dashboard:serve`.
 
 ### Feature coverage
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,7 +115,7 @@ npx tsx tools/capture.ts "play 60; sleep 0.5; sample :bd_haus"
 
 The vitest run includes `src/app/__tests__/version.test.ts` which enforces the `package.json` ↔ `src/app/version.ts` composition pair from dharana §10. If you bumped one file and forgot the other, this test fails immediately. Do not skip it, do not `--no-verify` around it.
 
-Both build commands must be run — `build:single` produces the sonicpi.cc deploy artifact, `build:lib` produces the npm package. A release that passes one but not the other ships a broken half-product.
+Both build commands must be run — `build:single` produces the sonicweb.cc deploy artifact, `build:lib` produces the npm package. A release that passes one but not the other ships a broken half-product.
 
 ### 4. Commit and push
 ```bash
@@ -211,8 +211,8 @@ npm view @mjayb/sonicpijs dist-tags
 ```
 **If `latest` moved on a prerelease, STOP and fix.** Recovery: `npm dist-tag add @mjayb/sonicpijs@<previous-stable> latest`.
 
-### 13. Verify sonicpi.cc deploy
-- Open sonicpi.cc in a fresh **incognito** window (your normal browser may serve a cached build)
+### 13. Verify sonicweb.cc deploy
+- Open sonicweb.cc in a fresh **incognito** window (your normal browser may serve a cached build)
 - Read the version label in the top-right of the menu bar
 - It MUST display `v1.X.Y-beta.N`
 - If the old version shows:
@@ -305,7 +305,7 @@ Post-merge (after this PR is squash-merged to main):
 - [ ] publish.yml workflow watched to completion, all steps green
 - [ ] Post-publish dist-tag check: npm view @mjayb/sonicpijs dist-tags
       (latest unchanged, beta points to new version)
-- [ ] sonicpi.cc incognito check — menu bar footer shows new version
+- [ ] sonicweb.cc incognito check — menu bar footer shows new version
 - [ ] Announcement (separate step — drafts in ~/.anvideck/.../drafts/)
 ```
 
@@ -315,5 +315,5 @@ Post-merge (after this PR is squash-merged to main):
 
 - [ ] Script to extract per-version CHANGELOG sections automatically (currently awk one-liner)
 - [ ] Automated check that `v${package.json.version}` matches the git tag being pushed (currently manual)
-- [ ] Second Vercel deploy target for `beta.sonicpi.cc` — deferred until after v1.5.0 stable (dharana §10 Distribution Channels subsection)
+- [ ] Second Vercel deploy target for `beta.sonicweb.cc` — deferred until after v1.5.0 stable (dharana §10 Distribution Channels subsection)
 - [ ] Rollback automation for "prerelease accidentally became latest" — currently manual dist-tag reassignment

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # SonicPi.js Roadmap
 
-> Live at [sonicpi.cc](https://sonicpi.cc) | npm: [`@mjayb/sonicpijs`](https://www.npmjs.com/package/@mjayb/sonicpijs)
+> Live at [sonicweb.cc](https://sonicweb.cc) | npm: [`@mjayb/sonicpijs`](https://www.npmjs.com/package/@mjayb/sonicpijs)
 
 ---
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     logo: { src: '/docs/favicon.svg', alt: 'SonicPi.js' },
 
     nav: [
-      { text: 'Try it', link: 'https://sonicpi.cc' },
+      { text: 'Try it', link: 'https://sonicweb.cc' },
       { text: 'npm', link: 'https://www.npmjs.com/package/@mjayb/sonicpijs' },
       { text: 'GitHub', link: 'https://github.com/MrityunjayBhardwaj/SonicPi.js' },
     ],

--- a/docs/.vitepress/theme/player.ts
+++ b/docs/.vitepress/theme/player.ts
@@ -3,16 +3,16 @@
 // whole page). The engine is the project's own browser engine, imported lazily
 // on the first Run so the docs stay fast and SSR-safe.
 
-// Reuse the editor's own share-link encoder so the docs' "open in sonicpi.cc"
+// Reuse the editor's own share-link encoder so the docs' "open in sonicweb.cc"
 // link and the app's permalinks stay byte-for-byte identical (#c=<base64url>).
 // config.ts allows fs access to the repo root, so importing from ../src works.
 import { encodeShareCode } from '../../../src/app/ShareLink'
 
-// The live editor at sonicpi.cc loads a shared buffer verbatim from the URL
+// The live editor at sonicweb.cc loads a shared buffer verbatim from the URL
 // fragment on startup (App.loadBuffers → decodeShareCode). It does NOT auto-run
 // — autoplay needs a user gesture in the destination tab — so the snippet lands
 // ready-to-run and the user clicks Run there.
-const SONICPI_CC = 'https://sonicpi.cc/'
+const SONICPI_CC = 'https://sonicweb.cc/'
 
 type Engine = {
   init(): Promise<void>
@@ -122,13 +122,13 @@ export function decorateRubyBlocks() {
       else run(block, code, btn)
     })
 
-    // Third control: open this snippet in the live editor at sonicpi.cc.
+    // Third control: open this snippet in the live editor at sonicweb.cc.
     const link = document.createElement('a')
     link.className = 'spw-link'
     link.href = SONICPI_CC + encodeShareCode(code)
     link.target = '_blank'
     link.rel = 'noopener'
-    link.innerHTML = '<span class="spw-label">↗ Open in sonicpi.cc</span>'
+    link.innerHTML = '<span class="spw-label">↗ Open in sonicweb.cc</span>'
 
     bar.appendChild(btn)
     bar.appendChild(link)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -14,7 +14,7 @@ Based on [Sonic Pi](https://sonic-pi.net) by Sam Aaron.
 npx sonicpijs
 ```
 
-**Option B:** Visit [sonicpi.cc](https://sonicpi.cc) (hosted, zero install).
+**Option B:** Visit [sonicweb.cc](https://sonicweb.cc) (hosted, zero install).
 
 Once it loads, you will see a code editor with a welcome program already written.
 Press **Run** (or **Ctrl+Enter**) to hear it. Press **Stop** (or **Escape**) to silence everything.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ hero:
     alt: SonicPi.js
   actions:
     - theme: brand
-      text: Try it at sonicpi.cc
-      link: https://sonicpi.cc
+      text: Try it at sonicweb.cc
+      link: https://sonicweb.cc
     - theme: alt
       text: Get Started
       link: /getting-started

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "bugs": {
     "url": "https://github.com/MrityunjayBhardwaj/SonicPi.js/issues"
   },
-  "homepage": "https://sonicpi.cc",
+  "homepage": "https://sonicweb.cc",
   "license": "MIT",
   "dependencies": {
     "web-tree-sitter": "^0.24.3"

--- a/src/app/__tests__/ShareLink.test.ts
+++ b/src/app/__tests__/ShareLink.test.ts
@@ -57,8 +57,8 @@ describe('ShareLink', () => {
   })
 
   it('buildShareURL appends the fragment to an explicit base', () => {
-    const url = buildShareURL('play 72', 'https://sonicpi.cc/')
-    expect(url).toBe('https://sonicpi.cc/' + encodeShareCode('play 72'))
+    const url = buildShareURL('play 72', 'https://sonicweb.cc/')
+    expect(url).toBe('https://sonicweb.cc/' + encodeShareCode('play 72'))
     expect(decodeShareCode(new URL(url).hash)).toBe('play 72')
   })
 

--- a/src/app/version.ts
+++ b/src/app/version.ts
@@ -10,7 +10,7 @@
  * 1. Keeps tsconfig include clean (package.json lives outside src/)
  * 2. Works identically in dev and production — no Vite define wiring
  *
- * Failure mode this prevents: users on sonicpi.cc hit a bug, open the
+ * Failure mode this prevents: users on sonicweb.cc hit a bug, open the
  * Report Bug button, and have no way to tell which engine version they
  * were running. Without this, every bug report starts with "which version?"
  */

--- a/src/engine/Recorder.ts
+++ b/src/engine/Recorder.ts
@@ -15,7 +15,7 @@
  *   PCM signal scsynth produced — apples-to-apples with desktop's recording_save.
  *
  * Why not SuperSonic.startCapture / stopCapture?
- *   SAB-mode-only. Our deploy serves without COOP/COEP headers (sonicpi.cc,
+ *   SAB-mode-only. Our deploy serves without COOP/COEP headers (sonicweb.cc,
  *   the npm-published lib, sandboxed iframes), so SuperSonic boots in
  *   postMessage mode. ScriptProcessor works in both modes and gives us the
  *   same final-mix tap point we had before.

--- a/test_results/audio-controls.js
+++ b/test_results/audio-controls.js
@@ -8,7 +8,7 @@
 //                        wasm, and the rand-stream from the CDN itself, so the
 //                        dashboard hosts nothing but the engine bundle. Only
 //                        shown over http(s); file:// can't load an ES module.
-//   ↗ Open in sonicpi.cc opens the snippet in the live editor, ready to run.
+//   ↗ Open in sonicweb.cc opens the snippet in the live editor, ready to run.
 //                        Pure link, no deps — shown everywhere (file:// included).
 //
 // The engine bundle is produced by `npm run dashboard:audio` and served from
@@ -17,7 +17,7 @@
 (function () {
   'use strict'
 
-  var SONICPI_CC = 'https://sonicpi.cc/'
+  var SONICPI_CC = 'https://sonicweb.cc/'
 
   // Resolve sibling assets relative to THIS script (currentScript is only valid
   // during synchronous top-level execution — capture it now, not in callbacks).
@@ -168,7 +168,7 @@
       link.className = 'spw-link'
       link.target = '_blank'
       link.rel = 'noopener'
-      link.textContent = '↗ Open in sonicpi.cc'
+      link.textContent = '↗ Open in sonicweb.cc'
       bar.appendChild(link)
       bar.__spwLink = link
 
@@ -224,7 +224,7 @@
   }
 
   // Opened from disk (file://), browsers block the ES-module engine load, so only
-  // the "open in sonicpi.cc" link works. Show a one-time banner explaining how to
+  // the "open in sonicweb.cc" link works. Show a one-time banner explaining how to
   // get the in-page Run/Stop controls.
   function injectFileHintOnce() {
     if (HTTP_SERVED || document.getElementById('spw-file-hint')) return
@@ -234,7 +234,7 @@
       'ui-monospace,Menlo,monospace;color:#0b0d12;background:#e0af68;text-align:center'
     bar.innerHTML = '▶ Run/Stop needs the dashboards served over http — run ' +
       '<code style="background:rgba(0,0,0,.15);padding:1px 5px;border-radius:4px">npm run dashboard:serve</code>' +
-      ' (or use the live site). Opened from disk, only the ↗ open-in-sonicpi.cc link works.'
+      ' (or use the live site). Opened from disk, only the ↗ open-in-sonicweb.cc link works.'
     document.body.insertBefore(bar, document.body.firstChild)
   }
 

--- a/tools/build-dashboard-audio.mjs
+++ b/tools/build-dashboard-audio.mjs
@@ -19,7 +19,7 @@
 // Inline audio still requires the dashboards to be SERVED over http (test_results/
 // as the web root: `npm run dashboard:serve`, or the Vercel publish bundle) — a
 // file:// page can't load the ES-module bundle. There audio-controls.js shows
-// only the "open in sonicpi.cc" link, by design.
+// only the "open in sonicweb.cc" link, by design.
 
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'

--- a/tools/build-dashboard-publish.mjs
+++ b/tools/build-dashboard-publish.mjs
@@ -18,7 +18,7 @@
  *        <audio controls preload="metadata" src="community/.../web.wav"></audio>
  *
  * Usage:
- *   R2_BASE="https://imgs.sonicpi.cc" node tools/build-dashboard-publish.mjs
+ *   R2_BASE="https://imgs.sonicweb.cc" node tools/build-dashboard-publish.mjs
  *   node tools/build-dashboard-publish.mjs --r2-base https://<bucket>.<acct>.r2.dev \
  *        [--src test_results] [--out dashboard-dist]
  *

--- a/tools/lib/dashboard-nav.ts
+++ b/tools/lib/dashboard-nav.ts
@@ -50,7 +50,7 @@ const DEFAULT_META = 'desktop ↔ web parity'
 export function navBlock(meta: string = DEFAULT_META): string {
   const safe = String(meta).replace(/"/g, '&quot;')
   // audio-controls.js (committed alongside nav.js) makes every Ruby snippet
-  // playable in-page + adds an "open in sonicpi.cc" link. Same file://-safe
+  // playable in-page + adds an "open in sonicweb.cc" link. Same file://-safe
   // classic-script pattern as nav.js; harmless on snippet-less pages.
   return `<nav class="tab-bar" id="topnav" data-meta="${safe}"></nav>\n<script src="nav.js"></script>\n<script src="audio-controls.js"></script>`
 }

--- a/tools/verify-dashboard-audio.mjs
+++ b/tools/verify-dashboard-audio.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Headless end-to-end verification (SV79: render, don't trust 200+parse) for the
-// dashboard inline-audio + "open in sonicpi.cc" controls. Serves test_results/ as
+// dashboard inline-audio + "open in sonicweb.cc" controls. Serves test_results/ as
 // the web root over http (so the engine can fetch /tree-sitter.wasm + rand-stream)
 // and, for each target page: decorates snippets, round-trips the share link, and
 // actually clicks Run to confirm the engine reaches hasAudio + playing.
@@ -64,7 +64,7 @@ for (const pg of pages) {
       const pre = document.querySelector('pre.snippet, pre.src, details.snippet pre')
       return { href: a?.getAttribute('href') || null, code: (pre?.textContent || '').replace(/\n$/, ''), target: a?.target, rel: a?.rel }
     })
-    const decoded = link.href && link.href.startsWith('https://sonicpi.cc/') ? decodeShareCode(link.href.slice('https://sonicpi.cc/'.length)) : null
+    const decoded = link.href && link.href.startsWith('https://sonicweb.cc/') ? decodeShareCode(link.href.slice('https://sonicweb.cc/'.length)) : null
     const linkOk = decoded === link.code && link.target === '_blank' && /noopener/.test(link.rel || '')
 
     // 2) inline Run → engine reaches audio + playing

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,20 @@
 {
   "buildCommand": "npm run build:all",
   "outputDirectory": "dist",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "sonicpi.cc" }],
+      "destination": "https://sonicweb.cc/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.sonicpi.cc" }],
+      "destination": "https://sonicweb.cc/:path*",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     { "source": "/docs/:path*", "destination": "/docs/:path*" },
     { "source": "/((?!docs).*)", "destination": "/index.html" }


### PR DESCRIPTION
Sam asked to drop "sonicpi" from the domain. **sonicweb.cc** becomes canonical; **sonicpi.cc** 308-redirects to it.

## ⚠️ Do not merge until sonicweb.cc DNS is live + verified on Vercel
The `vercel.json` redirect deploys with `main` (git-connected auto-deploy). Merging before `sonicweb.cc` resolves would make `sonicpi.cc` redirect to a dead domain → site down. Draft until the cutover is ready.

## What's in here
- **`vercel.json`** — host-based 308 redirect: `sonicpi.cc` / `www.sonicpi.cc` → `https://sonicweb.cc/<path>`. Path preserved; `#c=` share fragments survive (browser reattaches them across redirects).
- **Rename** `sonicpi.cc` → `sonicweb.cc`: the "↗ open in" links (docs player + dashboard `audio-controls.js`), `package.json` homepage, docs nav, README / ROADMAP / RELEASE / getting-started, ShareLink test base.

The editor's own permalinks use `location.origin` (`ShareLink.ts:50`), so they rebrand automatically when served on sonicweb.cc.

## Cutover runbook
1. **GoDaddy (you):** point `sonicweb.cc` at Vercel — add `A  @  76.76.21.21` (apex). For `www`, add `CNAME  www  cname.vercel-dns.com`.
2. **Vercel:** `sonicweb.cc` is already added to project `sonicpi-js`; it auto-verifies + issues SSL once DNS resolves (`vercel domains inspect sonicweb.cc` to check).
3. Once `https://sonicweb.cc` serves the app, **merge this PR** → auto-deploy → `sonicpi.cc` begins redirecting.

tsc clean; vitest 1500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)