### PR TITLE
🔧 fix(engine): point RAND_STREAM_REPO at renamed SonicWeb repo

### DIFF
--- a/src/engine/cdn-manifest.ts
+++ b/src/engine/cdn-manifest.ts
@@ -57,15 +57,14 @@ export const TREE_SITTER_WASMS_VERSION = '0.1.13' as const
  * jsdelivr pinned to a commit SHA (immutable, cacheable forever). Bump only if
  * the frozen table itself is ever regenerated.
  *
- * NOTE (rebrand 2026-06-23, SV82): the repo slug intentionally stays
- * `SonicPiWeb` even though the product/repo is renamed to "SonicWeb". This
- * string feeds a runtime jsdelivr fetch of the PRNG table; flipping it to
- * `SonicWeb` would 404 (SP5 silent no-audio) until the GitHub repo rename
- * lands, and GitHub permanently redirects the old slug after a rename, so the
- * old path stays valid forever. Flip to `SonicWeb` only AFTER the repo is
- * renamed AND the jsdelivr URL is re-verified to return 200 (see #612).
+ * Repo slug = `SonicWeb` (renamed from `SonicPiWeb` 2026-06-23, #613). This
+ * string feeds a RUNTIME jsdelivr fetch, so it MUST track the live GitHub repo
+ * name — a stale slug 404s the PRNG table = SP5 silent no-audio. GitHub does
+ * permanently redirect the old `SonicPiWeb` slug, so the pin keeps resolving
+ * either way; the slug is updated here for correctness (#612). The `@<SHA>` pin
+ * is immutable and lives under the repo's history regardless of its name.
  */
-export const RAND_STREAM_REPO = 'MrityunjayBhardwaj/SonicPiWeb' as const
+export const RAND_STREAM_REPO = 'MrityunjayBhardwaj/SonicWeb' as const
 export const RAND_STREAM_PIN = '68cf288' as const
 
 /**


### PR DESCRIPTION
Flips the one brand string deliberately held back during the rebrand. `closes #612`.

## Change
`cdn-manifest.ts` `RAND_STREAM_REPO`: `MrityunjayBhardwaj/SonicPiWeb` → `MrityunjayBhardwaj/SonicWeb` (+ comment).

This constant feeds the engine's **self-sufficient** rand-stream default (#604/SV80) used by bare/embedding consumers (docs player, npm package). The **webapp is unaffected** — `App.ts:907` passes a local `/rand-stream.wav` override.

## Why it was held
During the rebrand the GitHub repo wasn't renamed yet; the new slug 404'd → SP5 silent no-audio. The repo rename (#613) unblocked it.

## Verified (L3 — B3/SP5 boundary)
- New URL `cdn.jsdelivr.net/gh/MrityunjayBhardwaj/SonicWeb@68cf288/public/rand-stream.wav` → **200**
- **Byte-identical** to the old slug: sha256 `e74bff97…` (same SHA pin)
- Decodes as valid **mono / 16-bit / 441000-frame** WAV → the exact PRNG table `RandStream.ts` expects
- `tsc --noEmit` clean · `vitest` cdn-manifest + SPRand green

Completes the rebrand. SV82 boundary now fully consistent (no `SonicPiWeb` strings remain except historical/changelog).